### PR TITLE
Improve ground mesh rendering and reduce grid flickering

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6,5 +6,5 @@
 - add different antenna designs
 - add gain value annotations to renders and indicate optimal take off angle
 - add T index input or programatic pull, and estimate optimal physical range of a signal for the given frequency
-- improve rendering of the ground mesh to prevent thin lines flickering
+- [x] improve rendering of the ground mesh to prevent thin lines flickering
 - The swr sweep graph needs annotations for key crossover points and values. Without them it just looks like a curve with no context

--- a/src/components/Scene/GroundPlane.tsx
+++ b/src/components/Scene/GroundPlane.tsx
@@ -28,19 +28,25 @@ export function GroundPlane({ groundId, height, showGrid }: GroundPlaneProps) {
     <group>
       <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, -0.01, 0]} receiveShadow>
         <planeGeometry args={[400, 400]} />
-        <meshStandardMaterial color={color} roughness={0.95} />
+        <meshStandardMaterial
+          color={color}
+          roughness={0.95}
+          polygonOffset
+          polygonOffsetFactor={1}
+          polygonOffsetUnits={1}
+        />
       </mesh>
       {showGrid && (
         <Grid
           args={[400, 400]}
           cellSize={5}
-          cellThickness={0.6}
+          cellThickness={1.0}
           cellColor="#555"
           sectionSize={25}
-          sectionThickness={1.2}
+          sectionThickness={2.0}
           sectionColor="#888"
-          fadeDistance={120}
-          fadeStrength={1}
+          fadeDistance={150}
+          fadeStrength={5}
           infiniteGrid
         />
       )}


### PR DESCRIPTION
This PR improves the 3D rendering stability of the ground plane and grid.

Key changes:
- **Z-Fighting Prevention**: Enabled `polygonOffset` on the `meshStandardMaterial` of the ground plane. This ensures that the ground surface is consistently rendered behind the scale grid in the depth buffer, even at shallow viewing angles or large distances.
- **Aliasing Reduction**: Increased `cellThickness` from 0.6 to 1.0 and `sectionThickness` from 1.2 to 2.0. Slightly thicker lines are more robust against sub-pixel aliasing, which previously caused "shimmering" or flickering as the camera moved.
- **Improved Fading**: Updated `fadeDistance` to 150 and `fadeStrength` to 5 to provide a smoother and more aesthetically pleasing transition for the infinite grid into the distance.
- **Cleanup**: Updated `TODO.md` to check off the corresponding item.

---
*PR created automatically by Jules for task [6507042886296925473](https://jules.google.com/task/6507042886296925473) started by @2fst4u*