### PR TITLE
🎨 Palette: Accessibility Enhancements for Form Controls and Icon Buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-15 - ARIA Labels and Tooltips
+**Learning:** Initial scan reveals many interactive elements and form controls missing accessible labels (e.g. `<button>`, `<input>`).
+**Action:** Add appropriate `aria-label`s to icon buttons and `htmlFor`/`id` associations to form labels.

--- a/src/components/Panel/DipoleControl.tsx
+++ b/src/components/Panel/DipoleControl.tsx
@@ -27,20 +27,28 @@ export function DipoleControl() {
     <div className="panel-section">
       <h3>Dipole</h3>
 
-      <label>Length ({unit})</label>
+      <label htmlFor="dipole-length">Length ({unit})</label>
       <div className="row">
         <input
+          id="dipole-length"
           type="number"
           min={0.1}
           step={0.1}
           value={dispLen.toFixed(2)}
           onChange={(e) => setLength(fromDisplayLength(parseFloat(e.target.value), units))}
         />
-        <button onClick={setHalfWaveLength} title="Set length to resonant ½λ">½λ</button>
+        <button
+          onClick={setHalfWaveLength}
+          title="Set length to resonant ½λ"
+          aria-label="Set length to resonant half wavelength"
+        >
+          ½λ
+        </button>
       </div>
 
-      <label style={{ marginTop: 10 }}>Height above ground ({unit}) — {dispHeight.toFixed(1)}</label>
+      <label htmlFor="dipole-height" style={{ marginTop: 10 }}>Height above ground ({unit}) — {dispHeight.toFixed(1)}</label>
       <input
+        id="dipole-height"
         type="range"
         min={0}
         max={maxHeight}
@@ -49,13 +57,14 @@ export function DipoleControl() {
         onChange={(e) => setHeight(fromDisplayLength(parseFloat(e.target.value), units))}
       />
 
-      <label style={{ marginTop: 10 }}>Orientation</label>
-      <div className="button-group">
+      <label id="dipole-orientation" style={{ marginTop: 10 }}>Orientation</label>
+      <div className="button-group" role="group" aria-labelledby="dipole-orientation">
         {orientations.map((o) => (
           <button
             key={o}
             className={orientation === o ? 'active' : ''}
             onClick={() => setOrientation(o)}
+            aria-pressed={orientation === o}
           >
             {o}
           </button>

--- a/src/components/Panel/UnitToggle.tsx
+++ b/src/components/Panel/UnitToggle.tsx
@@ -8,10 +8,14 @@ export function UnitToggle() {
       <button
         className={units === 'metric' ? 'active' : ''}
         onClick={() => setUnits('metric')}
+        aria-pressed={units === 'metric'}
+        aria-label="Meters"
       >m</button>
       <button
         className={units === 'imperial' ? 'active' : ''}
         onClick={() => setUnits('imperial')}
+        aria-pressed={units === 'imperial'}
+        aria-label="Feet"
       >ft</button>
     </div>
   );

--- a/src/components/UI/ThemeToggle.tsx
+++ b/src/components/UI/ThemeToggle.tsx
@@ -4,7 +4,11 @@ export function ThemeToggle() {
   const theme = useAntennaStore((s) => s.theme);
   const toggle = useAntennaStore((s) => s.toggleTheme);
   return (
-    <button onClick={toggle} title={theme === 'dark' ? 'Switch to light' : 'Switch to dark'}>
+    <button
+      onClick={toggle}
+      title={theme === 'dark' ? 'Switch to light' : 'Switch to dark'}
+      aria-label={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+    >
       {theme === 'dark' ? '☀' : '☾'}
     </button>
   );


### PR DESCRIPTION
🎨 Palette: UX Improvement - Accessibility Enhancements

💡 **What:** 
- Added `aria-label`s to the ThemeToggle icon button and UnitToggle buttons.
- Linked `<label>`s explicitly to inputs in `DipoleControl.tsx` using matching `htmlFor` and `id` attributes.
- Added `role="group"`, `aria-labelledby`, and `aria-pressed` states to dynamic button groups like Orientation.
- Recorded the specific accessibility learning in `.jules/palette.md`.

🎯 **Why:** 
Screen readers need explicit semantics for elements that rely on visual cues (like an icon of a sun/moon, "m", or "ft"). Linking labels to inputs natively increases the hit area for click/tap interaction while automatically providing form field context.

♿ **Accessibility:** 
This micro-UX improvement ensures full structural compliance for basic inputs, immediately making the interface much more pleasant to navigate via assistive technology.

---
*PR created automatically by Jules for task [13816080095162895748](https://jules.google.com/task/13816080095162895748) started by @2fst4u*