### PR TITLE
🧪 Spec: Add store and boundary tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ nec2-build/test-*.mjs
 *.njsproj
 *.sln
 *.sw?
+coverage/

--- a/.jules/spec.md
+++ b/.jules/spec.md
@@ -1,0 +1,5 @@
+## 2024-05-18 - Missing vitest coverage dependency and unhandled rejection
+
+**Learning:** `pnpm test --coverage` requires `@vitest/coverage-v8` but it wasn't in `package.json`. Also, components using `ResizeObserver` (like `@react-three/fiber` canvas) throw exceptions if it's not present globally in `jsdom`.
+
+**Action:** Added `@vitest/coverage-v8` to `devDependencies` and mocked `ResizeObserver` globally in `vitest.setup.ts`.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,7 +6,7 @@ import tseslint from 'typescript-eslint'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
-  globalIgnores(['dist']),
+  globalIgnores(['dist', 'coverage']),
   {
     files: ['**/*.{ts,tsx}'],
     extends: [

--- a/tests/ErrorBoundary.test.tsx
+++ b/tests/ErrorBoundary.test.tsx
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen} from '@testing-library/react';
+import { ErrorBoundary } from '../src/components/UI/ErrorBoundary';
+import React from 'react';
+
+const Bomb = ({ shouldThrow }: { shouldThrow?: boolean }) => {
+  if (shouldThrow) {
+    throw new Error('Boom!');
+  }
+  return <div>Safe</div>;
+};
+
+describe('ErrorBoundary', () => {
+  it('renders children when there is no error', () => {
+    render(
+      <ErrorBoundary>
+        <div>Content</div>
+      </ErrorBoundary>
+    );
+    expect(screen.getByText('Content')).toBeTruthy();
+  });
+
+  it('renders default fallback when an error occurs', () => {
+    // Suppress expected console.error during test
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(
+      <ErrorBoundary>
+        <Bomb shouldThrow />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText('Render error')).toBeTruthy();
+    expect(screen.getByText('Boom!')).toBeTruthy();
+
+    consoleSpy.mockRestore();
+  });
+
+  it('renders custom fallback when provided', () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(
+      <ErrorBoundary fallback={(error, reset) => (
+        <div>
+          <span>Custom Fallback: {error.message}</span>
+          <button onClick={reset}>Reset Me</button>
+        </div>
+      )}>
+        <Bomb shouldThrow />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText('Custom Fallback: Boom!')).toBeTruthy();
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/tests/antennaStore.test.ts
+++ b/tests/antennaStore.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+import { useAntennaStore, buildWires, buildGroundParams, selectSimulationInput } from '../src/store/antennaStore';
+
+
+describe('antennaStore selectors', () => {
+  describe('buildWires', () => {
+    it('generates correct wire coordinates for EW orientation', () => {
+      // Arrange
+      const state = {
+        length: 20,
+        height: 10,
+        orientation: 'EW' as const,
+        wireRadius: 0.001,
+        segments: 21,
+      };
+
+      // Act
+      const wires = buildWires(state);
+
+      // Assert
+      expect(wires).toHaveLength(1);
+      expect(wires[0].start).toEqual([-10, 0, 10]);
+      expect(wires[0].end).toEqual([10, 0, 10]);
+      expect(wires[0].radius).toBe(0.001);
+      expect(wires[0].segments).toBe(21);
+    });
+
+    it('generates correct wire coordinates for NS orientation', () => {
+      const state = {
+        length: 20,
+        height: 15,
+        orientation: 'NS' as const,
+        wireRadius: 0.002,
+        segments: 11,
+      };
+      const wires = buildWires(state);
+      expect(wires[0].start).toEqual([0, -10, 15]);
+      expect(wires[0].end).toEqual([0, 10, 15]);
+    });
+  });
+
+  describe('buildGroundParams', () => {
+    it('returns free space ground when height is <= 0', () => {
+      // Arrange
+      const state = useAntennaStore.getState();
+
+      // Act
+      const ground = buildGroundParams({ ...state, height: 0 });
+
+      // Assert
+      expect(ground.type).toBe('free');
+    });
+
+    it('returns perfect ground when groundId is perfect', () => {
+      const state = useAntennaStore.getState();
+      const ground = buildGroundParams({ ...state, height: 10, groundId: 'perfect' });
+      expect(ground.type).toBe('perfect');
+    });
+
+    it('returns real ground with sigma and epsilon when groundId is custom', () => {
+      const state = useAntennaStore.getState();
+      const ground = buildGroundParams({ ...state, height: 10, groundId: 'custom', groundSigma: 0.005, groundEpsilon: 13 });
+      expect(ground.type).toBe('real');
+      if (ground.type === 'real') {
+        expect(ground.sigma).toBe(0.005);
+        expect(ground.epsilon).toBe(13);
+      }
+    });
+  });
+
+  describe('selectSimulationInput', () => {
+    it('combines state into simulation input correctly', () => {
+      // Arrange
+      const state = useAntennaStore.getState();
+      const testState = {
+        ...state,
+        frequency: 14.1,
+        length: 10,
+        height: 5,
+        orientation: 'EW' as const,
+        segments: 11,
+      };
+
+      // Act
+      const input = selectSimulationInput(testState);
+
+      // Assert
+      expect(input.frequencyMHz).toBe(14.1);
+      expect(input.wires).toHaveLength(1);
+      expect(input.wires[0].segments).toBe(11);
+      expect(input.excitation.wireTag).toBe(1);
+      expect(input.excitation.segment).toBe(6); // Math.ceil(11 / 2)
+      expect(input.patternResolution.thetaSteps).toBe(37);
+      expect(input.patternResolution.phiSteps).toBe(72);
+    });
+  });
+});
+
+describe('antennaStore actions', () => {
+  it('updates frequency and clamps correctly', () => {
+    // Arrange
+    const store = useAntennaStore.getState();
+
+    // Act
+    store.setFrequency(40); // Max is 30
+
+    // Assert
+    expect(useAntennaStore.getState().frequency).toBe(30);
+
+    // Act
+    store.setFrequency(1); // Min is 1.8
+
+    // Assert
+    expect(useAntennaStore.getState().frequency).toBe(1.8);
+
+    // Act
+    store.setFrequency(14.1);
+
+    // Assert
+    expect(useAntennaStore.getState().frequency).toBe(14.1);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,5 +5,15 @@ export default defineConfig({
     environment: 'jsdom',
     include: ['tests/**/*.test.{ts,tsx}', 'src/**/*.test.{ts,tsx}'],
     globals: false,
+    setupFiles: ['./vitest.setup.ts'],
+    coverage: {
+      provider: 'v8',
+      thresholds: {
+        statements: 46,
+        branches: 32,
+        functions: 50,
+        lines: 59,
+      }
+    }
   },
 });

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,8 @@
+
+// Mock ResizeObserver
+class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+globalThis.ResizeObserver = ResizeObserver;


### PR DESCRIPTION
💡 What: Added unit tests for `ErrorBoundary` and `antennaStore`. Mocked `ResizeObserver` globally in `vitest.setup.ts`. Ignored `coverage/` in `.gitignore` and `eslint.config.js`.

🎯 Why: The `ErrorBoundary` needed testing to ensure fallbacks render correctly. `antennaStore` selectors like `buildWires` and actions needed baseline coverage. Also fixed an issue where running tests that mount the 3D scene would throw unhandled exceptions because `ResizeObserver` is missing from JSDOM.

📈 Maturity Impact: Bumped coverage thresholds for statements from unconfigured to 46%, branches to 32%, functions to 50%, and lines to 59% to lock in progress toward business standards.

---
*PR created automatically by Jules for task [2356503267760899122](https://jules.google.com/task/2356503267760899122) started by @2fst4u*