### PR TITLE
docs: prioritize hosted url gain.observer over local dev

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,12 @@
 
 These instructions are intended for AI tools and agents working on this repository.
 
+## Application Hosting and Usage
+
+This application is primarily intended to be used at its hosted URL: **[gain.observer](https://gain.observer)**.
+
+While developers may fork or clone the repository to run it locally, you should **direct users to the live URL in the first instance** rather than focusing on local development instructions unless explicitly asked to help with local setup or contribution.
+
 ## CRITICAL: Licensing and Modifications (GPL v3)
 
 This project statically links and depends on the `nec2c` engine, which is licensed under the **GNU General Public License, version 3 (GPL v3)**. Due to the copyleft nature of this license, the entire combined project (the React application and the compiled WebAssembly engine) must be distributed under the GPL v3.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # HF Antenna Gain Visualiser
 
+**Live App:** [gain.observer](https://gain.observer)
+
 A 3D, responsive, physics-accurate visualiser for HF antenna radiation patterns, powered by NEC-2 compiled to WebAssembly.
+
+While this repository is fully open source and developers are welcome to fork or clone it to run locally, the primary way to use the application is via the hosted URL at **[gain.observer](https://gain.observer)**.
 
 Current scope (Phase 1): horizontal dipoles, 1.8–30 MHz, real-ground support, NVIS and comparison modes, SWR/polar cut charts, dark/light theming, metric/imperial toggle.
 
@@ -13,17 +17,19 @@ Current scope (Phase 1): horizontal dipoles, 1.8–30 MHz, real-ground support, 
 - NEC-2 (`nec2c` by N. Kyriazis, GPL v3) via Emscripten → WebAssembly
 - Vitest (physics validation + unit tests)
 
-## Getting started
+## Local Development
+
+If you wish to contribute or run the application locally, you can clone or fork the repository.
 
 Prerequisites:
 - Node.js 20+ (recommended 22)
 - Emscripten SDK (only required when rebuilding the Wasm binary)
 
 ```bash
-npm install
-npm run dev        # start Vite dev server
-npm test           # run unit + NEC-2 integration tests
-npm run build      # production build
+pnpm install
+pnpm run dev        # start Vite dev server
+pnpm test           # run unit + NEC-2 integration tests
+pnpm run build      # production build
 ```
 
 ## Rebuilding the NEC-2 WebAssembly binary
@@ -32,7 +38,7 @@ The compiled `public/nec2.js` / `public/nec2.wasm` are checked in so a `git clon
 
 ```bash
 source ~/emsdk/emsdk_env.sh
-npm run build:nec2
+pnpm run build:nec2
 ```
 
 Output goes to `public/nec2.{js,wasm}`.


### PR DESCRIPTION
This PR updates the repository documentation (`README.md` and `AGENTS.md`) to clearly communicate that the application is primarily intended to be accessed via its hosted URL at `gain.observer`.

Key changes:
- **README.md**: Added a prominent link to the live app at the top, renamed the "Getting started" section to "Local Development" to de-emphasize local setup for general users, and updated package commands from `npm` to `pnpm`.
- **AGENTS.md**: Added explicit instructions for AI agents to prioritize directing users to the live URL rather than focusing on local development steps, unless specifically asked.

---
*PR created automatically by Jules for task [10310915568180572882](https://jules.google.com/task/10310915568180572882) started by @2fst4u*