### PR TITLE
Fix 3D scene theme synchronization

### DIFF
--- a/src/components/Scene/AntennaScene.tsx
+++ b/src/components/Scene/AntennaScene.tsx
@@ -12,6 +12,7 @@ import { DipoleWire } from './DipoleWire';
 import { GroundPlane } from './GroundPlane';
 import { RadiationPattern } from './RadiationPattern';
 import { useAntennaStore, type ComparisonSnapshot } from '../../store/antennaStore';
+import { THEME_COLORS } from '../../utils/themeColors';
 
 interface AntennaSceneProps {
   readonly snapshot?: ComparisonSnapshot | null;
@@ -31,6 +32,7 @@ export function AntennaScene({ snapshot = null }: AntennaSceneProps) {
   const dbRange = useAntennaStore((s) => s.dbRange);
   const colormap = useAntennaStore((s) => s.colormap);
   const mode = useAntennaStore((s) => s.mode);
+  const theme = useAntennaStore((s) => s.theme);
 
   const length = snapshot?.length ?? liveLength;
   const height = snapshot?.height ?? liveHeight;
@@ -47,7 +49,7 @@ export function AntennaScene({ snapshot = null }: AntennaSceneProps) {
       gl={{ antialias: true, alpha: false }}
       style={{ background: 'var(--bg-canvas)' }}
     >
-      <color attach="background" args={[getBg()]} />
+      <color attach="background" args={[THEME_COLORS[theme].background]} />
       <ambientLight intensity={0.35} />
       <directionalLight position={[15, 25, 10]} intensity={1.15} castShadow />
       <directionalLight position={[-10, 8, -8]} intensity={0.45} />
@@ -84,11 +86,4 @@ export function AntennaScene({ snapshot = null }: AntennaSceneProps) {
       </GizmoHelper>
     </Canvas>
   );
-}
-
-function getBg(): string {
-  // Peek the actual CSS variable — falls back to a neutral dark.
-  if (typeof window === 'undefined') return '#0a0d12';
-  const v = getComputedStyle(document.documentElement).getPropertyValue('--bg-canvas').trim();
-  return v || '#0a0d12';
 }

--- a/src/components/Scene/DipoleWire.tsx
+++ b/src/components/Scene/DipoleWire.tsx
@@ -14,7 +14,8 @@
 
 import { useMemo } from 'react';
 import * as THREE from 'three';
-import { buildWires, type Orientation } from '../../store/antennaStore';
+import { useAntennaStore, buildWires, type Orientation } from '../../store/antennaStore';
+import { THEME_COLORS } from '../../utils/themeColors';
 
 interface DipoleWireProps {
   readonly length: number;
@@ -29,6 +30,7 @@ function necToScene(p: readonly [number, number, number]): [number, number, numb
 }
 
 export function DipoleWire({ length, height, orientation, wireRadius, segments }: DipoleWireProps) {
+  const theme = useAntennaStore((s) => s.theme);
   const rendered = useMemo(() => {
     // Build synthetic state just for the wire geometry. We reuse buildWires()
     // to keep the coordinate convention in one place.
@@ -68,16 +70,20 @@ export function DipoleWire({ length, height, orientation, wireRadius, segments }
           <mesh position={s.position} quaternion={s.quaternion}>
             <cylinderGeometry args={[s.radius, s.radius, s.length, 16]} />
             <meshStandardMaterial
-              color="#e09a3f"
-              emissive="#7a3d00"
-              emissiveIntensity={0.35}
+              color={THEME_COLORS[theme].wire}
+              emissive={THEME_COLORS[theme].wire}
+              emissiveIntensity={0.15}
               metalness={0.85}
               roughness={0.35}
             />
           </mesh>
           <mesh position={s.feed}>
             <sphereGeometry args={[0.22, 16, 16]} />
-            <meshStandardMaterial color="#ff3a3a" emissive="#aa0000" emissiveIntensity={0.8} />
+            <meshStandardMaterial
+              color={THEME_COLORS[theme].feedpoint}
+              emissive={THEME_COLORS[theme].feedpoint}
+              emissiveIntensity={0.4}
+            />
           </mesh>
         </group>
       ))}

--- a/src/components/Scene/GroundPlane.tsx
+++ b/src/components/Scene/GroundPlane.tsx
@@ -4,14 +4,8 @@
 // We draw a large grid on top for scale reference.
 
 import { Grid } from '@react-three/drei';
-const GROUND_COLORS: Record<string, string> = {
-  sea: '#1d5980',
-  fresh: '#2f7ca0',
-  pastoral: '#3a3022',
-  'dry-rocky': '#6a5a44',
-  city: '#3f3f44',
-  perfect: '#888888',
-};
+import { useAntennaStore } from '../../store/antennaStore';
+import { THEME_COLORS } from '../../utils/themeColors';
 
 interface GroundPlaneProps {
   readonly groundId: string;
@@ -20,9 +14,11 @@ interface GroundPlaneProps {
 }
 
 export function GroundPlane({ groundId, height, showGrid }: GroundPlaneProps) {
+  const theme = useAntennaStore((s) => s.theme);
   if (height <= 0 || groundId === 'free') return null;
 
-  const color = GROUND_COLORS[groundId] ?? '#3a3022';
+  const colors = THEME_COLORS[theme].ground;
+  const color = (colors as Record<string, string>)[groundId] ?? colors.pastoral;
 
   return (
     <group>
@@ -41,10 +37,10 @@ export function GroundPlane({ groundId, height, showGrid }: GroundPlaneProps) {
           args={[400, 400]}
           cellSize={5}
           cellThickness={1.0}
-          cellColor="#555"
+          cellColor={theme === 'dark' ? '#555' : '#aaa'}
           sectionSize={25}
           sectionThickness={2.0}
-          sectionColor="#888"
+          sectionColor={theme === 'dark' ? '#888' : '#777'}
           fadeDistance={150}
           fadeStrength={5}
           infiniteGrid

--- a/src/utils/themeColors.ts
+++ b/src/utils/themeColors.ts
@@ -1,0 +1,44 @@
+export type Theme = 'dark' | 'light';
+
+export interface ThemeColors {
+  background: string;
+  wire: string;
+  feedpoint: string;
+  ground: {
+    sea: string;
+    fresh: string;
+    pastoral: string;
+    'dry-rocky': string;
+    city: string;
+    perfect: string;
+  };
+}
+
+export const THEME_COLORS: Record<Theme, ThemeColors> = {
+  dark: {
+    background: '#0a0d12',
+    wire: '#e09a3f',
+    feedpoint: '#ff5a5a',
+    ground: {
+      sea: '#1d5980',
+      fresh: '#2f7ca0',
+      pastoral: '#3a2d20',
+      'dry-rocky': '#6a5a44',
+      city: '#3f3f44',
+      perfect: '#888888',
+    },
+  },
+  light: {
+    background: '#e8ecf1',
+    wire: '#b87333',
+    feedpoint: '#d93030',
+    ground: {
+      sea: '#5ca6d6',
+      fresh: '#7eb7d4',
+      pastoral: '#ad9468',
+      'dry-rocky': '#c2af92',
+      city: '#949ba8',
+      perfect: '#aaaaaa',
+    },
+  },
+};


### PR DESCRIPTION
This PR fixes a bug where the 3D rendered background and scene elements stayed dark or flipped out of sync when toggling between dark and light modes.

The root cause was the `AntennaScene` component attempting to read the background color from the DOM using `getComputedStyle` within the render cycle. Since this isn't a reactive pattern in React, the component didn't know it needed to re-render when the theme changed, leading to the "one-step-behind" behavior.

I've introduced a centralized `THEME_COLORS` utility that provides synchronous access to the correct hex colors for both themes. All 3D components now subscribe directly to the `theme` state from the store, ensuring they re-render immediately and correctly when the theme is toggled.

Key changes:
- New `src/utils/themeColors.ts` containing theme constants.
- `AntennaScene.tsx`: Subscribes to theme and uses it for the canvas background.
- `GroundPlane.tsx`: Uses theme-aware colors for ground materials and grid lines.
- `DipoleWire.tsx`: Uses theme-aware colors for the wire and feedpoint.

Fixes #15

---
*PR created automatically by Jules for task [5395430703613155607](https://jules.google.com/task/5395430703613155607) started by @2fst4u*