### PR TITLE
🧪 Add unit tests for necCard generator

### DIFF
--- a/tests/necCard.test.ts
+++ b/tests/necCard.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from 'vitest';
+import { buildNecCards } from '../src/physics/necCard';
+import type { SimulationInput } from '../src/physics/types';
+
+describe('buildNecCards', () => {
+  const defaultInput: SimulationInput = {
+    frequencyMHz: 14.15,
+    wires: [
+      {
+        start: [0, -5, 10],
+        end: [0, 5, 10],
+        radius: 0.001,
+        segments: 11,
+      },
+    ],
+    ground: { type: 'free' },
+    excitation: {
+      wireTag: 1,
+      segment: 6,
+    },
+    patternResolution: {
+      thetaSteps: 37,
+      phiSteps: 73,
+    },
+  };
+
+  it('generates a valid basic deck for a dipole in free space', () => {
+    const output = buildNecCards(defaultInput);
+    const lines = output.trim().split('\n');
+
+    expect(lines[0]).toBe('CM gain-visualiser auto-generated deck');
+    expect(lines[1]).toBe('CM f=14.15 MHz  ground=free');
+    expect(lines[2]).toBe('CE');
+    expect(lines[3]).toBe('GW 1 11 0.00000 -5.00000 10.00000 0.00000 5.00000 10.00000 0.00100');
+    expect(lines[4]).toBe('GE 0');
+    expect(lines[5]).toBe('FR 0 1 0 0 14.150000 0');
+    expect(lines[6]).toBe('EX 0 1 6 0 1.0000 0.0000');
+    expect(lines[7]).toBe('RP 0 37 73 1000 0 0 5.0000 4.9315');
+    expect(lines[8]).toBe('EN');
+  });
+
+  describe('geometry and coordinate formatting', () => {
+    it('handles multiple wires with auto-incrementing tags', () => {
+      const input: SimulationInput = {
+        ...defaultInput,
+        wires: [
+          { start: [0, 0, 0], end: [1, 0, 0], radius: 0.01, segments: 10 },
+          { start: [1, 0, 0], end: [1, 1, 0], radius: 0.01, segments: 10 },
+        ],
+      };
+      const output = buildNecCards(input);
+      expect(output).toContain('GW 1 10 0.00000 0.00000 0.00000 1.00000 0.00000 0.00000 0.01000');
+      expect(output).toContain('GW 2 10 1.00000 0.00000 0.00000 1.00000 1.00000 0.00000 0.01000');
+    });
+
+    it('respects explicit wire tags', () => {
+      const input: SimulationInput = {
+        ...defaultInput,
+        wires: [
+          { start: [0, 0, 0], end: [1, 0, 0], radius: 0.01, segments: 10, tag: 42 },
+        ],
+      };
+      const output = buildNecCards(input);
+      expect(output).toContain('GW 42 10 0.00000 0.00000 0.00000 1.00000 0.00000 0.00000 0.01000');
+    });
+
+    it('formats coordinates and radius to 5 decimal places', () => {
+      const input: SimulationInput = {
+        ...defaultInput,
+        wires: [
+          {
+            start: [1.234567, 2.345678, 3.456789],
+            end: [4.5678901, 5.6789012, 6.7890123],
+            radius: 0.0001234,
+            segments: 5,
+          },
+        ],
+      };
+      const output = buildNecCards(input);
+      // GW tag nseg x1 y1 z1 x2 y2 z2 rad
+      expect(output).toContain('GW 1 5 1.23457 2.34568 3.45679 4.56789 5.67890 6.78901 0.00012');
+    });
+  });
+
+  describe('ground configurations', () => {
+    it('generates GE 0 and no GN card for free space', () => {
+      const output = buildNecCards({ ...defaultInput, ground: { type: 'free' } });
+      expect(output).toContain('GE 0');
+      expect(output).not.toContain('GN');
+    });
+
+    it('generates GE 1 and GN 1 for perfect ground', () => {
+      const output = buildNecCards({ ...defaultInput, ground: { type: 'perfect' } });
+      expect(output).toContain('GE 1');
+      expect(output).toContain('GN 1');
+    });
+
+    it('generates GE 1 and GN 2 for real ground with custom parameters', () => {
+      const output = buildNecCards({
+        ...defaultInput,
+        ground: { type: 'real', epsilon: 15.5, sigma: 0.012345 },
+      });
+      expect(output).toContain('GE 1');
+      expect(output).toContain('GN 2 0 0 0 15.500 0.01235');
+    });
+
+    it('uses default real ground parameters if not provided', () => {
+      const output = buildNecCards({
+        ...defaultInput,
+        ground: { type: 'real' },
+      });
+      expect(output).toContain('GE 1');
+      expect(output).toContain('GN 2 0 0 0 13.000 0.00500');
+    });
+  });
+
+  describe('frequency, excitation, and control cards', () => {
+    it('formats FR card correctly', () => {
+      const output = buildNecCards({ ...defaultInput, frequencyMHz: 7.05 });
+      expect(output).toContain('FR 0 1 0 0 7.050000 0');
+    });
+
+    it('formats EX card with standard voltage', () => {
+      const output = buildNecCards(defaultInput);
+      expect(output).toContain('EX 0 1 6 0 1.0000 0.0000');
+    });
+
+    it('formats EX card with complex voltage', () => {
+      const input: SimulationInput = {
+        ...defaultInput,
+        excitation: { wireTag: 1, segment: 1, real: 0.5, imag: -0.5 },
+      };
+      const output = buildNecCards(input);
+      expect(output).toContain('EX 0 1 1 0 0.5000 -0.5000');
+    });
+
+    it('includes required CE and EN markers', () => {
+      const output = buildNecCards(defaultInput);
+      const lines = output.trim().split('\n');
+      expect(lines[0].startsWith('CM')).toBe(true);
+      expect(lines[lines.length - 1]).toBe('EN');
+    });
+  });
+
+  describe('simulation control and radiation pattern', () => {
+    it('generates RP card by default', () => {
+      const output = buildNecCards(defaultInput);
+      expect(output).toContain('RP 0 37 73 1000 0 0 5.0000 4.9315');
+    });
+
+    it('generates XQ card when includePattern is false', () => {
+      const output = buildNecCards(defaultInput, { includePattern: false });
+      expect(output).toContain('XQ');
+      expect(output).not.toContain('RP');
+    });
+
+    it('calculates dTheta and dPhi correctly', () => {
+      const input: SimulationInput = {
+        ...defaultInput,
+        patternResolution: { thetaSteps: 19, phiSteps: 36 },
+      };
+      // dTheta = 180 / (19 - 1) = 10
+      // dPhi = 360 / 36 = 10
+      const output = buildNecCards(input);
+      expect(output).toContain('RP 0 19 36 1000 0 0 10.0000 10.0000');
+    });
+  });
+
+  describe('error handling', () => {
+    it('throws error for NaN coordinates', () => {
+      const input: SimulationInput = {
+        ...defaultInput,
+        wires: [{ ...defaultInput.wires[0], start: [NaN, 0, 0] }],
+      };
+      expect(() => buildNecCards(input)).toThrow('Non-finite numeric value in NEC card: NaN');
+    });
+
+    it('throws error for Infinity in numeric fields', () => {
+      const input: SimulationInput = {
+        ...defaultInput,
+        frequencyMHz: Infinity,
+      };
+      expect(() => buildNecCards(input)).toThrow('Non-finite numeric value in NEC card: Infinity');
+    });
+  });
+});


### PR DESCRIPTION
🎯 **What:** This PR addresses the missing test coverage for the `buildNecCards` function in `src/physics/necCard.ts`.

📊 **Coverage:** The new test suite in `tests/necCard.test.ts` covers:
- **Geometry:** GW cards, wire tagging, and coordinate formatting.
- **Ground:** GE and GN cards for all supported ground types (free, perfect, real).
- **Excitation:** EX card formatting with real and complex voltages.
- **Simulation Control:** RP (radiation pattern) vs XQ (execution only) logic.
- **Error Handling:** Validation of finite numeric inputs (NaN/Infinity checks).

✨ **Result:** Improved reliability and confidence in the core NEC-2 input generation logic, ensuring that any future refactoring of the card deck builder is safely guarded by automated tests.

---
*PR created automatically by Jules for task [12604829159327358611](https://jules.google.com/task/12604829159327358611) started by @2fst4u*