### PR TITLE
🧪 Add missing edge case test for impedance reflection coefficient

### DIFF
--- a/tests/impedance.test.ts
+++ b/tests/impedance.test.ts
@@ -34,4 +34,9 @@ describe('reflection coefficient and SWR', () => {
   it('extremely high resistance capped at 999', () => {
     expect(swr({ R: 1e10, X: 0 })).toBe(999);
   });
+
+  it('den === 0 edge case (e.g. Z = -Z0) gives |Γ| = 1', () => {
+    // With Z0 = 50, Z = -50 + j0 gives denR = -50 + 50 = 0 and denX = 0 => den = 0
+    expect(reflectionCoefficientMag({ R: -50, X: 0 })).toBe(1);
+  });
 });


### PR DESCRIPTION
🎯 **What:** The testing gap in `src/physics/impedance.ts` where `reflectionCoefficientMag` handles the `den === 0` edge case was not previously verified by tests. This PR addresses that omission.
📊 **Coverage:** A test case was added to explicitly trigger the edge case by supplying an impedance equal to `-Z0` (e.g. `R: -50, X: 0`), verifying the return value handles a zero denominator correctly without throwing or calculating `NaN`.
✨ **Result:** Test coverage is explicitly improved for this mathematical safety check, giving higher confidence that invalid or structurally destructive impedances are properly mitigated when determining reflection properties.

---
*PR created automatically by Jules for task [16731724217499478460](https://jules.google.com/task/16731724217499478460) started by @2fst4u*