### PR TITLE
🧪 test: add unit tests for useTheme hook

### DIFF
--- a/tests/useTheme.test.ts
+++ b/tests/useTheme.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useTheme } from '../src/hooks/useTheme';
+import { useAntennaStore } from '../src/store/antennaStore';
+
+describe('useTheme hook', () => {
+  beforeEach(() => {
+    // Reset DOM and store before each test
+    document.documentElement.dataset.theme = '';
+    window.localStorage.clear();
+    useAntennaStore.setState({ theme: 'dark' });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('applies the initial theme to document and localStorage', () => {
+    renderHook(() => useTheme());
+
+    expect(document.documentElement.dataset.theme).toBe('dark');
+    expect(window.localStorage.getItem('gv.theme')).toBe('dark');
+  });
+
+  it('restores theme from localStorage on mount if valid', () => {
+    window.localStorage.setItem('gv.theme', 'light');
+
+    renderHook(() => useTheme());
+
+    // It should have called setTheme('light'), which updates the store and then applies it
+    expect(useAntennaStore.getState().theme).toBe('light');
+    expect(document.documentElement.dataset.theme).toBe('light');
+  });
+
+  it('ignores invalid theme in localStorage', () => {
+    window.localStorage.setItem('gv.theme', 'invalid-theme');
+
+    renderHook(() => useTheme());
+
+    // Should remain 'dark'
+    expect(useAntennaStore.getState().theme).toBe('dark');
+    expect(document.documentElement.dataset.theme).toBe('dark');
+  });
+
+  it('updates document and localStorage when theme changes in store', () => {
+    renderHook(() => useTheme());
+
+    act(() => {
+      useAntennaStore.getState().setTheme('light');
+    });
+
+    expect(document.documentElement.dataset.theme).toBe('light');
+    expect(window.localStorage.getItem('gv.theme')).toBe('light');
+  });
+});


### PR DESCRIPTION
🎯 **What:** Added a missing test suite for the `useTheme` hook.
📊 **Coverage:** The test suite now explicitly covers:
- Applying the initial theme to the document and local storage.
- Restoring a valid theme (`light` or `dark`) from local storage on mount.
- Ignoring invalid theme values found in local storage, falling back to the store's default.
- Updating both the DOM (`document.documentElement.dataset.theme`) and `localStorage` when the theme changes within the central store.
✨ **Result:** Improved test coverage and reliability for theme management operations, ensuring that user theme preferences persist predictably and side-effects properly fire when state updates.

---
*PR created automatically by Jules for task [410423831220862512](https://jules.google.com/task/410423831220862512) started by @2fst4u*