### PR TITLE
Fix horizontal overflow in Polar cuts charts

### DIFF
--- a/src/components/Charts/PolarPlots.tsx
+++ b/src/components/Charts/PolarPlots.tsx
@@ -77,8 +77,8 @@ export function PolarPlots() {
   return (
     <div className="panel-section">
       <h3>Polar cuts</h3>
-      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8 }}>
-        <div>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(130px, 1fr))', gap: 8 }}>
+        <div style={{ minWidth: 0 }}>
           <div style={{ fontSize: 11, color: 'var(--text-muted)', textAlign: 'center' }}>
             Azimuth @ {result.takeoffElevationDeg.toFixed(0)}° elev.
           </div>
@@ -97,7 +97,7 @@ export function PolarPlots() {
             />
           </div>
         </div>
-        <div>
+        <div style={{ minWidth: 0 }}>
           <div style={{ fontSize: 11, color: 'var(--text-muted)', textAlign: 'center' }}>
             Elevation @ {result.takeoffAzimuthDeg.toFixed(0)}° az.
           </div>


### PR DESCRIPTION
The polar cuts charts in the sidebar were causing horizontal overflow because they were forced into a 2-column layout even when space was limited. This PR updates the `PolarPlots` component to use a responsive grid that automatically wraps when columns cannot maintain a minimum width (130px). It also adds `min-width: 0` to the grid items, which is required for Chart.js canvases to correctly shrink within their containers.

Fixes #29

---
*PR created automatically by Jules for task [199963563037311324](https://jules.google.com/task/199963563037311324) started by @2fst4u*