### PR TITLE
Remove "SWR 2.0" label from SWR graph

### DIFF
--- a/src/components/Charts/SWRChart.tsx
+++ b/src/components/Charts/SWRChart.tsx
@@ -150,7 +150,6 @@ export function SWRChart() {
             borderColor: '#ff6b6b',
             borderWidth: 1,
             borderDash: [6, 4],
-            label: { display: true, content: 'SWR 2.0', position: 'end', color: '#ff6b6b' },
           },
           currentFrequency: {
             type: 'line',


### PR DESCRIPTION
Removed the "SWR 2.0" text label from the SWR chart annotation in `src/components/Charts/SWRChart.tsx`. The horizontal threshold line at Y=2 is preserved to provide visual context without the redundant and messy text overlay. Tested and visually verified with a Playwright screenshot.

Fixes #35

---
*PR created automatically by Jules for task [1781245507046267879](https://jules.google.com/task/1781245507046267879) started by @2fst4u*