### PR TITLE
🧹 code health: remove unused vacuum physical constants

### DIFF
--- a/src/physics/constants.ts
+++ b/src/physics/constants.ts
@@ -9,17 +9,8 @@ export const SPEED_OF_LIGHT = 299_792_458;
 /** Speed of light expressed as MHz·m (useful: λ_m = C_MHZ_M / f_MHz). */
 export const C_MHZ_M = SPEED_OF_LIGHT / 1_000_000;
 
-/** Characteristic impedance of free space, ohms. */
-export const ETA_0 = 376.730_313_668;
-
 /** System / feedline reference impedance, ohms. */
 export const Z0_SYSTEM = 50;
-
-/** Permittivity of free space, F/m. */
-export const EPSILON_0 = 8.854_187_8128e-12;
-
-/** Permeability of free space, H/m. */
-export const MU_0 = 1.256_637_062_12e-6;
 
 /** Default wire radius for HF antennas, metres (≈ 14 AWG copper ~ 2 mm). */
 export const DEFAULT_WIRE_RADIUS_M = 0.001;


### PR DESCRIPTION
🎯 **What:** Removed the unused physics constants `MU_0`, `EPSILON_0`, and `ETA_0` from `src/physics/constants.ts`.
💡 **Why:** These constants (vacuum permeability, permittivity, and characteristic impedance of free space) were added in the initial creation of the file but were never actually used. The application relies on the C-based NEC-2 WebAssembly engine to perform all heavy electromagnetic field calculations, meaning the TypeScript UI layer never needs to reference these foundational constants itself. Removing dead code reduces cognitive load and improves maintainability.
✅ **Verification:** Verified via `grep` that none of the constants were used anywhere in the `src/` directory. Verified that the test suite, linter, and build checks still pass cleanly after removal.
✨ **Result:** A cleaner `constants.ts` file containing only the values actually used by the TypeScript client layer.

---
*PR created automatically by Jules for task [9689037753832529026](https://jules.google.com/task/9689037753832529026) started by @2fst4u*