### PR TITLE
🧹 Refactor physics unit conversions to remove unused exports

### DIFF
--- a/src/physics/units.ts
+++ b/src/physics/units.ts
@@ -4,11 +4,11 @@ export type UnitSystem = 'metric' | 'imperial';
 
 const METERS_PER_FOOT = 0.3048;
 
-export function metersToFeet(m: number): number {
+function metersToFeet(m: number): number {
   return m / METERS_PER_FOOT;
 }
 
-export function feetToMeters(ft: number): number {
+function feetToMeters(ft: number): number {
   return ft * METERS_PER_FOOT;
 }
 

--- a/tests/units.test.ts
+++ b/tests/units.test.ts
@@ -1,7 +1,5 @@
 import { describe, expect, it } from 'vitest';
 import {
-  metersToFeet,
-  feetToMeters,
   toDisplayLength,
   fromDisplayLength,
   formatLength,
@@ -11,7 +9,7 @@ describe('unit conversions', () => {
   it('round-trips m → ft → m within float precision', () => {
     const samples = [0, 0.1, 1, 10.05, 21.11, 100];
     for (const m of samples) {
-      const back = feetToMeters(metersToFeet(m));
+      const back = fromDisplayLength(toDisplayLength(m, 'imperial'), 'imperial');
       expect(back).toBeCloseTo(m, 10);
     }
   });
@@ -34,8 +32,8 @@ describe('unit conversions', () => {
 
   it('converts common benchmarks correctly', () => {
     // 1 meter approx 3.28084 feet
-    expect(metersToFeet(1)).toBeCloseTo(3.28084, 5);
+    expect(toDisplayLength(1, 'imperial')).toBeCloseTo(3.28084, 5);
     // 1 foot is exactly 0.3048 meters
-    expect(feetToMeters(1)).toBe(0.3048);
+    expect(fromDisplayLength(1, 'imperial')).toBe(0.3048);
   });
 });


### PR DESCRIPTION
🎯 **What:** Removed unused exports for `metersToFeet` and `feetToMeters` in `src/physics/units.ts` and updated tests in `tests/units.test.ts` to test through the public API.
💡 **Why:** `metersToFeet` and `feetToMeters` are internal implementation details used to support `toDisplayLength` and `fromDisplayLength`. Un-exporting them reduces the public API surface area, reducing the chance of them being misused externally and improving overall module encapsulation. Tests were updated to reflect this and verify through public entry points.
✅ **Verification:** Ran `npm run lint` and `npm test`. Both passed without regressions, proving that the underlying logic remains functional and correctly bound to the public APIs.
✨ **Result:** A cleaner, more maintainable module API for the physics unit conversion utilities.

---
*PR created automatically by Jules for task [3518389681573091576](https://jules.google.com/task/3518389681573091576) started by @2fst4u*