### PR TITLE
🧹 code health: remove unused export from wavelengthMeters

### DIFF
--- a/src/physics/constants.ts
+++ b/src/physics/constants.ts
@@ -18,7 +18,7 @@ export const DEFAULT_WIRE_RADIUS_M = 0.001;
 /**
  * Convenience: wavelength in metres for a given frequency in MHz.
  */
-export function wavelengthMeters(frequencyMHz: number): number {
+function wavelengthMeters(frequencyMHz: number): number {
   return C_MHZ_M / frequencyMHz;
 }
 

--- a/tests/constants.test.ts
+++ b/tests/constants.test.ts
@@ -1,18 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import { wavelengthMeters, halfWaveLength, HF_BAND_PRESETS } from '../src/physics/constants';
+import { halfWaveLength, HF_BAND_PRESETS } from '../src/physics/constants';
 
 describe('physics constants and helpers', () => {
-  it('wavelengthMeters matches speed of light / f', () => {
-    expect(wavelengthMeters(7.1)).toBeCloseTo(42.224, 2);
-    expect(wavelengthMeters(14.2)).toBeCloseTo(21.112, 2);
-    expect(wavelengthMeters(28.4)).toBeCloseTo(10.556, 2);
-  });
-
   it('halfWaveLength accounts for end effect', () => {
     // 40m band dipole
-    const wl = wavelengthMeters(7.1);
-    expect(halfWaveLength(7.1, 1.0)).toBeCloseTo(wl / 2, 5);
-    expect(halfWaveLength(7.1, 0.95)).toBeCloseTo(wl * 0.5 * 0.95, 5);
+    // wavelength at 7.1 MHz = 299.792458 / 7.1 = 42.2242898...
+    expect(halfWaveLength(7.1, 1.0)).toBeCloseTo(21.1121, 4);
+    expect(halfWaveLength(7.1, 0.95)).toBeCloseTo(20.0565, 4);
   });
 
   it('HF_BAND_PRESETS contains standard bands', () => {


### PR DESCRIPTION
🎯 **What:** Removed the `export` keyword from `wavelengthMeters` in `src/physics/constants.ts` to make it a module-internal helper.
💡 **Why:** This function was only used by `halfWaveLength` in the same file. Exporting it unnecessarily exposed internal implementation details to the wider application context. Encapsulating it cleans up the module API surface.
✅ **Verification:** Updated `tests/constants.test.ts` to no longer rely on the internal function, and successfully ran the test suite (`npm test`) and linter (`npm run lint`).
✨ **Result:** Improved code health by applying encapsulation, reducing cognitive load on the API surface.

---
*PR created automatically by Jules for task [15472124564616116491](https://jules.google.com/task/15472124564616116491) started by @2fst4u*