### PR TITLE
🧹 Refactor: Remove unused export reflectionCoefficientMag

### DIFF
--- a/src/physics/impedance.ts
+++ b/src/physics/impedance.ts
@@ -7,7 +7,7 @@ import type { ImpedanceResult } from './types';
  * Reflection coefficient magnitude for a load Z against the system impedance.
  * |Γ| = |Z - Z0| / |Z + Z0|, where Z is complex.
  */
-export function reflectionCoefficientMag(z: ImpedanceResult, z0: number = Z0_SYSTEM): number {
+function reflectionCoefficientMag(z: ImpedanceResult, z0: number = Z0_SYSTEM): number {
   const numR = z.R - z0;
   const numX = z.X;
   const denR = z.R + z0;

--- a/tests/impedance.test.ts
+++ b/tests/impedance.test.ts
@@ -1,14 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import { reflectionCoefficientMag, swr } from '../src/physics/impedance';
+import { swr } from '../src/physics/impedance';
 
 describe('reflection coefficient and SWR', () => {
   it('perfect match => |Γ|=0, SWR=1', () => {
-    expect(reflectionCoefficientMag({ R: 50, X: 0 })).toBeCloseTo(0, 10);
     expect(swr({ R: 50, X: 0 })).toBeCloseTo(1, 10);
   });
 
   it('open circuit => |Γ|=1, SWR at display cap', () => {
-    expect(reflectionCoefficientMag({ R: 1e15, X: 0 })).toBeCloseTo(1, 4);
     expect(swr({ R: 1e15, X: 0 })).toBe(999);
   });
 
@@ -36,7 +34,8 @@ describe('reflection coefficient and SWR', () => {
   });
 
   it('den === 0 edge case (e.g. Z = -Z0) gives |Γ| = 1', () => {
-    // With Z0 = 50, Z = -50 + j0 gives denR = -50 + 50 = 0 and denX = 0 => den = 0
-    expect(reflectionCoefficientMag({ R: -50, X: 0 })).toBe(1);
+    // With Z0 = 50, Z = -50 + j0 gives denR = -50 + 50 = 0 and denX = 0 => den = 0.
+    // When |Γ| = 1, SWR is clamped at 999.
+    expect(swr({ R: -50, X: 0 })).toBe(999);
   });
 });


### PR DESCRIPTION
🎯 **What:** Removed the `export` keyword from `reflectionCoefficientMag` in `src/physics/impedance.ts` and refactored the corresponding unit tests to verify logic via the public `swr` function.
💡 **Why:** The function was flagged as dead/unused code outside its own module. Removing the export improves maintainability by strictly enforcing the module's public API and hiding internal implementation details, conforming to the repository's Testing & API Surface Pattern.
✅ **Verification:** Ran `npm run lint` and `npm test`. All 84 tests pass, confirming that the change does not introduce any regressions and successfully exercises the internal logic through the public `swr` method.
✨ **Result:** A cleaner API surface, better encapsulation, and improved code readability.

---
*PR created automatically by Jules for task [4501303311719722343](https://jules.google.com/task/4501303311719722343) started by @2fst4u*