### PR TITLE
🧹 Remove unused export of SPEED_OF_LIGHT

### DIFF
--- a/src/physics/constants.ts
+++ b/src/physics/constants.ts
@@ -4,7 +4,7 @@
 // display imperial but the physics layer and stored state are always metric.
 
 /** Speed of light in a vacuum, m/s. */
-export const SPEED_OF_LIGHT = 299_792_458;
+const SPEED_OF_LIGHT = 299_792_458;
 
 /** Speed of light expressed as MHz·m (useful: λ_m = C_MHZ_M / f_MHz). */
 export const C_MHZ_M = SPEED_OF_LIGHT / 1_000_000;


### PR DESCRIPTION
🎯 **What:** Removed the `export` keyword from `SPEED_OF_LIGHT` in `src/physics/constants.ts` since it is only used internally within the same file to calculate `C_MHZ_M`.
💡 **Why:** Reduces the public API surface area, eliminating dead exported code and improving clarity and maintainability.
✅ **Verification:** Verified safe by running `npm test` after the change, with all 83 tests passing successfully.
✨ **Result:** Cleaned up unused export while preserving complete behavior and unit test coverage.

---
*PR created automatically by Jules for task [12109163170592389089](https://jules.google.com/task/12109163170592389089) started by @2fst4u*