### PR TITLE
🧹 chore: encapsulate C_MHZ_M constant

### DIFF
--- a/src/physics/constants.ts
+++ b/src/physics/constants.ts
@@ -7,7 +7,7 @@
 const SPEED_OF_LIGHT = 299_792_458;
 
 /** Speed of light expressed as MHz·m (useful: λ_m = C_MHZ_M / f_MHz). */
-export const C_MHZ_M = SPEED_OF_LIGHT / 1_000_000;
+const C_MHZ_M = SPEED_OF_LIGHT / 1_000_000;
 
 /** System / feedline reference impedance, ohms. */
 export const Z0_SYSTEM = 50;
@@ -18,7 +18,7 @@ export const DEFAULT_WIRE_RADIUS_M = 0.001;
 /**
  * Convenience: wavelength in metres for a given frequency in MHz.
  */
-function wavelengthMeters(frequencyMHz: number): number {
+export function wavelengthMeters(frequencyMHz: number): number {
   return C_MHZ_M / frequencyMHz;
 }
 

--- a/tests/nec2Engine.integration.test.ts
+++ b/tests/nec2Engine.integration.test.ts
@@ -8,7 +8,7 @@
 
 import { describe, expect, it, beforeAll } from 'vitest';
 import { Nec2Engine } from '../src/physics/nec2Engine';
-import { halfWaveLength, C_MHZ_M } from '../src/physics/constants';
+import { halfWaveLength, wavelengthMeters } from '../src/physics/constants';
 import type { SimulationInput } from '../src/physics/types';
 import { pathToFileURL } from 'node:url';
 import { resolve } from 'node:path';
@@ -53,14 +53,14 @@ describe('Nec2Engine (real Wasm)', () => {
     expect(r.impedance.R).toBeGreaterThan(60);
     expect(r.impedance.R).toBeLessThan(90);
     // Wavelength sanity.
-    const lambda = C_MHZ_M / freq;
+    const lambda = wavelengthMeters(freq);
     expect(lambda).toBeCloseTo(42.224, 2);
   }, 30_000);
 
   it('reports higher gain when above real ground vs free space', async () => {
     const freq = 7.1;
     const tip = halfWaveLength(freq, 1.0) / 2;
-    const lambda = C_MHZ_M / freq;
+    const lambda = wavelengthMeters(freq);
 
     const fs: SimulationInput = {
       wires: [{ start: [-tip, 0, 0], end: [tip, 0, 0], radius: 0.001, segments: 21, tag: 1 }],
@@ -98,7 +98,7 @@ describe('Nec2Engine (real Wasm)', () => {
   it('quarter-wave height produces NVIS (high take-off angle)', async () => {
     const freq = 7.1;
     const tip = halfWaveLength(freq, 1.0) / 2;
-    const lambda = C_MHZ_M / freq;
+    const lambda = wavelengthMeters(freq);
 
     const input: SimulationInput = {
       wires: [{


### PR DESCRIPTION
🎯 **What:** The `C_MHZ_M` constant was exported and manually used to calculate wavelength in test files, resulting in logic duplication and exposure of internal implementation details. I removed the `export` keyword from `C_MHZ_M` and exported the existing `wavelengthMeters` helper function instead.
💡 **Why:** This improves encapsulation and code health by relying on a single, clear helper function (`wavelengthMeters`) instead of scattering `C_MHZ_M / frequency` logic across the codebase. It creates a cleaner API boundary for the `constants.ts` module.
✅ **Verification:** Ran `npm install && npm run lint && npm test`. All tests passed, confirming the behavior is identical and perfectly preserved.
✨ **Result:** Better encapsulation with no broken functionality.

---
*PR created automatically by Jules for task [16873270693942551128](https://jules.google.com/task/16873270693942551128) started by @2fst4u*