### PR TITLE
🎨 Palette: Improve accessibility in DisplayControl form elements

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-20 - Discrete External Links
 **Learning:** External links should be visually secondary to primary app controls to avoid cluttering the interface.
 **Action:** Place external links like GitHub source at the bottom of the control panel with muted colors and a subtle separator.
+
+## 2024-05-23 - Linking Labels and Inputs
+**Learning:** Orphaned labels and inputs in React components can cause screen readers to fail to announce the purpose of form controls.
+**Action:** Always link labels and inputs using explicit `htmlFor` and `id` attributes, even if they're visually adjacent, to ensure maximum compatibility with screen readers.

--- a/src/components/Panel/DisplayControl.tsx
+++ b/src/components/Panel/DisplayControl.tsx
@@ -20,42 +20,45 @@ export function DisplayControl() {
   return (
     <div className="panel-section">
       <h3>Display</h3>
-      <label>Colormap</label>
-      <div className="button-group">
+      <label id="colormap-label">Colormap</label>
+      <div className="button-group" role="group" aria-labelledby="colormap-label">
         {COLORMAPS.map((c) => (
           <button
             key={c}
             className={colormap === c ? 'active' : ''}
             onClick={() => setColormap(c)}
+            aria-pressed={colormap === c}
           >{c}</button>
         ))}
       </div>
 
-      <label style={{ marginTop: 10 }}>Dynamic range — {dbRange} dB</label>
+      <label htmlFor="dynamic-range" style={{ marginTop: 10 }}>Dynamic range — {dbRange} dB</label>
       <input
+        id="dynamic-range"
         type="range" min={10} max={50} step={1}
         value={dbRange}
         onChange={(e) => setDbRange(parseInt(e.target.value))}
       />
 
-      <label style={{ marginTop: 8 }}>Pattern scale — {patternScale.toFixed(2)}×</label>
+      <label htmlFor="pattern-scale" style={{ marginTop: 8 }}>Pattern scale — {patternScale.toFixed(2)}×</label>
       <input
+        id="pattern-scale"
         type="range" min={0.3} max={3} step={0.1}
         value={patternScale}
         onChange={(e) => setPatternScale(parseFloat(e.target.value))}
       />
 
       <div style={{ display: 'flex', flexDirection: 'column', gap: 4, marginTop: 10, fontSize: 12 }}>
-        <label style={{ display: 'flex', alignItems: 'center', gap: 6, textTransform: 'none', letterSpacing: 0, margin: 0 }}>
-          <input type="checkbox" checked={showGrid} onChange={(e) => setShowGrid(e.target.checked)} />
+        <label htmlFor="show-grid" style={{ display: 'flex', alignItems: 'center', gap: 6, textTransform: 'none', letterSpacing: 0, margin: 0 }}>
+          <input id="show-grid" type="checkbox" checked={showGrid} onChange={(e) => setShowGrid(e.target.checked)} />
           Ground grid
         </label>
-        <label style={{ display: 'flex', alignItems: 'center', gap: 6, textTransform: 'none', letterSpacing: 0, margin: 0 }}>
-          <input type="checkbox" checked={showAxes} onChange={(e) => setShowAxes(e.target.checked)} />
+        <label htmlFor="show-axes" style={{ display: 'flex', alignItems: 'center', gap: 6, textTransform: 'none', letterSpacing: 0, margin: 0 }}>
+          <input id="show-axes" type="checkbox" checked={showAxes} onChange={(e) => setShowAxes(e.target.checked)} />
           Axes helper
         </label>
-        <label style={{ display: 'flex', alignItems: 'center', gap: 6, textTransform: 'none', letterSpacing: 0, margin: 0 }}>
-          <input type="checkbox" checked={showPolarCuts} onChange={(e) => setShowPolarCuts(e.target.checked)} />
+        <label htmlFor="show-polar-cuts" style={{ display: 'flex', alignItems: 'center', gap: 6, textTransform: 'none', letterSpacing: 0, margin: 0 }}>
+          <input id="show-polar-cuts" type="checkbox" checked={showPolarCuts} onChange={(e) => setShowPolarCuts(e.target.checked)} />
           Polar plots
         </label>
       </div>


### PR DESCRIPTION
🎨 Palette: Improve accessibility in DisplayControl form elements

💡 What: Added explicit `htmlFor` and `id` attributes to form controls (sliders, checkboxes) and proper `aria-pressed` and `role="group"` to the colormap toggle group.
🎯 Why: Ensures screen readers can correctly associate labels with their inputs and understand the state of the toggle buttons.
♿ Accessibility: Improved form control semantics and state reporting for AT users.

---
*PR created automatically by Jules for task [13232444069401334162](https://jules.google.com/task/13232444069401334162) started by @2fst4u*