### PR TITLE
Improve polar cut orientation and readability

### DIFF
--- a/src/components/Charts/PolarPlots.tsx
+++ b/src/components/Charts/PolarPlots.tsx
@@ -1,17 +1,19 @@
 // 2D polar plots: azimuth cut at take-off elevation, elevation cut at peak azimuth.
 
-import { PolarArea } from 'react-chartjs-2';
+import { Radar } from 'react-chartjs-2';
 import {
   Chart as ChartJS,
   RadialLinearScale,
-  ArcElement,
+  PointElement,
+  LineElement,
+  Filler,
   Tooltip,
 } from 'chart.js';
 import { useAntennaStore } from '../../store/antennaStore';
 import { useMemo } from 'react';
 import type { GainPattern } from '../../physics/types';
 
-ChartJS.register(RadialLinearScale, ArcElement, Tooltip);
+ChartJS.register(RadialLinearScale, PointElement, LineElement, Filler, Tooltip);
 
 function cutAzimuth(p: GainPattern, thetaDeg: number): number[] {
   const ti = Math.max(0, Math.min(p.thetaSteps - 1, Math.round(thetaDeg / p.dTheta)));
@@ -23,13 +25,57 @@ function cutAzimuth(p: GainPattern, thetaDeg: number): number[] {
   return out;
 }
 
-function cutElevation(p: GainPattern, phiDeg: number): number[] {
-  const pi = Math.max(0, Math.min(p.phiSteps - 1, Math.round(phiDeg / p.dPhi)));
-  const out = new Array<number>(p.thetaSteps);
-  for (let ti = 0; ti < p.thetaSteps; ti++) {
-    out[ti] = p.data[ti * p.phiSteps + pi] ?? -60;
+function getAzimuthLabels(p: GainPattern): string[] {
+  const labels = new Array<string>(p.phiSteps).fill('');
+  for (let pi = 0; pi < p.phiSteps; pi++) {
+    const phiDeg = pi * p.dPhi;
+    // We only label primary cardinal points if they align with the phi step.
+    if (phiDeg === 0 || phiDeg === 360) labels[pi] = 'N';
+    else if (phiDeg === 45) labels[pi] = 'NE';
+    else if (phiDeg === 90) labels[pi] = 'E';
+    else if (phiDeg === 135) labels[pi] = 'SE';
+    else if (phiDeg === 180) labels[pi] = 'S';
+    else if (phiDeg === 225) labels[pi] = 'SW';
+    else if (phiDeg === 270) labels[pi] = 'W';
+    else if (phiDeg === 315) labels[pi] = 'NW';
   }
+  return labels;
+}
+
+function cutElevation(p: GainPattern, phiDeg: number): number[] {
+  // To create a full 360 degree elevation slice:
+  // Top (0 deg) is Zenith. Bottom (180 deg) is Nadir.
+  // Right side (0 to 180) maps to forward azimuth (phiDeg).
+  // Left side (360 down to 180) maps to backward azimuth (phiDeg + 180).
+  const numPoints = Math.round(360 / p.dTheta);
+  const out = new Array<number>(numPoints).fill(-60);
+
+  const forwardPi = Math.max(0, Math.min(p.phiSteps - 1, Math.round(phiDeg / p.dPhi)));
+  const backwardPhiDeg = (phiDeg + 180) % 360;
+  const backwardPi = Math.max(0, Math.min(p.phiSteps - 1, Math.round(backwardPhiDeg / p.dPhi)));
+
+  for (let ti = 0; ti < p.thetaSteps; ti++) {
+    out[ti] = p.data[ti * p.phiSteps + forwardPi] ?? -60;
+  }
+
+  for (let ti = 1; ti < p.thetaSteps - 1; ti++) {
+    const radarIdx = numPoints - ti;
+    out[radarIdx] = p.data[ti * p.phiSteps + backwardPi] ?? -60;
+  }
+
   return out;
+}
+
+function getElevationLabels(p: GainPattern): string[] {
+  const numPoints = Math.round(360 / p.dTheta);
+  const labels = new Array<string>(numPoints).fill('');
+  for (let i = 0; i < numPoints; i++) {
+    const deg = i * p.dTheta;
+    if (deg === 0) labels[i] = 'Zenith';
+    else if (deg === 90 || deg === 270) labels[i] = 'Horizon';
+    else if (deg === 180) labels[i] = 'Down';
+  }
+  return labels;
 }
 
 /** Shift dBi into a 0..range display scale so PolarArea has positive radii. */
@@ -63,11 +109,13 @@ export function PolarPlots() {
     plugins: { legend: { display: false }, tooltip: { enabled: true } },
     scales: {
       r: {
+        startAngle: 0, // 0 degrees at top
         suggestedMin: 0,
         suggestedMax: dbRange,
         ticks: { display: false },
-        grid: { color: 'rgba(128,128,128,0.2)' },
+        grid: { color: 'rgba(128,128,128,0.2)', circular: true },
         angleLines: { color: 'rgba(128,128,128,0.2)' },
+        pointLabels: { color: 'var(--text-muted)', font: { size: 10 } },
       },
     },
   } as const;
@@ -83,14 +131,17 @@ export function PolarPlots() {
             Azimuth @ {result.takeoffElevationDeg.toFixed(0)}° elev.
           </div>
           <div style={{ height: 160 }}>
-            <PolarArea
+            <Radar
               data={{
-                labels: azData.map((_, i) => `${i * result.pattern.dPhi}°`),
+                labels: getAzimuthLabels(result.pattern),
                 datasets: [{
                   data: azData,
                   backgroundColor: color,
                   borderColor: color,
                   borderWidth: 1,
+                  pointRadius: 0,
+                  pointHoverRadius: 4,
+                  fill: true,
                 }],
               }}
               options={commonOpts}
@@ -102,14 +153,17 @@ export function PolarPlots() {
             Elevation @ {result.takeoffAzimuthDeg.toFixed(0)}° az.
           </div>
           <div style={{ height: 160 }}>
-            <PolarArea
+            <Radar
               data={{
-                labels: elData.map((_, i) => `${i * result.pattern.dTheta}°`),
+                labels: getElevationLabels(result.pattern),
                 datasets: [{
                   data: elData,
                   backgroundColor: color,
                   borderColor: color,
                   borderWidth: 1,
+                  pointRadius: 0,
+                  pointHoverRadius: 4,
+                  fill: true,
                 }],
               }}
               options={commonOpts}

--- a/src/components/Charts/PolarPlots.tsx
+++ b/src/components/Charts/PolarPlots.tsx
@@ -88,29 +88,38 @@ export function PolarPlots() {
   const result = useAntennaStore((s) => s.result);
   const dbRange = useAntennaStore((s) => s.dbRange);
   const showPolarCuts = useAntennaStore((s) => s.showPolarCuts);
+  const orientation = useAntennaStore((s) => s.orientation);
 
   const azData = useMemo(() => {
     if (!result) return null;
-    // 15 degrees elevation corresponds to theta = 75 degrees (from zenith)
-    const cut = cutAzimuth(result.pattern, 90 - 15);
+    // Horizon is at 0 degrees elevation, which corresponds to theta = 90 degrees (from zenith)
+    const cut = cutAzimuth(result.pattern, 90);
     return normaliseForPolar(cut, result.maxGainDbi, dbRange);
   }, [result, dbRange]);
 
-  const elDataNS = useMemo(() => {
+  const { broadsideAz, endOnAz } = useMemo(() => {
+    switch (orientation) {
+      case 'NS': return { broadsideAz: 90, endOnAz: 0 };
+      case 'EW': return { broadsideAz: 0, endOnAz: 90 };
+      case 'NE-SW': return { broadsideAz: 135, endOnAz: 45 };
+      case 'NW-SE': return { broadsideAz: 45, endOnAz: 135 };
+      default: return { broadsideAz: 0, endOnAz: 90 };
+    }
+  }, [orientation]);
+
+  const elDataBroadside = useMemo(() => {
     if (!result) return null;
-    // N/S cut is at azimuth 0 degrees
-    const cut = cutElevation(result.pattern, 0);
+    const cut = cutElevation(result.pattern, broadsideAz);
     return normaliseForPolar(cut, result.maxGainDbi, dbRange);
-  }, [result, dbRange]);
+  }, [result, dbRange, broadsideAz]);
 
-  const elDataEW = useMemo(() => {
+  const elDataEndOn = useMemo(() => {
     if (!result) return null;
-    // E/W cut is at azimuth 90 degrees
-    const cut = cutElevation(result.pattern, 90);
+    const cut = cutElevation(result.pattern, endOnAz);
     return normaliseForPolar(cut, result.maxGainDbi, dbRange);
-  }, [result, dbRange]);
+  }, [result, dbRange, endOnAz]);
 
-  if (!showPolarCuts || !result || !azData || !elDataNS || !elDataEW) return null;
+  if (!showPolarCuts || !result || !azData || !elDataBroadside || !elDataEndOn) return null;
 
   const commonOpts = {
     responsive: true,
@@ -137,7 +146,7 @@ export function PolarPlots() {
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(130px, 1fr))', gap: 8 }}>
         <div style={{ minWidth: 0 }}>
           <div style={{ fontSize: 11, color: 'var(--text-muted)', textAlign: 'center' }}>
-            Azimuth @ 15° elev.
+            Azimuth @ Horizon (0°)
           </div>
           <div style={{ height: 160 }}>
             <Radar
@@ -159,14 +168,14 @@ export function PolarPlots() {
         </div>
         <div style={{ minWidth: 0 }}>
           <div style={{ fontSize: 11, color: 'var(--text-muted)', textAlign: 'center' }}>
-            Elevation (N/S cut)
+            Elevation (Broadside)
           </div>
           <div style={{ height: 160 }}>
             <Radar
               data={{
                 labels: getElevationLabels(result.pattern),
                 datasets: [{
-                  data: elDataNS,
+                  data: elDataBroadside,
                   backgroundColor: color,
                   borderColor: color,
                   borderWidth: 1,
@@ -181,14 +190,14 @@ export function PolarPlots() {
         </div>
         <div style={{ minWidth: 0 }}>
           <div style={{ fontSize: 11, color: 'var(--text-muted)', textAlign: 'center' }}>
-            Elevation (E/W cut)
+            Elevation (End-on)
           </div>
           <div style={{ height: 160 }}>
             <Radar
               data={{
                 labels: getElevationLabels(result.pattern),
                 datasets: [{
-                  data: elDataEW,
+                  data: elDataEndOn,
                   backgroundColor: color,
                   borderColor: color,
                   borderWidth: 1,

--- a/src/components/Charts/PolarPlots.tsx
+++ b/src/components/Charts/PolarPlots.tsx
@@ -91,17 +91,26 @@ export function PolarPlots() {
 
   const azData = useMemo(() => {
     if (!result) return null;
-    const cut = cutAzimuth(result.pattern, 90 - result.takeoffElevationDeg);
+    // 15 degrees elevation corresponds to theta = 75 degrees (from zenith)
+    const cut = cutAzimuth(result.pattern, 90 - 15);
     return normaliseForPolar(cut, result.maxGainDbi, dbRange);
   }, [result, dbRange]);
 
-  const elData = useMemo(() => {
+  const elDataNS = useMemo(() => {
     if (!result) return null;
-    const cut = cutElevation(result.pattern, result.takeoffAzimuthDeg);
+    // N/S cut is at azimuth 0 degrees
+    const cut = cutElevation(result.pattern, 0);
     return normaliseForPolar(cut, result.maxGainDbi, dbRange);
   }, [result, dbRange]);
 
-  if (!showPolarCuts || !result || !azData || !elData) return null;
+  const elDataEW = useMemo(() => {
+    if (!result) return null;
+    // E/W cut is at azimuth 90 degrees
+    const cut = cutElevation(result.pattern, 90);
+    return normaliseForPolar(cut, result.maxGainDbi, dbRange);
+  }, [result, dbRange]);
+
+  if (!showPolarCuts || !result || !azData || !elDataNS || !elDataEW) return null;
 
   const commonOpts = {
     responsive: true,
@@ -128,7 +137,7 @@ export function PolarPlots() {
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(130px, 1fr))', gap: 8 }}>
         <div style={{ minWidth: 0 }}>
           <div style={{ fontSize: 11, color: 'var(--text-muted)', textAlign: 'center' }}>
-            Azimuth @ {result.takeoffElevationDeg.toFixed(0)}° elev.
+            Azimuth @ 15° elev.
           </div>
           <div style={{ height: 160 }}>
             <Radar
@@ -150,14 +159,36 @@ export function PolarPlots() {
         </div>
         <div style={{ minWidth: 0 }}>
           <div style={{ fontSize: 11, color: 'var(--text-muted)', textAlign: 'center' }}>
-            Elevation @ {result.takeoffAzimuthDeg.toFixed(0)}° az.
+            Elevation (N/S cut)
           </div>
           <div style={{ height: 160 }}>
             <Radar
               data={{
                 labels: getElevationLabels(result.pattern),
                 datasets: [{
-                  data: elData,
+                  data: elDataNS,
+                  backgroundColor: color,
+                  borderColor: color,
+                  borderWidth: 1,
+                  pointRadius: 0,
+                  pointHoverRadius: 4,
+                  fill: true,
+                }],
+              }}
+              options={commonOpts}
+            />
+          </div>
+        </div>
+        <div style={{ minWidth: 0 }}>
+          <div style={{ fontSize: 11, color: 'var(--text-muted)', textAlign: 'center' }}>
+            Elevation (E/W cut)
+          </div>
+          <div style={{ height: 160 }}>
+            <Radar
+              data={{
+                labels: getElevationLabels(result.pattern),
+                datasets: [{
+                  data: elDataEW,
                   backgroundColor: color,
                   borderColor: color,
                   borderWidth: 1,

--- a/src/components/Charts/PolarPlots.tsx
+++ b/src/components/Charts/PolarPlots.tsx
@@ -84,11 +84,17 @@ function normaliseForPolar(values: number[], maxDb: number, rangeDb: number): nu
   return values.map((v) => Math.max(0, v - min));
 }
 
+function getCssVar(name: string): string {
+  if (typeof window === 'undefined') return '';
+  return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+}
+
 export function PolarPlots() {
   const result = useAntennaStore((s) => s.result);
   const dbRange = useAntennaStore((s) => s.dbRange);
   const showPolarCuts = useAntennaStore((s) => s.showPolarCuts);
   const orientation = useAntennaStore((s) => s.orientation);
+  const theme = useAntennaStore((s) => s.theme); // Subscribe to theme to re-evaluate colors on toggle
 
   const azData = useMemo(() => {
     if (!result) return null;
@@ -121,6 +127,9 @@ export function PolarPlots() {
 
   if (!showPolarCuts || !result || !azData || !elDataBroadside || !elDataEndOn) return null;
 
+  const chartText = theme === 'dark' ? getCssVar('--chart-text') || '#c6cdd6' : getCssVar('--chart-text') || '#3a4250';
+  const chartGrid = theme === 'dark' ? getCssVar('--chart-grid') || 'rgba(255, 255, 255, 0.08)' : getCssVar('--chart-grid') || 'rgba(0, 0, 0, 0.08)';
+
   const commonOpts = {
     responsive: true,
     maintainAspectRatio: false,
@@ -131,9 +140,9 @@ export function PolarPlots() {
         suggestedMin: 0,
         suggestedMax: dbRange,
         ticks: { display: false },
-        grid: { color: 'rgba(128,128,128,0.2)', circular: true },
-        angleLines: { color: 'rgba(128,128,128,0.2)' },
-        pointLabels: { color: 'var(--text-muted)', font: { size: 10 } },
+        grid: { color: chartGrid, circular: true },
+        angleLines: { color: chartGrid },
+        pointLabels: { color: chartText, font: { size: 10 } },
       },
     },
   } as const;
@@ -145,7 +154,7 @@ export function PolarPlots() {
       <h3>Polar cuts</h3>
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(130px, 1fr))', gap: 8 }}>
         <div style={{ minWidth: 0 }}>
-          <div style={{ fontSize: 11, color: 'var(--text-muted)', textAlign: 'center' }}>
+          <div style={{ fontSize: 11, color: 'var(--text-dim)', textAlign: 'center' }}>
             Azimuth @ Horizon (0°)
           </div>
           <div style={{ height: 160 }}>
@@ -167,7 +176,7 @@ export function PolarPlots() {
           </div>
         </div>
         <div style={{ minWidth: 0 }}>
-          <div style={{ fontSize: 11, color: 'var(--text-muted)', textAlign: 'center' }}>
+          <div style={{ fontSize: 11, color: 'var(--text-dim)', textAlign: 'center' }}>
             Elevation (Broadside)
           </div>
           <div style={{ height: 160 }}>
@@ -189,7 +198,7 @@ export function PolarPlots() {
           </div>
         </div>
         <div style={{ minWidth: 0 }}>
-          <div style={{ fontSize: 11, color: 'var(--text-muted)', textAlign: 'center' }}>
+          <div style={{ fontSize: 11, color: 'var(--text-dim)', textAlign: 'center' }}>
             Elevation (End-on)
           </div>
           <div style={{ height: 160 }}>


### PR DESCRIPTION
Resolves the issue of difficult-to-interpret polar cuts by switching the visualization to a standard continuous line format. Azimuth is plotted natively across 360 degrees, while Elevation incorporates forward/backward wrapping to create a true representation of the complete slice structure.

---
*PR created automatically by Jules for task [6588360244143626344](https://jules.google.com/task/6588360244143626344) started by @2fst4u*