### PR TITLE
feat: add 3D scene colormap legend

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,3 @@
-- add legend to rendering to understand the colours 
 - add balun calculations
 - add feedline calculations
 - add offset feed point calculations

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -91,7 +91,7 @@ function ScenePane({
   title: string;
   subtitle: string;
   children: ReactNode;
-  result: SimulationResult | null;
+  result: import('./physics/types').SimulationResult | null;
 }) {
   return (
     <div className="scene-pane">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { AntennaScene } from './components/Scene/AntennaScene';
 import { ControlPanel } from './components/Panel/ControlPanel';
 import { ErrorBoundary } from './components/UI/ErrorBoundary';
+import { ColormapLegend } from './components/Scene/ColormapLegend';
 import { useTheme } from './hooks/useTheme';
 import { useUnitsPersistence } from './hooks/useUnits';
 import { usePhysicsEngine } from './hooks/usePhysicsEngine';
@@ -18,6 +19,7 @@ export function App() {
   const loading = useAntennaStore((s) => s.loading);
   const engineReady = useAntennaStore((s) => s.engineReady);
   const comparisonReference = useAntennaStore((s) => s.comparisonReference);
+  const liveResult = useAntennaStore((s) => s.result);
 
   const showComparison = mode === 'comparison' && comparisonReference;
 
@@ -26,12 +28,12 @@ export function App() {
       <div className="app-viewport">
         {showComparison ? (
           <div className="scene-compare-grid">
-            <ScenePane title="Reference" subtitle="Frozen snapshot">
+            <ScenePane title="Reference" subtitle="Frozen snapshot" result={comparisonReference?.result ?? null}>
               <ErrorBoundary fallback={sceneFallback}>
                 <AntennaScene snapshot={comparisonReference} />
               </ErrorBoundary>
             </ScenePane>
-            <ScenePane title="Current" subtitle="Live controls">
+            <ScenePane title="Current" subtitle="Live controls" result={liveResult}>
               <ErrorBoundary fallback={sceneFallback}>
                 <AntennaScene />
               </ErrorBoundary>
@@ -53,7 +55,7 @@ export function App() {
             </ScenePane>
           </div>
         ) : (
-          <ScenePane title="Radiation Pattern" subtitle="Live view">
+          <ScenePane title="Radiation Pattern" subtitle="Live view" result={liveResult}>
             <ErrorBoundary fallback={sceneFallback}>
               <AntennaScene />
             </ErrorBoundary>
@@ -84,10 +86,12 @@ function ScenePane({
   title,
   subtitle,
   children,
+  result,
 }: {
   title: string;
   subtitle: string;
   children: ReactNode;
+  result: SimulationResult | null;
 }) {
   return (
     <div className="scene-pane">
@@ -95,6 +99,7 @@ function ScenePane({
         <div className="scene-pane-title">{title}</div>
         <div className="scene-pane-subtitle">{subtitle}</div>
       </div>
+      <ColormapLegend result={result} />
       {children}
     </div>
   );

--- a/src/components/Scene/ColormapLegend.tsx
+++ b/src/components/Scene/ColormapLegend.tsx
@@ -1,0 +1,32 @@
+import { useAntennaStore } from '../../store/antennaStore';
+import { getColormapCssGradient } from '../../utils/colormap';
+import type { SimulationResult } from '../../physics/types';
+
+interface Props {
+  readonly result: SimulationResult | null;
+}
+
+export function ColormapLegend({ result }: Props) {
+  const colormap = useAntennaStore((s) => s.colormap);
+  const dbRange = useAntennaStore((s) => s.dbRange);
+
+  if (!result) return null;
+
+  const maxDb = result.maxGainDbi;
+  const minDb = maxDb - dbRange;
+
+  const gradient = getColormapCssGradient(colormap);
+
+  return (
+    <div className="colormap-legend">
+      <div className="colormap-legend-labels">
+        <span>{maxDb.toFixed(1)} dBi</span>
+        <span>{minDb.toFixed(1)} dBi</span>
+      </div>
+      <div
+        className="colormap-legend-gradient"
+        style={{ background: gradient }}
+      />
+    </div>
+  );
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -306,3 +306,37 @@ label {
     grid-template-rows: repeat(2, minmax(220px, 1fr));
   }
 }
+
+/* Colormap Legend */
+.colormap-legend {
+  position: absolute;
+  bottom: 20px;
+  left: 20px;
+  z-index: 6;
+  display: flex;
+  align-items: stretch;
+  gap: 8px;
+  padding: 8px 10px;
+  background: color-mix(in srgb, var(--bg-raised) 88%, transparent);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  height: 120px;
+}
+
+.colormap-legend-labels {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  font-size: 11px;
+  color: var(--text-dim);
+  font-family: monospace;
+  text-align: right;
+  white-space: nowrap;
+}
+
+.colormap-legend-gradient {
+  width: 12px;
+  border-radius: 2px;
+  border: 1px solid rgba(0, 0, 0, 0.2);
+}

--- a/src/utils/colormap.ts
+++ b/src/utils/colormap.ts
@@ -104,3 +104,21 @@ export function sampleColormapFast(table: readonly RGB[], t: number, out: Float3
   out[offset + 1] = a[1] + (b[1] - a[1]) * w;
   out[offset + 2] = a[2] + (b[2] - a[2]) * w;
 }
+
+/**
+ * Converts a colormap table into a CSS linear gradient string.
+ * Used for rendering a legend gradient that matches the 3D scene colors.
+ */
+export function getColormapCssGradient(name: ColormapName): string {
+  const table = pickTable(name);
+  const stops = table.map((rgb, index) => {
+    const percentage = (index / (table.length - 1)) * 100;
+    const r = Math.round(rgb[0] * 255);
+    const g = Math.round(rgb[1] * 255);
+    const b = Math.round(rgb[2] * 255);
+    return `rgb(${r}, ${g}, ${b}) ${percentage.toFixed(2)}%`;
+  });
+  // Draw the gradient from bottom (0%) to top (100%) so that
+  // the highest value is at the top of the element.
+  return `linear-gradient(to top, ${stops.join(', ')})`;
+}


### PR DESCRIPTION
- Created `ColormapLegend.tsx` component to render the legend.
- Updated `ScenePane` in `App.tsx` to include the legend based on either the live or reference simulation result.
- Added `getColormapCssGradient` utility to correctly map WebGL color tables to CSS linear gradients.
- Added CSS styles for the `.colormap-legend` in `global.css`.
- Removed legend item from `TODO.md`.

---
*PR created automatically by Jules for task [2471497476600752769](https://jules.google.com/task/2471497476600752769) started by @2fst4u*