### PR TITLE
📚 Archivist: Fix package manager commands in README.md

### DIFF
--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -1,0 +1,3 @@
+## 2024-05-03 - Package Manager Drift
+**Learning:** The documentation originally instructed users to use `pnpm`, but the repository strictly uses `npm` (as evidenced by `package-lock.json`, `.npmrc` with `legacy-peer-deps=true`, and the GitHub Actions test workflow which runs `npm ci`). The `README.md` likely drifted from the actual toolchain over time or inherited an old template.
+**Action:** The `README.md` was updated to accurately reflect `npm` commands to prevent setup failures and confusion.

--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ Prerequisites:
 - Emscripten SDK (only required when rebuilding the Wasm binary)
 
 ```bash
-pnpm install
-pnpm run dev        # start Vite dev server
-pnpm test           # run unit + NEC-2 integration tests
-pnpm run build      # production build
+npm install
+npm run dev        # start Vite dev server
+npm test           # run unit + NEC-2 integration tests
+npm run build      # production build
 ```
 
 ## Rebuilding the NEC-2 WebAssembly binary
@@ -38,7 +38,7 @@ The compiled `public/nec2.js` / `public/nec2.wasm` are checked in so a `git clon
 
 ```bash
 source ~/emsdk/emsdk_env.sh
-pnpm run build:nec2
+npm run build:nec2
 ```
 
 Output goes to `public/nec2.{js,wasm}`.


### PR DESCRIPTION
💡 **Problem:** The `README.md` previously instructed users to use `pnpm` for installation and execution, but the repository clearly utilizes `npm` as its package manager (evidenced by `package-lock.json`, `.npmrc`, and GitHub Action workflows running `npm ci`).

🎯 **Fix:** Updated all instances of `pnpm` commands in the `README.md` to `npm` to perfectly match reality and ensure a smooth setup experience for users and contributors.

🧪 **Verification:**
- Verified `package.json`, `package-lock.json`, and `.npmrc`.
- Confirmed GitHub actions (`.github/workflows/test.yml`) run `npm ci`.
- Successfully ran `npm install`, `npm run lint`, and `npm test` locally with no errors or test failures.

🔎 **Scope:** This PR contains strictly documentation changes to the `README.md` and the creation of an archivist journal file to log the drift. No application behavior or logic has been modified.

---
*PR created automatically by Jules for task [2244299874880808010](https://jules.google.com/task/2244299874880808010) started by @2fst4u*