### PR TITLE
🔭 Scout: Add Open Graph and Twitter Card metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,20 @@
     <meta name="theme-color" content="#0c0f14" />
     <meta name="color-scheme" content="dark light" />
     <meta name="description" content="HF antenna gain visualiser — 3D radiation patterns powered by NEC-2 WebAssembly." />
+
+    <!-- Open Graph Metadata -->
+    <meta property="og:title" content="HF Gain Visualiser" />
+    <meta property="og:description" content="HF antenna gain visualiser — 3D radiation patterns powered by NEC-2 WebAssembly." />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://www.gain.observer/" />
+    <meta property="og:image" content="https://www.gain.observer/favicon.svg" />
+
+    <!-- Twitter Card Metadata -->
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="HF Gain Visualiser" />
+    <meta name="twitter:description" content="HF antenna gain visualiser — 3D radiation patterns powered by NEC-2 WebAssembly." />
+    <meta name="twitter:image" content="https://www.gain.observer/favicon.svg" />
+
     <title>HF Gain Visualiser</title>
   </head>
   <body>


### PR DESCRIPTION
* 💡 **What:** Added Open Graph (`og:*`) and Twitter Card (`twitter:*`) metadata tags to the `<head>` of `index.html`.
* 🎯 **Why:** `index.html` lacked essential social sharing and preview tags, which reduced its rich snippet visibility when links are shared on platforms like Twitter, Facebook, or iMessage.
* 📊 **Value:** Improves click-through rate and discoverability by providing rich image and description previews for social media sharing.
* 🔬 **Measurement:** Inspect the DOM in the `<head>` element to verify the presence of `property="og:*"` and `name="twitter:*"` tags.

---
*PR created automatically by Jules for task [12124034703692191560](https://jules.google.com/task/12124034703692191560) started by @2fst4u*