### PR TITLE
🛡️ Sentinel: [MEDIUM] Add CSP header to public/_headers

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -9,3 +9,5 @@
   Referrer-Policy: strict-origin-when-cross-origin
   # Opt-out of FLoC and restricts sensitive APIs, acting as a defense-in-depth measure
   Permissions-Policy: interest-cohort=()
+  # Content Security Policy to enforce secure content delivery and prevent XSS
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; worker-src 'self' blob:; object-src 'none';


### PR DESCRIPTION
Adds the CSP configuration to `public/_headers` so that it is served correctly in production on Cloudflare Pages.

---
*PR created automatically by Jules for task [8454197341156252360](https://jules.google.com/task/8454197341156252360) started by @2fst4u*