### PR TITLE
Fix text input snapping in control panels

### DIFF
--- a/src/components/Panel/DipoleControl.tsx
+++ b/src/components/Panel/DipoleControl.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import { useAntennaStore } from '../../store/antennaStore';
 import {
   toDisplayLength,
@@ -19,6 +20,15 @@ export function DipoleControl() {
   const unit = displayLengthUnit(units);
   const dispLen = toDisplayLength(length, units);
   const dispHeight = toDisplayLength(height, units);
+
+  const [localLen, setLocalLen] = useState(dispLen.toString());
+  const [isFocused, setIsFocused] = useState(false);
+
+  useEffect(() => {
+    if (!isFocused) {
+      setLocalLen(dispLen.toString());
+    }
+  }, [dispLen, isFocused]);
   const maxHeight = units === 'metric' ? 40 : 131;
 
   const orientations: Orientation[] = ['EW', 'NS', 'NE-SW', 'NW-SE'];
@@ -34,10 +44,19 @@ export function DipoleControl() {
           type="number"
           min={0.1}
           step={0.1}
-          value={dispLen.toFixed(2)}
+          value={localLen}
+          onFocus={() => setIsFocused(true)}
           onChange={(e) => {
-            const val = parseFloat(e.target.value);
-            if (!isNaN(val)) setLength(fromDisplayLength(val, units));
+            const s = e.target.value;
+            setLocalLen(s);
+            const val = parseFloat(s);
+            if (!isNaN(val)) {
+              setLength(fromDisplayLength(val, units));
+            }
+          }}
+          onBlur={() => {
+            setIsFocused(false);
+            setLocalLen(dispLen.toString());
           }}
         />
         <button

--- a/src/components/Panel/DipoleControl.tsx
+++ b/src/components/Panel/DipoleControl.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useAntennaStore } from '../../store/antennaStore';
 import {
   toDisplayLength,
@@ -21,14 +21,16 @@ export function DipoleControl() {
   const dispLen = toDisplayLength(length, units);
   const dispHeight = toDisplayLength(height, units);
 
-  const [localLen, setLocalLen] = useState(dispLen.toString());
+  const [localLen, setLocalLen] = useState(dispLen.toFixed(2));
   const [isFocused, setIsFocused] = useState(false);
 
-  useEffect(() => {
+  const [prevDispLen, setPrevDispLen] = useState(dispLen);
+  if (dispLen !== prevDispLen) {
+    setPrevDispLen(dispLen);
     if (!isFocused) {
-      setLocalLen(dispLen.toString());
+      setLocalLen(dispLen.toFixed(2));
     }
-  }, [dispLen, isFocused]);
+  }
   const maxHeight = units === 'metric' ? 40 : 131;
 
   const orientations: Orientation[] = ['EW', 'NS', 'NE-SW', 'NW-SE'];
@@ -56,7 +58,7 @@ export function DipoleControl() {
           }}
           onBlur={() => {
             setIsFocused(false);
-            setLocalLen(dispLen.toString());
+            setLocalLen(dispLen.toFixed(2));
           }}
         />
         <button

--- a/src/components/Panel/FeedlineControl.tsx
+++ b/src/components/Panel/FeedlineControl.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useAntennaStore } from '../../store/antennaStore';
 import {
   FEEDLINE_PRESETS,
@@ -30,14 +30,16 @@ export function FeedlineControl() {
   const dispLen = toDisplayLength(feedlineLength, units);
   const dispOffset = toDisplayLength(feedlineOffset, units);
 
-  const [localLen, setLocalLen] = useState(dispLen.toString());
+  const [localLen, setLocalLen] = useState(dispLen.toFixed(2));
   const [isFocused, setIsFocused] = useState(false);
 
-  useEffect(() => {
+  const [prevDispLen, setPrevDispLen] = useState(dispLen);
+  if (dispLen !== prevDispLen) {
+    setPrevDispLen(dispLen);
     if (!isFocused) {
-      setLocalLen(dispLen.toString());
+      setLocalLen(dispLen.toFixed(2));
     }
-  }, [dispLen, isFocused]);
+  }
   const offsetLimit = Math.max(0, dipoleLength / 2 - 0.05);
   const dispOffsetLimit = toDisplayLength(offsetLimit, units);
   const lossDb = enabled ? feedlineLossDb(preset, frequency, feedlineLength) : 0;
@@ -82,7 +84,7 @@ export function FeedlineControl() {
             }}
             onBlur={() => {
               setIsFocused(false);
-              setLocalLen(dispLen.toString());
+              setLocalLen(dispLen.toFixed(2));
             }}
           />
 

--- a/src/components/Panel/FeedlineControl.tsx
+++ b/src/components/Panel/FeedlineControl.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import { useAntennaStore } from '../../store/antennaStore';
 import {
   FEEDLINE_PRESETS,
@@ -28,6 +29,15 @@ export function FeedlineControl() {
   const unit = displayLengthUnit(units);
   const dispLen = toDisplayLength(feedlineLength, units);
   const dispOffset = toDisplayLength(feedlineOffset, units);
+
+  const [localLen, setLocalLen] = useState(dispLen.toString());
+  const [isFocused, setIsFocused] = useState(false);
+
+  useEffect(() => {
+    if (!isFocused) {
+      setLocalLen(dispLen.toString());
+    }
+  }, [dispLen, isFocused]);
   const offsetLimit = Math.max(0, dipoleLength / 2 - 0.05);
   const dispOffsetLimit = toDisplayLength(offsetLimit, units);
   const lossDb = enabled ? feedlineLossDb(preset, frequency, feedlineLength) : 0;
@@ -60,10 +70,19 @@ export function FeedlineControl() {
             min={0}
             max={units === 'metric' ? 200 : 656}
             step={units === 'metric' ? 0.5 : 1}
-            value={dispLen.toFixed(2)}
+            value={localLen}
+            onFocus={() => setIsFocused(true)}
             onChange={(e) => {
-              const val = parseFloat(e.target.value);
-              if (!isNaN(val)) setFeedlineLength(fromDisplayLength(val, units));
+              const s = e.target.value;
+              setLocalLen(s);
+              const val = parseFloat(s);
+              if (!isNaN(val)) {
+                setFeedlineLength(fromDisplayLength(val, units));
+              }
+            }}
+            onBlur={() => {
+              setIsFocused(false);
+              setLocalLen(dispLen.toString());
             }}
           />
 

--- a/src/components/Panel/FrequencyControl.tsx
+++ b/src/components/Panel/FrequencyControl.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import { useAntennaStore } from '../../store/antennaStore';
 import { HF_BAND_PRESETS, halfWaveLength } from '../../physics/constants';
 
@@ -5,6 +6,19 @@ export function FrequencyControl() {
   const frequency = useAntennaStore((s) => s.frequency);
   const setFrequency = useAntennaStore((s) => s.setFrequency);
   const setLength = useAntennaStore((s) => s.setLength);
+
+  // Use local string state to allow natural typing (trailing dots/zeros)
+  // without immediate snapping from the store's clamp logic.
+  const [localVal, setLocalVal] = useState(frequency.toString());
+  const [isFocused, setIsFocused] = useState(false);
+
+  // Sync local state when the store value changes (e.g. via preset buttons),
+  // but ONLY if the user isn't currently typing in the field.
+  useEffect(() => {
+    if (!isFocused) {
+      setLocalVal(frequency.toString());
+    }
+  }, [frequency, isFocused]);
 
   return (
     <div className="panel-section">
@@ -15,11 +29,21 @@ export function FrequencyControl() {
           min={1.8}
           max={30}
           step={0.01}
-          value={frequency}
+          value={localVal}
           aria-label="Frequency in MHz"
+          onFocus={() => setIsFocused(true)}
           onChange={(e) => {
-            const val = parseFloat(e.target.value);
-            if (!isNaN(val)) setFrequency(val);
+            const s = e.target.value;
+            setLocalVal(s);
+            const val = parseFloat(s);
+            if (!isNaN(val)) {
+              setFrequency(val);
+            }
+          }}
+          onBlur={() => {
+            setIsFocused(false);
+            // On blur, ensure the local value matches the (possibly clamped) store value.
+            setLocalVal(frequency.toString());
           }}
         />
       </div>

--- a/src/components/Panel/FrequencyControl.tsx
+++ b/src/components/Panel/FrequencyControl.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useAntennaStore } from '../../store/antennaStore';
 import { HF_BAND_PRESETS, halfWaveLength } from '../../physics/constants';
 
@@ -9,16 +9,18 @@ export function FrequencyControl() {
 
   // Use local string state to allow natural typing (trailing dots/zeros)
   // without immediate snapping from the store's clamp logic.
-  const [localVal, setLocalVal] = useState(frequency.toString());
+  const [localVal, setLocalVal] = useState(frequency.toFixed(3));
   const [isFocused, setIsFocused] = useState(false);
 
   // Sync local state when the store value changes (e.g. via preset buttons),
   // but ONLY if the user isn't currently typing in the field.
-  useEffect(() => {
+  const [prevFrequency, setPrevFrequency] = useState(frequency);
+  if (frequency !== prevFrequency) {
+    setPrevFrequency(frequency);
     if (!isFocused) {
-      setLocalVal(frequency.toString());
+      setLocalVal(frequency.toFixed(3));
     }
-  }, [frequency, isFocused]);
+  }
 
   return (
     <div className="panel-section">
@@ -43,7 +45,7 @@ export function FrequencyControl() {
           onBlur={() => {
             setIsFocused(false);
             // On blur, ensure the local value matches the (possibly clamped) store value.
-            setLocalVal(frequency.toString());
+            setLocalVal(frequency.toFixed(3));
           }}
         />
       </div>

--- a/src/components/Panel/GroundControl.tsx
+++ b/src/components/Panel/GroundControl.tsx
@@ -1,6 +1,6 @@
+import { useEffect, useState } from 'react';
 import { useAntennaStore } from '../../store/antennaStore';
 import { GROUND_PRESETS } from '../../physics/constants';
-import { useState } from 'react';
 
 export function GroundControl() {
   const groundId = useAntennaStore((s) => s.groundId);
@@ -9,6 +9,23 @@ export function GroundControl() {
   const setGround = useAntennaStore((s) => s.setGround);
   const setCustomGround = useAntennaStore((s) => s.setCustomGround);
   const [expanded, setExpanded] = useState(false);
+
+  const [localSigma, setLocalSigma] = useState(sigma.toString());
+  const [localEpsilon, setLocalEpsilon] = useState(epsilon.toString());
+  const [isSigmaFocused, setIsSigmaFocused] = useState(false);
+  const [isEpsilonFocused, setIsEpsilonFocused] = useState(false);
+
+  useEffect(() => {
+    if (!isSigmaFocused) {
+      setLocalSigma(sigma.toString());
+    }
+  }, [sigma, isSigmaFocused]);
+
+  useEffect(() => {
+    if (!isEpsilonFocused) {
+      setLocalEpsilon(epsilon.toString());
+    }
+  }, [epsilon, isEpsilonFocused]);
 
   return (
     <div className="panel-section">
@@ -40,10 +57,19 @@ export function GroundControl() {
             type="number"
             min={0}
             step={0.001}
-            value={sigma}
+            value={localSigma}
+            onFocus={() => setIsSigmaFocused(true)}
             onChange={(e) => {
-              const val = parseFloat(e.target.value);
-              if (!isNaN(val)) setCustomGround(val, epsilon);
+              const s = e.target.value;
+              setLocalSigma(s);
+              const val = parseFloat(s);
+              if (!isNaN(val)) {
+                setCustomGround(val, epsilon);
+              }
+            }}
+            onBlur={() => {
+              setIsSigmaFocused(false);
+              setLocalSigma(sigma.toString());
             }}
           />
           <label htmlFor="custom-ground-epsilon" style={{ marginTop: 6 }}>Permittivity εr</label>
@@ -52,10 +78,19 @@ export function GroundControl() {
             type="number"
             min={1}
             step={0.5}
-            value={epsilon}
+            value={localEpsilon}
+            onFocus={() => setIsEpsilonFocused(true)}
             onChange={(e) => {
-              const val = parseFloat(e.target.value);
-              if (!isNaN(val)) setCustomGround(sigma, val);
+              const s = e.target.value;
+              setLocalEpsilon(s);
+              const val = parseFloat(s);
+              if (!isNaN(val)) {
+                setCustomGround(sigma, val);
+              }
+            }}
+            onBlur={() => {
+              setIsEpsilonFocused(false);
+              setLocalEpsilon(epsilon.toString());
             }}
           />
         </>

--- a/src/components/Panel/GroundControl.tsx
+++ b/src/components/Panel/GroundControl.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useAntennaStore } from '../../store/antennaStore';
 import { GROUND_PRESETS } from '../../physics/constants';
 
@@ -15,17 +15,21 @@ export function GroundControl() {
   const [isSigmaFocused, setIsSigmaFocused] = useState(false);
   const [isEpsilonFocused, setIsEpsilonFocused] = useState(false);
 
-  useEffect(() => {
+  const [prevSigma, setPrevSigma] = useState(sigma);
+  if (sigma !== prevSigma) {
+    setPrevSigma(sigma);
     if (!isSigmaFocused) {
       setLocalSigma(sigma.toString());
     }
-  }, [sigma, isSigmaFocused]);
+  }
 
-  useEffect(() => {
+  const [prevEpsilon, setPrevEpsilon] = useState(epsilon);
+  if (epsilon !== prevEpsilon) {
+    setPrevEpsilon(epsilon);
     if (!isEpsilonFocused) {
       setLocalEpsilon(epsilon.toString());
     }
-  }, [epsilon, isEpsilonFocused]);
+  }
 
   return (
     <div className="panel-section">


### PR DESCRIPTION
Fixed an issue where typing into numeric text fields caused the value to "snap" to a formatted version immediately, disrupting the typing experience. Implemented a local state pattern with focus tracking for all affected inputs.

Fixes #71

---
*PR created automatically by Jules for task [16519563118734629577](https://jules.google.com/task/16519563118734629577) started by @2fst4u*