### PR TITLE
🎨 Palette: Add keyboard navigation focus indicators

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-03 - Always Append to Journals
 **Learning:** Found that when writing to journal files like `.jules/palette.md` using shell commands (e.g., `cat << 'EOF' > ...`), it is crucial to use the append operator (`>>`) instead of the overwrite operator (`>`). Overwriting destroys historical context and previous critical learnings.
 **Action:** Always verify the existence of a journal file and explicitly use the append redirection operator (`>>`) when adding new entries to preserve history.
+
+## 2024-05-04 - Keyboard Navigation Focus Indicators
+**Learning:** Found that keyboard navigation was lacking explicit visual feedback (`:focus-visible`) across the UI, particularly for interactive elements like buttons, inputs, and selects. Adding global `:focus-visible` styles with a high-contrast accent color greatly improves keyboard accessibility without negatively impacting mouse users.
+**Action:** Always verify keyboard accessibility and add clear `:focus-visible` styles to interactive elements when building out new UIs or auditing existing ones.

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -118,6 +118,14 @@ button:hover:not(:disabled) {
   border-color: var(--border-strong);
 }
 
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+a:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
 button.primary {
   background: var(--accent);
   color: white;


### PR DESCRIPTION
This PR improves keyboard navigation accessibility by adding a distinct focus ring to interactive elements (`button`, `input`, `select`, `a`). It uses the `:focus-visible` pseudo-class so that the ring only appears for keyboard users, ensuring a clean UI for mouse/touch users while meeting WCAG focus visibility guidelines.

---
*PR created automatically by Jules for task [7985970900107541476](https://jules.google.com/task/7985970900107541476) started by @2fst4u*