### PR TITLE
🧪 Spec: Add UnitToggle tests

### DIFF
--- a/.jules/spec.md
+++ b/.jules/spec.md
@@ -9,3 +9,7 @@
 ## 2025-02-12 - Fixing Unexpected any Types in StatsReadout
 **Learning:** React component test hooks using `@testing-library/react` and TypeScript need to ensure explicit type cast without using `as any` because strict linting rules (`@typescript-eslint/no-explicit-any`) will reject it, causing CI failures.
 **Action:** Cast mock results to their specific store interfaces such as `as unknown as import('../src/physics/types').SimulationResult` or `as unknown as import('../src/store/antennaStore').ComparisonSnapshot` rather than `as any`.
+## 2024-05-04 - UnitToggle.tsx coverage and vitest configuration
+**Learning:** Testing component behaviour interacting directly with Zustand state via `useAntennaStore.setState()` ensures we evaluate application effects rather than isolated mocks. Also, it might be necessary to reset state with `cleanup()` or `afterEach()` hooks when doing continuous updates to components to prevent pollution of consecutive tests.
+
+**Action:** Write test scenarios mapping closely user flows (like toggling an option off and verifying the opposite behaviour occurs and the classname reflects this correctly) instead of internal behaviour.

--- a/tests/UnitToggle.test.tsx
+++ b/tests/UnitToggle.test.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { UnitToggle } from '../src/components/Panel/UnitToggle';
+import { useAntennaStore } from '../src/store/antennaStore';
+
+describe('UnitToggle', () => {
+  beforeEach(() => {
+    useAntennaStore.setState({ units: 'metric' });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders with metric as active by default', () => {
+    render(<UnitToggle />);
+    const metricButton = screen.getByRole('button', { name: 'Meters' });
+    const imperialButton = screen.getByRole('button', { name: 'Feet' });
+
+    expect(metricButton.className).toContain('active');
+    expect(metricButton.getAttribute('aria-pressed')).toBe('true');
+
+    expect(imperialButton.className).not.toContain('active');
+    expect(imperialButton.getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('toggles to imperial when clicked', () => {
+    render(<UnitToggle />);
+    const imperialButton = screen.getByRole('button', { name: 'Feet' });
+
+    fireEvent.click(imperialButton);
+
+    expect(useAntennaStore.getState().units).toBe('imperial');
+  });
+
+  it('toggles back to metric when clicked', () => {
+    useAntennaStore.setState({ units: 'imperial' });
+    render(<UnitToggle />);
+    const metricButton = screen.getByRole('button', { name: 'Meters' });
+
+    fireEvent.click(metricButton);
+
+    expect(useAntennaStore.getState().units).toBe('metric');
+  });
+
+  it('reflects state changes', () => {
+    useAntennaStore.setState({ units: 'imperial' });
+    render(<UnitToggle />);
+    const metricButton = screen.getByRole('button', { name: 'Meters' });
+    const imperialButton = screen.getByRole('button', { name: 'Feet' });
+
+    expect(imperialButton.className).toContain('active');
+    expect(metricButton.className).not.toContain('active');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,10 +9,10 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       thresholds: {
-        statements: 47,
-        branches: 33,
-        functions: 52,
-        lines: 60,
+        statements: 49,
+        branches: 35,
+        functions: 54,
+        lines: 62,
       }
     }
   },


### PR DESCRIPTION
💡 What: Added a new unit test for the `UnitToggle` component to verify its interaction with the Zustand store and UI rendering. Cleaned up DOM state with `cleanup()` on tests tear down to prevent test pollution. Also updated `vitest.config.ts` with new global thresholds.
🎯 Why: `UnitToggle` represents a core piece of UI state interaction which wasn't fully tested, this improves codebase resilience and provides regression safety.
📈 Maturity Impact: Bumped coverage thresholds from 47% to 49% (statements), 33% to 35% (branches), 52% to 54% (functions), and 60% to 62% (lines) to lock in progress toward business standards.

---
*PR created automatically by Jules for task [11742832175842406095](https://jules.google.com/task/11742832175842406095) started by @2fst4u*