### PR TITLE
Add "Centre" button to feedpoint offset control

### DIFF
--- a/src/components/Panel/FeedlineControl.tsx
+++ b/src/components/Panel/FeedlineControl.tsx
@@ -91,18 +91,28 @@ export function FeedlineControl() {
           <label htmlFor="feedline-offset" style={{ marginTop: 10 }}>
             Attachment offset from centre ({unit}) — {dispOffset.toFixed(2)}
           </label>
-          <input
-            id="feedline-offset"
-            type="range"
-            min={-dispOffsetLimit}
-            max={dispOffsetLimit}
-            step={units === 'metric' ? 0.05 : 0.25}
-            value={dispOffset}
-            onChange={(e) => {
-              const val = parseFloat(e.target.value);
-              if (!isNaN(val)) setFeedlineOffset(fromDisplayLength(val, units));
-            }}
-          />
+          <div className="row">
+            <input
+              id="feedline-offset"
+              type="range"
+              min={-dispOffsetLimit}
+              max={dispOffsetLimit}
+              step={units === 'metric' ? 0.05 : 0.25}
+              value={dispOffset}
+              onChange={(e) => {
+                const val = parseFloat(e.target.value);
+                if (!isNaN(val)) setFeedlineOffset(fromDisplayLength(val, units));
+              }}
+            />
+            <button
+              onClick={() => setFeedlineOffset(0)}
+              title="Centre feedpoint"
+              aria-label="Centre feedpoint"
+              style={{ flex: '0 0 auto' }}
+            >
+              Centre
+            </button>
+          </div>
           <div style={{ marginTop: 4, fontSize: 11, color: 'var(--text-muted)' }}>
             {Math.abs(feedlineOffset) < 1e-6
               ? 'Centred (perfectly balanced — no common-mode current).'

--- a/tests/FeedlineControl.test.tsx
+++ b/tests/FeedlineControl.test.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { FeedlineControl } from '../src/components/Panel/FeedlineControl';
+import { useAntennaStore } from '../src/store/antennaStore';
+
+describe('FeedlineControl', () => {
+  beforeEach(() => {
+    useAntennaStore.setState({
+      units: 'metric',
+      feedlineId: 'rg58',
+      feedlineOffset: 1.0,
+      length: 20.0,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders the Centre button when feedline is enabled', () => {
+    render(<FeedlineControl />);
+    const centreButton = screen.getByRole('button', { name: 'Centre feedpoint' });
+    expect(centreButton).toBeDefined();
+    expect(centreButton.textContent).toBe('Centre');
+  });
+
+  it('resets feedline offset to 0 when Centre button is clicked', () => {
+    render(<FeedlineControl />);
+    const centreButton = screen.getByRole('button', { name: 'Centre feedpoint' });
+
+    fireEvent.click(centreButton);
+
+    expect(useAntennaStore.getState().feedlineOffset).toBe(0);
+  });
+
+  it('does not render feedline length and offset when cable is "none"', () => {
+    useAntennaStore.setState({ feedlineId: 'none' });
+    render(<FeedlineControl />);
+
+    expect(screen.queryByLabelText(/Length/)).toBeNull();
+    expect(screen.queryByLabelText(/Attachment offset/)).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Centre feedpoint' })).toBeNull();
+  });
+});


### PR DESCRIPTION
This PR adds a "Centre" button to the Feedline control panel, allowing users to quickly snap the feedpoint attachment offset back to 0 (geometric centre).

Changes:
- Modified `src/components/Panel/FeedlineControl.tsx` to include the button next to the offset slider.
- Added `tests/FeedlineControl.test.tsx` to ensure the button correctly updates the store and respects the enabled state of the feedline.
- Verified visual alignment and functionality via Playwright screenshots and video.

Fixes #76

---
*PR created automatically by Jules for task [5732006879119116103](https://jules.google.com/task/5732006879119116103) started by @2fst4u*