### PR TITLE
Allow numeric orientation input (degrees)

### DIFF
--- a/src/components/Charts/PolarPlots.tsx
+++ b/src/components/Charts/PolarPlots.tsx
@@ -105,13 +105,23 @@ export function PolarPlots() {
   }, [result, dbRange]);
 
   const { broadsideAz, endOnAz } = useMemo(() => {
-    switch (orientation) {
-      case 'NS': return { broadsideAz: 90, endOnAz: 0 };
-      case 'EW': return { broadsideAz: 0, endOnAz: 90 };
-      case 'NE-SW': return { broadsideAz: 135, endOnAz: 45 };
-      case 'NW-SE': return { broadsideAz: 45, endOnAz: 135 };
-      default: return { broadsideAz: 0, endOnAz: 90 };
+    let azimuth = 0;
+    if (typeof orientation === 'number') {
+      azimuth = orientation;
+    } else {
+      switch (orientation) {
+        case 'NS': azimuth = 0; break;
+        case 'EW': azimuth = 90; break;
+        case 'NE-SW': azimuth = 45; break;
+        case 'NW-SE': azimuth = 315; break;
+      }
     }
+    // "End-on" is along the wire axis (phi = azimuth).
+    // "Broadside" is perpendicular to the wire axis (azimuth + 90).
+    return {
+      endOnAz: azimuth % 360,
+      broadsideAz: (azimuth + 90) % 360,
+    };
   }, [orientation]);
 
   const elDataBroadside = useMemo(() => {

--- a/src/components/Panel/ComparisonControl.tsx
+++ b/src/components/Panel/ComparisonControl.tsx
@@ -50,7 +50,11 @@ export function ComparisonControl() {
           </div>
           <div className="stat">
             <span className="stat-label">Orientation</span>
-            <span className="stat-value">{reference.orientation}</span>
+            <span className="stat-value">
+              {typeof reference.orientation === 'number'
+                ? `${reference.orientation.toFixed(0)}°`
+                : reference.orientation}
+            </span>
           </div>
           <div className="stat">
             <span className="stat-label">Ground</span>

--- a/src/components/Panel/DipoleControl.tsx
+++ b/src/components/Panel/DipoleControl.tsx
@@ -5,7 +5,9 @@ import {
   fromDisplayLength,
   displayLengthUnit,
 } from '../../physics/units';
-import type { Orientation } from '../../store/antennaStore';
+import {
+  type OrientationPreset,
+} from '../../store/antennaStore';
 
 export function DipoleControl() {
   const units = useAntennaStore((s) => s.units);
@@ -31,9 +33,28 @@ export function DipoleControl() {
       setLocalLen(dispLen.toFixed(2));
     }
   }
-  const maxHeight = units === 'metric' ? 40 : 131;
 
-  const orientations: Orientation[] = ['EW', 'NS', 'NE-SW', 'NW-SE'];
+  const orientations: OrientationPreset[] = ['NS', 'EW', 'NE-SW', 'NW-SE'];
+  const PRESET_DEGREES: Record<OrientationPreset, number> = {
+    'NS': 0,
+    'EW': 90,
+    'NE-SW': 45,
+    'NW-SE': 315,
+  };
+
+  const currentDegrees = typeof orientation === 'number' ? orientation : PRESET_DEGREES[orientation];
+  const [localOrient, setLocalOrient] = useState(currentDegrees.toString());
+  const [isOrientFocused, setIsOrientFocused] = useState(false);
+
+  const [prevOrient, setPrevOrient] = useState(orientation);
+  if (orientation !== prevOrient) {
+    setPrevOrient(orientation);
+    if (!isOrientFocused) {
+      setLocalOrient(currentDegrees.toString());
+    }
+  }
+
+  const maxHeight = units === 'metric' ? 40 : 131;
 
   return (
     <div className="panel-section">
@@ -84,8 +105,32 @@ export function DipoleControl() {
         }}
       />
 
-      <label id="dipole-orientation" style={{ marginTop: 10 }}>Orientation</label>
-      <div className="button-group" role="group" aria-labelledby="dipole-orientation">
+      <label htmlFor="dipole-orientation" style={{ marginTop: 10 }}>Orientation (°)</label>
+      <div className="row">
+        <input
+          id="dipole-orientation"
+          type="number"
+          min={0}
+          max={359}
+          step={1}
+          value={localOrient}
+          onFocus={() => setIsOrientFocused(true)}
+          onChange={(e) => {
+            const s = e.target.value;
+            setLocalOrient(s);
+            const val = parseFloat(s);
+            if (!isNaN(val)) {
+              setOrientation(val);
+            }
+          }}
+          onBlur={() => {
+            setIsOrientFocused(false);
+            setLocalOrient(currentDegrees.toString());
+          }}
+        />
+      </div>
+
+      <div className="button-group" role="group" aria-label="Orientation presets">
         {orientations.map((o) => (
           <button
             key={o}

--- a/src/store/antennaStore.ts
+++ b/src/store/antennaStore.ts
@@ -30,7 +30,8 @@ import {
 } from '../physics/constants';
 import type { UnitSystem } from '../physics/units';
 
-export type Orientation = 'EW' | 'NS' | 'NE-SW' | 'NW-SE';
+export type OrientationPreset = 'EW' | 'NS' | 'NE-SW' | 'NW-SE';
+export type Orientation = OrientationPreset | number;
 export type Theme = 'dark' | 'light';
 export type Mode = 'normal' | 'nvis' | 'comparison';
 export type Colormap = 'viridis' | 'turbo' | 'jet';
@@ -201,7 +202,17 @@ export const useAntennaStore = create<AntennaState>()(
         if (!Number.isFinite(meters)) return;
         s.height = Math.max(0, meters);
       }),
-      setOrientation: (o) => set((s) => { s.orientation = o; }),
+      setOrientation: (o) => set((s) => {
+        if (typeof o === 'number') {
+          if (!Number.isFinite(o)) return;
+          // Normalize to [0, 360)
+          let normalized = o % 360;
+          if (normalized < 0) normalized += 360;
+          s.orientation = normalized;
+        } else {
+          s.orientation = o;
+        }
+      }),
       setWireRadius: (r) => set((s) => {
         if (!Number.isFinite(r)) return;
         s.wireRadius = Math.max(0.0001, r);
@@ -333,14 +344,29 @@ export const FEEDLINE_BRIDGE_LENGTH_M = 0.05;
  * plane, to avoid NEC's "wire touching ground" warning. */
 const FEEDLINE_GROUND_GAP_M = 0.1;
 
-/** Build a unit-vector along the chosen dipole orientation in the XY plane. */
+/**
+ * Build a unit-vector along the chosen dipole orientation in the XY plane.
+ *
+ * Convention: 0° is North (+Y / NS), 90° is East (+X / EW).
+ * Radio convention: 0 is North, clockwise increasing.
+ */
 function orientationVector(o: Orientation): [number, number] {
-  switch (o) {
-    case 'EW': return [1, 0];
-    case 'NS': return [0, 1];
-    case 'NE-SW': return [Math.SQRT1_2, Math.SQRT1_2];
-    case 'NW-SE': return [Math.SQRT1_2, -Math.SQRT1_2];
+  let deg = 0;
+  if (typeof o === 'number') {
+    deg = o;
+  } else {
+    switch (o) {
+      case 'NS': deg = 0; break;
+      case 'EW': deg = 90; break;
+      case 'NE-SW': deg = 45; break;
+      case 'NW-SE': deg = 315; break;
+    }
   }
+
+  // To map radio degrees (0=N, 90=E) to unit circle (0=E, 90=N):
+  // unit_angle = 90 - radio_angle
+  const rad = ((90 - deg) * Math.PI) / 180;
+  return [Math.cos(rad), Math.sin(rad)];
 }
 
 /**

--- a/tests/DipoleControl.test.tsx
+++ b/tests/DipoleControl.test.tsx
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { DipoleControl } from '../src/components/Panel/DipoleControl';
+import { useAntennaStore } from '../src/store/antennaStore';
+
+// Mock the store
+vi.mock('../src/store/antennaStore', async () => {
+  const actual = await vi.importActual('../src/store/antennaStore');
+  return {
+    ...actual,
+    useAntennaStore: vi.fn(),
+  };
+});
+
+interface MockState {
+  units: string;
+  length: number;
+  height: number;
+  orientation: string | number;
+  setLength: () => void;
+  setHalfWaveLength: () => void;
+  setHeight: () => void;
+  setOrientation: (o: string | number) => void;
+}
+
+describe('DipoleControl', () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('updates orientation when numeric input changes', () => {
+    const setOrientation = vi.fn();
+    vi.mocked(useAntennaStore).mockImplementation((selector: (s: MockState) => unknown) => {
+      const state: MockState = {
+        units: 'metric',
+        length: 20,
+        height: 10,
+        orientation: 'EW',
+        setLength: vi.fn(),
+        setHalfWaveLength: vi.fn(),
+        setHeight: vi.fn(),
+        setOrientation,
+      };
+      return selector(state);
+    });
+
+    render(<DipoleControl />);
+
+    const orientInput = document.getElementById('dipole-orientation') as HTMLInputElement;
+    fireEvent.change(orientInput, { target: { value: '45' } });
+
+    expect(setOrientation).toHaveBeenCalledWith(45);
+  });
+
+  it('updates orientation when preset buttons are clicked', () => {
+    const setOrientation = vi.fn();
+    vi.mocked(useAntennaStore).mockImplementation((selector: (s: MockState) => unknown) => {
+      const state: MockState = {
+        units: 'metric',
+        length: 20,
+        height: 10,
+        orientation: 'EW',
+        setLength: vi.fn(),
+        setHalfWaveLength: vi.fn(),
+        setHeight: vi.fn(),
+        setOrientation,
+      };
+      return selector(state);
+    });
+
+    render(<DipoleControl />);
+
+    const nsButton = screen.getByRole('button', { name: 'NS' });
+    fireEvent.click(nsButton);
+
+    expect(setOrientation).toHaveBeenCalledWith('NS');
+  });
+});

--- a/tests/antennaStore.test.ts
+++ b/tests/antennaStore.test.ts
@@ -22,8 +22,11 @@ describe('antennaStore selectors', () => {
 
       // Assert
       expect(wires).toHaveLength(1);
-      expect(wires[0].start).toEqual([-10, 0, 10]);
-      expect(wires[0].end).toEqual([10, 0, 10]);
+      // EW is 90 deg -> [1, 0]
+      expect(wires[0].start[0]).toBeCloseTo(-10, 5);
+      expect(wires[0].start[1]).toBeCloseTo(0, 5);
+      expect(wires[0].end[0]).toBeCloseTo(10, 5);
+      expect(wires[0].end[1]).toBeCloseTo(0, 5);
       expect(wires[0].radius).toBe(0.001);
       expect(wires[0].segments).toBe(21);
     });
@@ -41,8 +44,34 @@ describe('antennaStore selectors', () => {
       };
       const wires = buildWires(state);
       expect(wires).toHaveLength(1);
-      expect(wires[0].start).toEqual([0, -10, 15]);
-      expect(wires[0].end).toEqual([0, 10, 15]);
+      // NS is 0 deg -> [0, 1]
+      expect(wires[0].start[0]).toBeCloseTo(0, 5);
+      expect(wires[0].start[1]).toBeCloseTo(-10, 5);
+      expect(wires[0].end[0]).toBeCloseTo(0, 5);
+      expect(wires[0].end[1]).toBeCloseTo(10, 5);
+    });
+
+    it('generates correct wire coordinates for numeric orientation (45 deg)', () => {
+      const state = {
+        length: 10,
+        height: 5,
+        orientation: 45,
+        wireRadius: 0.001,
+        segments: 11,
+        feedlineId: 'none',
+        feedlineLength: 0,
+        feedlineOffset: 0,
+      };
+      const wires = buildWires(state);
+      expect(wires).toHaveLength(1);
+      const half = 5;
+      // 45 deg radio -> unit circle 45 deg [cos45, sin45]
+      const cos45 = Math.SQRT1_2;
+      const sin45 = Math.SQRT1_2;
+      expect(wires[0].start[0]).toBeCloseTo(-half * cos45, 5);
+      expect(wires[0].start[1]).toBeCloseTo(-half * sin45, 5);
+      expect(wires[0].end[0]).toBeCloseTo(half * cos45, 5);
+      expect(wires[0].end[1]).toBeCloseTo(half * sin45, 5);
     });
 
     it('builds split-dipole + bridge + shield when feedline is configured', () => {
@@ -272,6 +301,19 @@ describe('antennaStore selectors', () => {
 });
 
 describe('antennaStore actions', () => {
+  it('updates orientation and normalizes correctly', () => {
+    const store = useAntennaStore.getState();
+
+    store.setOrientation(370);
+    expect(useAntennaStore.getState().orientation).toBe(10);
+
+    store.setOrientation(-10);
+    expect(useAntennaStore.getState().orientation).toBe(350);
+
+    store.setOrientation('NS');
+    expect(useAntennaStore.getState().orientation).toBe('NS');
+  });
+
   it('updates frequency and clamps correctly', () => {
     // Arrange
     const store = useAntennaStore.getState();


### PR DESCRIPTION
This PR adds support for entering the antenna orientation as a numeric value in degrees (0-359), while maintaining the existing 'NS', 'EW', etc. preset buttons.

Key changes:
- **Store**: `orientation` state now accepts `OrientationPreset | number`. The `orientationVector` selector has been updated to follow the standard radio azimuth convention (0° is North, 90° is East). All inputs (presets and numbers) now correctly return unit vectors to ensure antenna length remains consistent.
- **UI**: A new numeric input field is added to the `DipoleControl` panel. It uses a local buffer to ensure a smooth typing experience, similar to the frequency and length inputs.
- **Charts**: `PolarPlots` now dynamically calculates the 'End-on' and 'Broadside' cuts based on the current numeric orientation.
- **Comparison**: The comparison summary now displays numeric orientations with a degree symbol.

Verification:
- Added unit tests in `tests/antennaStore.test.ts` for numeric orientation and vector calculation.
- Added a new component test `tests/DipoleControl.test.tsx` for the UI interaction.
- Verified visual correctness and interactivity via a Playwright script and screenshot.

Fixes #77

---
*PR created automatically by Jules for task [4136597553613011270](https://jules.google.com/task/4136597553613011270) started by @2fst4u*