### PR TITLE
feat: add T-index propagation estimator with radar plot

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,4 @@
 - add terminating resistor calculations
 - add different antenna designs, namely delta loop, terminated delta loop (and inverted) sloping V, inverted V, terminated V, and other common designs
 - add gain value annotations to renders and indicate optimal take off angle
-- add T index input or programatic pull, and estimate optimal physical range of a signal for the given frequency
+- ~~add T index input or programatic pull, and estimate optimal physical range of a signal for the given frequency~~ (done — manual T-index input + radar plot of estimated 1/2/3-hop range)

--- a/src/components/Charts/PropagationRadar.tsx
+++ b/src/components/Charts/PropagationRadar.tsx
@@ -1,0 +1,217 @@
+// Top-down "radar" plot of estimated propagation range.
+//
+// The antenna sits at the centre and three concentric rings show the
+// great-circle ground range covered by 1, 2, and 3 sky-wave hops at the
+// current take-off angle. Ring colour reflects open / marginal / closed
+// status from src/physics/propagation.ts.
+//
+// We deliberately use raw SVG (no Chart.js radar plugin) because:
+//   - the chart is genuinely circular concentric rings, which is awkward
+//     to express with Chart.js polar-area scales;
+//   - SVG is easy to make theme-responsive (CSS variables work directly);
+//   - it keeps the bundle small.
+
+import type { PropagationPrediction } from '../../physics/propagation';
+import type { UnitSystem } from '../../physics/units';
+
+interface PropagationRadarProps {
+  readonly prediction: PropagationPrediction;
+  readonly units: UnitSystem;
+  /** Antenna take-off azimuth in degrees (0 = +x = East in the scene
+   *  convention). Used to draw a directional indicator. */
+  readonly azimuthDeg?: number;
+  /** Pixel size (square). */
+  readonly size?: number;
+}
+
+const KM_PER_MILE = 1.609344;
+
+function formatDistance(km: number, units: UnitSystem): string {
+  if (units === 'imperial') {
+    const mi = km / KM_PER_MILE;
+    return `${mi.toFixed(0)} mi`;
+  }
+  return `${km.toFixed(0)} km`;
+}
+
+function statusFill(status: 'open' | 'marginal' | 'closed'): string {
+  // Use semantic CSS variables already defined in theme.css so the rings
+  // pick up theme overrides without hard-coding hex values here.
+  if (status === 'open') return 'var(--success)';
+  if (status === 'marginal') return 'var(--warning)';
+  return 'var(--danger)';
+}
+
+export function PropagationRadar({
+  prediction,
+  units,
+  azimuthDeg,
+  size = 280,
+}: PropagationRadarProps) {
+  const cx = size / 2;
+  const cy = size / 2;
+  // Leave a margin for axis labels.
+  const margin = 24;
+  const maxRangeKm = prediction.hops[prediction.hops.length - 1]?.rangeKm ?? 1;
+  const maxRadiusPx = (size / 2) - margin;
+  const kmToPx = maxRadiusPx / Math.max(1, maxRangeKm);
+
+  // Compass cardinal label positions.
+  const cardinals = [
+    { label: 'N', x: cx, y: margin - 6, anchor: 'middle' as const },
+    { label: 'S', x: cx, y: size - margin + 14, anchor: 'middle' as const },
+    { label: 'E', x: size - margin + 8, y: cy + 4, anchor: 'start' as const },
+    { label: 'W', x: margin - 8, y: cy + 4, anchor: 'end' as const },
+  ];
+
+  // Convert hop ranges to pixel radii.
+  const rings = prediction.hops.map((h) => ({
+    n: h.n,
+    rangeKm: h.rangeKm,
+    rPx: h.rangeKm * kmToPx,
+    status: h.status,
+  }));
+
+  // Optional pointer toward the take-off azimuth. Scene convention: 0° = +x
+  // (East). Compass north (top of the radar) is +y in screen coords. We map
+  // azimuth → angle measured clockwise from north (the conventional compass
+  // sense). Pre-rotate by -90° so 0° azimuth points east on the radar.
+  let pointer: { x: number; y: number } | null = null;
+  if (typeof azimuthDeg === 'number' && Number.isFinite(azimuthDeg)) {
+    const az = ((azimuthDeg % 360) + 360) % 360;
+    // Scene: 0=E, 90=N, 180=W, 270=S. Compass: 0=N, 90=E, 180=S, 270=W.
+    // Convert scene azimuth to screen-space angle (clockwise from north):
+    //   compassDeg = (90 - sceneAz) mod 360
+    const compass = ((90 - az) + 360) % 360;
+    const rad = compass * Math.PI / 180;
+    const r = maxRadiusPx;
+    pointer = {
+      x: cx + r * Math.sin(rad),
+      y: cy - r * Math.cos(rad),
+    };
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 8 }}>
+      <svg
+        width={size}
+        height={size}
+        role="img"
+        aria-label="Propagation range radar plot"
+        style={{ display: 'block', maxWidth: '100%' }}
+      >
+        {/* Background disc */}
+        <circle cx={cx} cy={cy} r={maxRadiusPx} fill="var(--bg-raised)" stroke="var(--border)" />
+
+        {/* Faint inner gridlines at 25/50/75% of max range */}
+        {[0.25, 0.5, 0.75].map((f) => (
+          <circle
+            key={f}
+            cx={cx}
+            cy={cy}
+            r={maxRadiusPx * f}
+            fill="none"
+            stroke="var(--border)"
+            strokeDasharray="2 3"
+            opacity={0.5}
+          />
+        ))}
+
+        {/* Cross-hair axes */}
+        <line x1={cx} y1={margin} x2={cx} y2={size - margin} stroke="var(--border)" opacity={0.5} />
+        <line x1={margin} y1={cy} x2={size - margin} y2={cy} stroke="var(--border)" opacity={0.5} />
+
+        {/* Hop rings: stroked from outermost to innermost so labels stay readable */}
+        {rings.slice().reverse().map((ring) => (
+          <circle
+            key={ring.n}
+            cx={cx}
+            cy={cy}
+            r={ring.rPx}
+            fill={statusFill(ring.status)}
+            fillOpacity={ring.status === 'open' ? 0.16 : ring.status === 'marginal' ? 0.16 : 0.12}
+            stroke={statusFill(ring.status)}
+            strokeOpacity={0.85}
+            strokeWidth={2}
+          />
+        ))}
+
+        {/* Direction-of-peak pointer */}
+        {pointer && (
+          <g>
+            <line
+              x1={cx}
+              y1={cy}
+              x2={pointer.x}
+              y2={pointer.y}
+              stroke="var(--accent)"
+              strokeWidth={2}
+              strokeDasharray="4 3"
+            />
+            <circle cx={pointer.x} cy={pointer.y} r={4} fill="var(--accent)" />
+          </g>
+        )}
+
+        {/* Centre dot = antenna location */}
+        <circle cx={cx} cy={cy} r={4} fill="var(--accent)" />
+
+        {/* Cardinal direction labels */}
+        {cardinals.map((c) => (
+          <text
+            key={c.label}
+            x={c.x}
+            y={c.y}
+            textAnchor={c.anchor}
+            fontSize={11}
+            fill="var(--text-muted)"
+            fontFamily="system-ui, sans-serif"
+          >
+            {c.label}
+          </text>
+        ))}
+
+        {/* Range label on each hop ring (placed along the +x axis to stay
+            clear of the direction pointer when present) */}
+        {rings.map((ring) => (
+          <text
+            key={ring.n}
+            x={cx + ring.rPx + 4}
+            y={cy - 4}
+            fontSize={10}
+            fill="var(--text-dim)"
+            fontFamily="system-ui, sans-serif"
+            textAnchor="start"
+          >
+            {`${ring.n}× ${formatDistance(ring.rangeKm, units)}`}
+          </text>
+        ))}
+      </svg>
+
+      {/* Inline legend */}
+      <div style={{ display: 'flex', gap: 12, fontSize: 11, color: 'var(--text-muted)' }}>
+        <LegendSwatch color="var(--success)" label="Open" />
+        <LegendSwatch color="var(--warning)" label="Marginal" />
+        <LegendSwatch color="var(--danger)" label="Closed" />
+      </div>
+    </div>
+  );
+}
+
+function LegendSwatch({ color, label }: { color: string; label: string }) {
+  return (
+    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+      <span
+        aria-hidden="true"
+        style={{
+          display: 'inline-block',
+          width: 10,
+          height: 10,
+          borderRadius: '50%',
+          background: color,
+          opacity: 0.85,
+        }}
+      />
+      {label}
+    </span>
+  );
+}

--- a/src/components/Panel/ControlPanel.tsx
+++ b/src/components/Panel/ControlPanel.tsx
@@ -4,6 +4,7 @@ import { GroundControl } from './GroundControl';
 import { FeedlineControl } from './FeedlineControl';
 import { ModeSelector } from './ModeSelector';
 import { StatsReadout } from './StatsReadout';
+import { PropagationControl } from './PropagationControl';
 import { DisplayControl } from './DisplayControl';
 import { SWRChart } from '../Charts/SWRChart';
 import { PolarPlots } from '../Charts/PolarPlots';
@@ -41,6 +42,7 @@ export function ControlPanel() {
       <GroundControl />
       <FeedlineControl />
       <StatsReadout />
+      <PropagationControl />
       <SWRChart />
       <PolarPlots />
       <DisplayControl />

--- a/src/components/Panel/PropagationControl.tsx
+++ b/src/components/Panel/PropagationControl.tsx
@@ -1,0 +1,295 @@
+// HF propagation panel — manual T-index entry plus a top-down radar plot
+// of estimated 1/2/3-hop range. Entirely client-side; no network calls.
+
+import { useMemo, useState } from 'react';
+import { useAntennaStore } from '../../store/antennaStore';
+import { useGeolocation } from '../../hooks/useGeolocation';
+import { predictPropagation } from '../../physics/propagation';
+import { PropagationRadar } from '../Charts/PropagationRadar';
+
+const MONTH_NAMES = [
+  'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+  'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+];
+
+export function PropagationControl() {
+  const frequency = useAntennaStore((s) => s.frequency);
+  const tIndex = useAntennaStore((s) => s.tIndex);
+  const setTIndex = useAntennaStore((s) => s.setTIndex);
+  const latitudeDeg = useAntennaStore((s) => s.latitudeDeg);
+  const longitudeDeg = useAntennaStore((s) => s.longitudeDeg);
+  const setLatitude = useAntennaStore((s) => s.setLatitude);
+  const monthOverride = useAntennaStore((s) => s.monthOverride);
+  const utcHourOverride = useAntennaStore((s) => s.utcHourOverride);
+  const setMonthOverride = useAntennaStore((s) => s.setMonthOverride);
+  const setUtcHourOverride = useAntennaStore((s) => s.setUtcHourOverride);
+  const result = useAntennaStore((s) => s.result);
+  const units = useAntennaStore((s) => s.units);
+
+  const { status: geoStatus, requestLocation } = useGeolocation();
+
+  const [showAssumptions, setShowAssumptions] = useState(false);
+  const [showTimeOverride, setShowTimeOverride] = useState(false);
+
+  // Resolve "now" once per render. We deliberately don't memoise on a
+  // ticking clock — propagation conditions change on the order of minutes,
+  // so the panel just refreshes on the next render trigger (e.g. user
+  // input). Adding a 60s ticker is easy if needed later.
+  const now = new Date();
+  const month = monthOverride ?? (now.getUTCMonth() + 1);
+  const utcHour = utcHourOverride ?? (now.getUTCHours() + now.getUTCMinutes() / 60);
+
+  const takeoffElevationDeg = result?.takeoffElevationDeg ?? 30;
+  const takeoffAzimuthDeg = result?.takeoffAzimuthDeg;
+
+  const prediction = useMemo(() => {
+    return predictPropagation({
+      frequencyMHz: frequency,
+      tIndex,
+      takeoffElevationDeg,
+      month,
+      utcHour,
+      latitudeDeg: latitudeDeg ?? 0,
+      longitudeDeg: longitudeDeg ?? 0,
+    });
+  }, [frequency, tIndex, takeoffElevationDeg, month, utcHour, latitudeDeg, longitudeDeg]);
+
+  const haveTakeoff = result !== null;
+
+  return (
+    <div className="panel-section">
+      <h3>
+        Propagation
+        <span className="badge">T = {tIndex.toFixed(0)}</span>
+      </h3>
+
+      {/* T-index input */}
+      <label htmlFor="t-index-input">T-index</label>
+      <div className="row">
+        <input
+          id="t-index-input"
+          type="number"
+          min={-100}
+          max={250}
+          step={1}
+          value={tIndex}
+          aria-label="Ionospheric T-index"
+          onChange={(e) => {
+            const v = parseFloat(e.target.value);
+            if (!isNaN(v)) setTIndex(v);
+          }}
+        />
+      </div>
+      <p style={{ fontSize: 11, color: 'var(--text-muted)', margin: '4px 0 10px' }}>
+        Australian IPS T-index. ~30 = quiet, ~100 = active. Look up today&apos;s
+        value from your usual space-weather source.
+      </p>
+
+      {/* Latitude + geolocation */}
+      <label htmlFor="lat-input">Latitude</label>
+      <div className="row" style={{ alignItems: 'center' }}>
+        <input
+          id="lat-input"
+          type="number"
+          min={-90}
+          max={90}
+          step={0.1}
+          value={latitudeDeg ?? ''}
+          placeholder="0.0"
+          aria-label="Latitude in degrees"
+          onChange={(e) => {
+            const v = parseFloat(e.target.value);
+            setLatitude(isNaN(v) ? null : v);
+          }}
+        />
+        <button
+          type="button"
+          onClick={() => { void requestLocation(); }}
+          disabled={geoStatus === 'requesting'}
+          style={{ flex: '0 0 auto' }}
+          title="Use the browser geolocation API to populate latitude. Asks for permission only when clicked."
+        >
+          {geoStatus === 'requesting' ? 'Locating…' : 'Use my location'}
+        </button>
+      </div>
+      <p style={{ fontSize: 11, color: 'var(--text-muted)', margin: '4px 0 10px' }}>
+        {geoStatusMessage(geoStatus, latitudeDeg)}
+      </p>
+
+      {/* Time / month — auto-filled from browser clock unless overridden */}
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline' }}>
+        <span style={{ fontSize: 11, color: 'var(--text-muted)' }}>
+          {monthOverride === null && utcHourOverride === null
+            ? `Auto: ${MONTH_NAMES[month - 1]}, ${formatUtcHour(utcHour)} UTC`
+            : `Override: ${MONTH_NAMES[month - 1]}, ${formatUtcHour(utcHour)} UTC`}
+        </span>
+        <button
+          type="button"
+          onClick={() => setShowTimeOverride((v) => !v)}
+          style={{
+            background: 'transparent', border: 'none', color: 'var(--accent)',
+            padding: 0, fontSize: 11, cursor: 'pointer',
+          }}
+        >
+          {showTimeOverride ? 'Hide time override' : 'Override time'}
+        </button>
+      </div>
+      {showTimeOverride && (
+        <div className="row" style={{ marginTop: 6, gap: 6 }}>
+          <select
+            value={monthOverride ?? ''}
+            onChange={(e) => {
+              const v = e.target.value;
+              setMonthOverride(v === '' ? null : parseInt(v, 10));
+            }}
+            aria-label="Month override"
+          >
+            <option value="">Auto month</option>
+            {MONTH_NAMES.map((n, i) => (
+              <option key={n} value={i + 1}>{n}</option>
+            ))}
+          </select>
+          <input
+            type="number"
+            min={0}
+            max={23.99}
+            step={0.5}
+            placeholder="UTC hour"
+            value={utcHourOverride ?? ''}
+            aria-label="UTC hour override"
+            onChange={(e) => {
+              const v = parseFloat(e.target.value);
+              setUtcHourOverride(isNaN(v) ? null : v);
+            }}
+          />
+        </div>
+      )}
+
+      {/* Conditions readout */}
+      <hr style={{ border: 0, borderTop: '1px solid var(--border)', margin: '12px 0 8px' }} />
+      <div className="stat">
+        <span className="stat-label">foF2</span>
+        <span className="stat-value">{prediction.foF2MHz.toFixed(2)} MHz</span>
+      </div>
+      <div className="stat">
+        <span className="stat-label">hmF2</span>
+        <span className="stat-value">{prediction.hmF2Km.toFixed(0)} km</span>
+      </div>
+      <div className="stat">
+        <span className="stat-label">MUF (this take-off)</span>
+        <span className="stat-value">{prediction.mufMHz.toFixed(2)} MHz</span>
+      </div>
+      <div className="stat" title="Lower usable frequency: D-layer absorption estimate. Least reliable part of the model — see assumptions.">
+        <span className="stat-label">
+          LUF <span style={{ color: 'var(--warning)', cursor: 'help' }} aria-label="LUF is the least reliable part of the model">ⓘ</span>
+        </span>
+        <span className="stat-value">{prediction.lufMHz.toFixed(2)} MHz</span>
+      </div>
+
+      {/* Radar plot */}
+      <hr style={{ border: 0, borderTop: '1px solid var(--border)', margin: '12px 0 8px' }} />
+      {haveTakeoff ? (
+        <PropagationRadar
+          prediction={prediction}
+          units={units}
+          azimuthDeg={takeoffAzimuthDeg}
+        />
+      ) : (
+        <div style={{ fontSize: 12, color: 'var(--text-muted)', textAlign: 'center', padding: '8px 0' }}>
+          Computing antenna pattern…
+        </div>
+      )}
+
+      {/* Per-hop status text (machine-readable for screen readers and a
+          quick textual summary alongside the radar) */}
+      <div style={{ marginTop: 10 }}>
+        {prediction.hops.map((h) => (
+          <div key={h.n} className="stat">
+            <span className="stat-label">{h.n}× hop</span>
+            <span
+              className="stat-value"
+              style={{ color: hopColor(h.status) }}
+              title={h.reason}
+            >
+              {formatRange(h.rangeKm, units)} · {h.status}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      {/* Assumptions disclosure */}
+      <button
+        type="button"
+        onClick={() => setShowAssumptions((v) => !v)}
+        style={{
+          marginTop: 10, background: 'transparent', border: 'none',
+          color: 'var(--accent)', padding: 0, fontSize: 11, cursor: 'pointer',
+        }}
+      >
+        {showAssumptions ? 'Hide model assumptions' : 'Model & assumptions'}
+      </button>
+      {showAssumptions && (
+        <div style={{ fontSize: 11, color: 'var(--text-muted)', marginTop: 6, lineHeight: 1.5 }}>
+          <p style={{ marginTop: 0 }}>
+            This is a closed-form approximation, not IRI / ASAPS / VOACAP.
+            It captures the right monotonic behaviours (foF2 rises with
+            T-index, MUF rises with shallower take-off) but is not a
+            propagation-prediction product.
+          </p>
+          <ul style={{ paddingLeft: 18, margin: '6px 0' }}>
+            <li>foF2 from T-index, solar zenith angle, latitude (no URSI/CCIR maps).</li>
+            <li>hmF2 from a simple day/night sinusoid centred on canonical values.</li>
+            <li>MUF: secant law with curved-Earth correction.</li>
+            <li>
+              <strong>LUF: heuristic from D-layer absorption.</strong> Treat with caution
+              — least reliable part of the model, especially near sunrise/sunset.
+            </li>
+            <li>User latitude is taken as the path-midpoint latitude (fine for short hops).</li>
+            <li>No sporadic-E, auroral, or polar effects.</li>
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function formatRange(km: number, units: 'metric' | 'imperial'): string {
+  if (units === 'imperial') {
+    return `${(km / 1.609344).toFixed(0)} mi`;
+  }
+  return `${km.toFixed(0)} km`;
+}
+
+function hopColor(status: 'open' | 'marginal' | 'closed'): string {
+  if (status === 'open') return 'var(--success)';
+  if (status === 'marginal') return 'var(--warning)';
+  return 'var(--danger)';
+}
+
+function formatUtcHour(h: number): string {
+  const hours = Math.floor(h);
+  const minutes = Math.round((h - hours) * 60);
+  return `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`;
+}
+
+function geoStatusMessage(
+  status: ReturnType<typeof useAntennaStore.getState>['geolocationStatus'],
+  latitudeDeg: number | null,
+): string {
+  switch (status) {
+    case 'idle':
+      return latitudeDeg === null
+        ? 'Defaults to 0° (equator) until set. Type a value or click "Use my location".'
+        : `Manual entry. Click "Use my location" to replace from the browser.`;
+    case 'requesting':
+      return 'Asking the browser for your location…';
+    case 'granted':
+      return 'Location obtained from the browser. You can still edit it manually.';
+    case 'denied':
+      return 'Permission denied. Using the value above; edit it manually if you wish.';
+    case 'unsupported':
+      return 'Browser geolocation is unavailable. Enter latitude manually.';
+    case 'error':
+      return 'Could not obtain location. Enter latitude manually.';
+  }
+}

--- a/src/hooks/useGeolocation.ts
+++ b/src/hooks/useGeolocation.ts
@@ -1,0 +1,72 @@
+// Opt-in geolocation helper.
+//
+// IMPORTANT: this hook NEVER calls navigator.geolocation on its own. The
+// browser's geolocation prompt only appears when the consumer invokes
+// requestLocation(). This is by design — gain.observer should not ask
+// for location at page load.
+//
+// The hook stores its lifecycle status in the antenna store
+// (geolocationStatus) so other components (e.g. the propagation panel)
+// can react to it without mounting this hook.
+
+import { useCallback } from 'react';
+import { useAntennaStore } from '../store/antennaStore';
+
+export interface GeolocationResult {
+  ok: boolean;
+  latitudeDeg?: number;
+  longitudeDeg?: number;
+  /** A short reason ('denied', 'unsupported', 'timeout', 'error') when ok=false. */
+  reason?: string;
+}
+
+export function useGeolocation(): {
+  status: ReturnType<typeof useAntennaStore.getState>['geolocationStatus'];
+  requestLocation: () => Promise<GeolocationResult>;
+} {
+  const status = useAntennaStore((s) => s.geolocationStatus);
+  const setStatus = useAntennaStore((s) => s.setGeolocationStatus);
+  const setLatitude = useAntennaStore((s) => s.setLatitude);
+  const setLongitude = useAntennaStore((s) => s.setLongitude);
+
+  const requestLocation = useCallback(async (): Promise<GeolocationResult> => {
+    if (typeof navigator === 'undefined' || !navigator.geolocation) {
+      setStatus('unsupported');
+      return { ok: false, reason: 'unsupported' };
+    }
+    setStatus('requesting');
+    return new Promise<GeolocationResult>((resolve) => {
+      navigator.geolocation.getCurrentPosition(
+        (pos) => {
+          const { latitude, longitude } = pos.coords;
+          setLatitude(latitude);
+          setLongitude(longitude);
+          setStatus('granted');
+          resolve({ ok: true, latitudeDeg: latitude, longitudeDeg: longitude });
+        },
+        (err) => {
+          // 1 = PERMISSION_DENIED, 2 = POSITION_UNAVAILABLE, 3 = TIMEOUT
+          if (err.code === 1) {
+            setStatus('denied');
+            resolve({ ok: false, reason: 'denied' });
+          } else if (err.code === 3) {
+            setStatus('error');
+            resolve({ ok: false, reason: 'timeout' });
+          } else {
+            setStatus('error');
+            resolve({ ok: false, reason: 'error' });
+          }
+        },
+        {
+          // We don't need GPS-grade precision for HF propagation maths.
+          // Cached fixes up to 10 minutes old are fine.
+          enableHighAccuracy: false,
+          maximumAge: 10 * 60 * 1000,
+          timeout: 10_000,
+        },
+      );
+    });
+  }, [setLatitude, setLongitude, setStatus]);
+
+  return { status, requestLocation };
+}

--- a/src/physics/propagation.ts
+++ b/src/physics/propagation.ts
@@ -1,0 +1,391 @@
+// HF sky-wave propagation estimator.
+//
+// Inputs the user supplies:
+//   • T-index   — the Australian IPS / BOM ionospheric T-index (dimensionless,
+//                 conventionally ranges roughly -50 (very disturbed) to +200
+//                 (very active solar conditions); ~30 ≈ quiet, ~100 ≈ active).
+//   • frequency — operating frequency, MHz (already in the antenna store).
+//   • take-off  — elevation angle of the antenna's main lobe (already
+//                 produced by the NEC-2 worker as result.takeoffElevationDeg).
+//   • month     — 1..12, typically auto-filled from the browser clock.
+//   • UTC hour  — 0..24, typically auto-filled from the browser clock.
+//   • latitude  — geographic latitude, degrees (-90..+90). We use it in place
+//                 of geomagnetic latitude — accurate enough for the fidelity
+//                 of this model and avoids shipping an IGRF table.
+//
+// Outputs:
+//   • foF2      — F2-layer critical frequency, MHz.
+//   • hmF2      — F2-layer virtual reflection height, km.
+//   • MUF       — maximum usable frequency for the user's take-off geometry.
+//   • LUF       — lower usable frequency (heuristic; see caveats).
+//   • hops[1..3]— ground range and open/marginal/closed status per hop.
+//
+// MODEL CAVEATS (deliberately surfaced in the UI):
+//
+//   This module is NOT IRI, ASAPS, or VOACAP. It is a published-style
+//   closed-form approximation that captures the right monotonic behaviours
+//   (foF2 rises with T-index, MUF rises with shallower take-off, range
+//   grows with hop count) and is good enough to drive intuition for an
+//   antenna visualiser. It is NOT a propagation-prediction product.
+//
+//   Specifically:
+//     - foF2 is approximated from T-index, solar zenith angle, and latitude
+//       using the form long-established in HF prediction literature (e.g.
+//       ITU-R Recommendation P.533 family of methods, simplified). It does
+//       not consult URSI/CCIR coefficient maps.
+//     - hmF2 follows a simple diurnal sinusoid centred on canonical
+//       day/night values (~280 km / ~340 km).
+//     - MUF uses the secant law with a curved-Earth correction.
+//     - LUF is a D-layer absorption heuristic from solar zenith angle and
+//       T-index. The LUF model is the least reliable part of this module.
+//     - The user's latitude is taken to be the path-midpoint latitude.
+//       Fine for short hops; less so for transcontinental paths.
+//     - No sporadic-E, auroral, polar, or path-asymmetry effects.
+//
+// References (for the curious — none of these is a verbatim implementation):
+//   • ITU-R Recommendation P.533: "Method for the prediction of the
+//     performance of HF circuits" — for the secant-law MUF and the general
+//     foF2/hmF2 framework.
+//   • IPS Radio & Space Services (Australia): definition of T-index.
+//   • Davies, K. (1990), Ionospheric Radio: zenith-angle absorption model.
+
+/**
+ * Inputs to a hop prediction.
+ */
+export interface PropagationInputs {
+  /** Operating frequency, MHz. */
+  readonly frequencyMHz: number;
+  /** T-index (dimensionless). Typical range -50..+200. */
+  readonly tIndex: number;
+  /** Antenna take-off elevation, degrees (0=horizon, 90=zenith). */
+  readonly takeoffElevationDeg: number;
+  /** Month, 1..12. */
+  readonly month: number;
+  /** UTC hour, 0..24 (fractional allowed). */
+  readonly utcHour: number;
+  /** Path-midpoint latitude, degrees (-90..+90). */
+  readonly latitudeDeg: number;
+  /** Path-midpoint longitude, degrees (-180..+180). Optional; defaults to 0
+   *  (Greenwich) if omitted, which collapses local-noon to UTC noon. */
+  readonly longitudeDeg?: number;
+}
+
+export type HopStatus = 'open' | 'marginal' | 'closed';
+
+export interface HopPrediction {
+  /** Hop number, 1-based. */
+  readonly n: number;
+  /** Ground range from antenna to receiver after this many hops, km. */
+  readonly rangeKm: number;
+  readonly status: HopStatus;
+  /** Human-readable reason ('f > MUF', 'f < LUF', 'within MUF margin', …). */
+  readonly reason: string;
+}
+
+export interface PropagationPrediction {
+  readonly foF2MHz: number;
+  readonly hmF2Km: number;
+  readonly mufMHz: number;
+  readonly lufMHz: number;
+  readonly hops: readonly HopPrediction[];
+  /** Solar zenith angle at path midpoint, degrees (0=overhead, 90=horizon, >90=below horizon). */
+  readonly solarZenithDeg: number;
+}
+
+/** Earth's mean radius, km. */
+const EARTH_RADIUS_KM = 6371;
+
+/** Maximum hops we model. */
+const MAX_HOPS = 3;
+
+/** "Marginal" margin around MUF/LUF as a fraction (10%). */
+const MARGIN_FRAC = 0.10;
+
+const DEG = Math.PI / 180;
+
+// ---------------------------------------------------------------------------
+// Solar geometry
+// ---------------------------------------------------------------------------
+
+/**
+ * Solar declination, degrees, for the given month.
+ *
+ * We approximate using a sinusoid peaking on June 21 (declination ≈ +23.44°)
+ * and bottoming on December 21 (≈ −23.44°), evaluated at mid-month for a
+ * stable monthly estimate. Good to ~1° which is more than fine here.
+ */
+export function solarDeclinationDeg(month: number): number {
+  const m = clamp(month, 1, 12);
+  // Day-of-year of the middle of the given month (not leap-aware; fine).
+  const midDoy: Record<number, number> = {
+    1: 15, 2: 46, 3: 75, 4: 105, 5: 135, 6: 162,
+    7: 196, 8: 227, 9: 258, 10: 288, 11: 318, 12: 349,
+  };
+  const doy = midDoy[Math.round(m) as keyof typeof midDoy] ?? 80;
+  // Standard approximation: -23.44 cos((doy + 10) * 360/365).
+  const arg = ((doy + 10) / 365) * 2 * Math.PI;
+  return -23.44 * Math.cos(arg);
+}
+
+/**
+ * Solar zenith angle at the given location and UTC time, degrees.
+ * 0 = sun directly overhead, 90 = on the horizon, >90 = below the horizon.
+ *
+ * Uses the standard cosχ = sinφ·sinδ + cosφ·cosδ·cosH formula, where H is
+ * the local hour angle. Longitude 0 (default) gives Greenwich-local time.
+ */
+export function solarZenithDeg(
+  latitudeDeg: number,
+  longitudeDeg: number,
+  month: number,
+  utcHour: number,
+): number {
+  const lat = clamp(latitudeDeg, -90, 90) * DEG;
+  const dec = solarDeclinationDeg(month) * DEG;
+  // Local solar time hour ≈ utcHour + longitude/15. Hour angle = (LST - 12) * 15°.
+  const lst = utcHour + longitudeDeg / 15;
+  const H = (((lst - 12) % 24) + 24) % 24;
+  const Hwrapped = H > 12 ? H - 24 : H; // -12..+12
+  const Hrad = Hwrapped * 15 * DEG;
+  const cosChi = Math.sin(lat) * Math.sin(dec) +
+                 Math.cos(lat) * Math.cos(dec) * Math.cos(Hrad);
+  return Math.acos(clamp(cosChi, -1, 1)) / DEG;
+}
+
+// ---------------------------------------------------------------------------
+// Ionospheric layer estimates
+// ---------------------------------------------------------------------------
+
+/**
+ * Estimate F2-layer critical frequency (foF2), MHz.
+ *
+ * Form: foF2 = base(zenith) * tIndexFactor(T) * latitudeFactor(lat)
+ *
+ *   base(zenith) — diurnal cosine; ~10 MHz at local noon, dropping to a
+ *   night-time floor of ~3 MHz when the sun is well below the horizon.
+ *
+ *   tIndexFactor(T) — IPS T-index is normalised so that T=0 corresponds to
+ *   approximately the long-term ionospheric median; positive values raise
+ *   foF2, negative values depress it. We use a smooth scaling that covers
+ *   the practical range:
+ *     T =  -50 → factor ≈ 0.55 (badly disturbed; foF2 floor)
+ *     T =    0 → factor ≈ 1.00 (median)
+ *     T =  100 → factor ≈ 1.55
+ *     T =  200 → factor ≈ 1.90 (very active conditions)
+ *
+ *   latitudeFactor(lat) — equatorial enhancement and polar depression.
+ *   ~1.10 at the geomagnetic equator, ~0.85 at high latitudes.
+ *
+ * Returns at least 1.5 MHz so downstream MUF math stays sane.
+ */
+export function estimateFoF2MHz(
+  tIndex: number,
+  month: number,
+  utcHour: number,
+  latitudeDeg: number,
+  longitudeDeg = 0,
+): number {
+  const chi = solarZenithDeg(latitudeDeg, longitudeDeg, month, utcHour);
+  const cosChi = Math.cos(chi * DEG);
+  // Diurnal base: smoothly transition between night (~3 MHz) and day (~10 MHz).
+  // Use a soft step at the horizon: factor goes 0..1 over chi ∈ [108°..0°]
+  // (108° includes astronomical twilight).
+  const dayFraction = clamp((108 - chi) / 108, 0, 1);
+  const noonGain = Math.max(0, cosChi); // additional bump near local noon
+  const base = 3.0 + dayFraction * 5.5 + noonGain * 1.5; // MHz
+
+  // T-index scaling: smooth, monotonic, asymptotic.
+  const t = clamp(tIndex, -100, 250);
+  const tFactor = 1 + 0.6 * Math.tanh(t / 100);
+
+  // Latitude factor: equatorial bump, polar dip.
+  const absLat = Math.abs(clamp(latitudeDeg, -90, 90));
+  const latFactor = 1.10 - 0.30 * (absLat / 90);
+
+  const fof2 = base * tFactor * latFactor;
+  return Math.max(1.5, fof2);
+}
+
+/**
+ * Estimate the F2 virtual reflection height (hmF2), km.
+ *
+ * Day F2 sits a bit lower (~280 km), night F2 rises (~340 km). We add a
+ * weak T-index dependence (active conditions push hmF2 up slightly) and a
+ * mild diurnal sinusoid driven by solar zenith angle.
+ */
+export function estimateHmF2Km(
+  tIndex: number,
+  month: number,
+  utcHour: number,
+  latitudeDeg: number,
+  longitudeDeg = 0,
+): number {
+  const chi = solarZenithDeg(latitudeDeg, longitudeDeg, month, utcHour);
+  // dayFraction = 1 at noon, 0 at deep night.
+  const dayFraction = clamp((108 - chi) / 108, 0, 1);
+  const day = 285;
+  const night = 340;
+  const base = night + (day - night) * dayFraction;
+  const tBump = clamp(tIndex, -100, 250) * 0.05; // ≈ ±5 km over the typical range
+  return clamp(base + tBump, 220, 420);
+}
+
+// ---------------------------------------------------------------------------
+// Hop geometry (curved-Earth)
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the great-circle ground range (km) covered by a single hop given
+ * the take-off elevation angle and the F2 reflection height.
+ *
+ * Geometry: triangle (Earth centre, antenna, virtual reflection point).
+ *   • antenna at radius R_e, take-off elevation ε above local horizon
+ *   • reflection point at radius R_e + h
+ *   • by sine rule the central angle 2·θ subtended at Earth's centre gives
+ *     the hop ground range = R_e · 2·θ
+ *
+ * We compute θ via the law of sines:
+ *   sin(angle at reflection point) / R_e = sin(90°+ε) / (R_e + h)
+ *   → sin(γ) = R_e · cos(ε) / (R_e + h)
+ *   → θ = π - (π/2 + ε) - γ  (interior angle sum)
+ * Range = R_e · 2θ for one hop landed and re-departed at the same elevation.
+ */
+export function hopRangeKm(takeoffElevationDeg: number, hmF2Km: number): number {
+  const eps = clamp(takeoffElevationDeg, 0.5, 89.5) * DEG;
+  const Re = EARTH_RADIUS_KM;
+  const h = clamp(hmF2Km, 50, 1000);
+  // Half-hop central angle θ (antenna → reflection point only).
+  const sinGamma = (Re * Math.cos(eps)) / (Re + h);
+  const gamma = Math.asin(clamp(sinGamma, -1, 1));
+  const theta = Math.PI - (Math.PI / 2 + eps) - gamma;
+  // Full hop = 2θ on the ground.
+  return Re * 2 * theta;
+}
+
+/**
+ * Maximum usable frequency for a single hop, MHz.
+ *
+ * Secant law with curved-Earth correction:
+ *   MUF = foF2 · sec(φ_i)
+ * where φ_i is the angle of incidence at the reflection point.
+ *
+ * For a flat earth, φ_i = 90° − ε (take-off elevation). Curved earth makes
+ * φ_i larger for a given ε because the path arrives at the layer more
+ * obliquely; we account for that in the geometry below.
+ */
+export function estimateMUFMHz(
+  foF2MHz: number,
+  takeoffElevationDeg: number,
+  hmF2Km: number,
+): number {
+  const eps = clamp(takeoffElevationDeg, 0.5, 89.5) * DEG;
+  const Re = EARTH_RADIUS_KM;
+  const h = clamp(hmF2Km, 50, 1000);
+  // Angle of incidence at the layer: from triangle geometry.
+  const sinGamma = (Re * Math.cos(eps)) / (Re + h);
+  const phi_i = Math.PI / 2 - Math.asin(clamp(sinGamma, -1, 1));
+  // sec(φ_i) clamped — at vertical incidence MUF = foF2.
+  const sec = 1 / Math.max(0.05, Math.cos(phi_i));
+  return foF2MHz * sec;
+}
+
+/**
+ * Estimate the lower usable frequency (LUF), MHz.
+ *
+ * D-layer absorption is the dominant loss below the MUF. It is strongly
+ * driven by solar zenith angle (peaks at local noon) and modulated by
+ * solar activity (T-index).
+ *
+ * This is a HEURISTIC — surface this to the user.
+ *
+ *   LUF ≈ LUF_floor + amplitude · max(0, cosχ) · (1 + 0.5·tanh(T/100))
+ *
+ *   LUF_floor       — night-time floor (~1.8 MHz, top of the LF/MF band).
+ *   amplitude       — peak day-time absorption (~5 MHz at quiet sun).
+ */
+export function estimateLUFMHz(
+  tIndex: number,
+  month: number,
+  utcHour: number,
+  latitudeDeg: number,
+  longitudeDeg = 0,
+): number {
+  const chi = solarZenithDeg(latitudeDeg, longitudeDeg, month, utcHour);
+  const cosChi = Math.cos(chi * DEG);
+  const day = Math.max(0, cosChi);
+  const tFactor = 1 + 0.5 * Math.tanh(clamp(tIndex, -100, 250) / 100);
+  const luf = 1.8 + 5.0 * day * tFactor;
+  return clamp(luf, 1.0, 12.0);
+}
+
+// ---------------------------------------------------------------------------
+// Top-level prediction
+// ---------------------------------------------------------------------------
+
+/**
+ * Predict the per-hop range and open/closed status for the given inputs.
+ * Returns rangeKm for hops 1, 2, 3 and a status reflecting the user's
+ * frequency vs the hop's MUF and the LUF.
+ */
+export function predictPropagation(input: PropagationInputs): PropagationPrediction {
+  const lon = input.longitudeDeg ?? 0;
+  const fof2 = estimateFoF2MHz(input.tIndex, input.month, input.utcHour, input.latitudeDeg, lon);
+  const hmF2 = estimateHmF2Km(input.tIndex, input.month, input.utcHour, input.latitudeDeg, lon);
+  const muf = estimateMUFMHz(fof2, input.takeoffElevationDeg, hmF2);
+  const luf = estimateLUFMHz(input.tIndex, input.month, input.utcHour, input.latitudeDeg, lon);
+  const chi = solarZenithDeg(input.latitudeDeg, lon, input.month, input.utcHour);
+
+  const oneHop = hopRangeKm(input.takeoffElevationDeg, hmF2);
+
+  const f = input.frequencyMHz;
+  const aboveMuf = f > muf;
+  const belowLuf = f < luf;
+  const closeToMuf = !aboveMuf && f > muf * (1 - MARGIN_FRAC);
+  const closeToLuf = !belowLuf && f < luf * (1 + MARGIN_FRAC);
+
+  let status: HopStatus;
+  let reason: string;
+  if (aboveMuf) {
+    status = 'closed';
+    reason = `f (${f.toFixed(2)} MHz) > MUF (${muf.toFixed(2)} MHz)`;
+  } else if (belowLuf) {
+    status = 'closed';
+    reason = `f (${f.toFixed(2)} MHz) < LUF (${luf.toFixed(2)} MHz)`;
+  } else if (closeToMuf) {
+    status = 'marginal';
+    reason = `within ${(MARGIN_FRAC * 100).toFixed(0)}% of MUF`;
+  } else if (closeToLuf) {
+    status = 'marginal';
+    reason = `within ${(MARGIN_FRAC * 100).toFixed(0)}% of LUF`;
+  } else {
+    status = 'open';
+    reason = 'between LUF and MUF';
+  }
+
+  // Each subsequent hop adds the same single-hop ground range. The status
+  // logic above is path-shape independent (it only depends on the user's
+  // operating frequency vs MUF/LUF for the take-off geometry), so all
+  // hops share the same status. Range scales linearly with hop count.
+  const hops: HopPrediction[] = [];
+  for (let n = 1; n <= MAX_HOPS; n++) {
+    hops.push({ n, rangeKm: oneHop * n, status, reason });
+  }
+
+  return {
+    foF2MHz: fof2,
+    hmF2Km: hmF2,
+    mufMHz: muf,
+    lufMHz: luf,
+    solarZenithDeg: chi,
+    hops,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function clamp(v: number, min: number, max: number): number {
+  if (!Number.isFinite(v)) return min;
+  return Math.max(min, Math.min(max, v));
+}

--- a/src/store/antennaStore.ts
+++ b/src/store/antennaStore.ts
@@ -96,6 +96,25 @@ export interface AntennaState {
   showAxes: boolean;
   showPolarCuts: boolean;
 
+  // Propagation (HF sky-wave estimator inputs).
+  //
+  // tIndex is the Australian IPS / BOM ionospheric T-index (dimensionless,
+  // typically -50..+200). It is entered manually — the app does not
+  // currently fetch it from any service.
+  //
+  // latitudeDeg is the path-midpoint latitude. Defaults to null (we treat
+  // null as 0° for predictions but the UI shows it as "not set"). The
+  // browser geolocation API may populate it on user request.
+  //
+  // monthOverride / utcHourOverride let the user explore conditions at a
+  // different time. When null, the UI auto-fills from the browser clock.
+  tIndex: number;
+  latitudeDeg: number | null;
+  longitudeDeg: number | null;
+  monthOverride: number | null;
+  utcHourOverride: number | null;
+  geolocationStatus: 'idle' | 'requesting' | 'granted' | 'denied' | 'unsupported' | 'error';
+
   // Solver output
   result: SimulationResult | null;
   sweep: SweepPoint[];
@@ -131,6 +150,14 @@ export interface AntennaState {
   setShowPolarCuts(v: boolean): void;
   captureComparisonReference(): void;
   clearComparisonReference(): void;
+
+  // Propagation actions
+  setTIndex(v: number): void;
+  setLatitude(deg: number | null): void;
+  setLongitude(deg: number | null): void;
+  setMonthOverride(month: number | null): void;
+  setUtcHourOverride(hour: number | null): void;
+  setGeolocationStatus(s: AntennaState['geolocationStatus']): void;
 
   // Actions — internal (used by hooks/workers only, prefixed with _)
   _setSimulationData(r: SimulationResult, sweep: readonly SweepPoint[]): void;
@@ -171,6 +198,15 @@ export const useAntennaStore = create<AntennaState>()(
       showGrid: true,
       showAxes: true,
       showPolarCuts: true,
+
+      // Propagation defaults: T=30 (~quiet sun, plausible long-term median),
+      // no location until user requests it, no time override.
+      tIndex: 30,
+      latitudeDeg: null,
+      longitudeDeg: null,
+      monthOverride: null,
+      utcHourOverride: null,
+      geolocationStatus: 'idle',
 
       result: null,
       sweep: [],
@@ -257,6 +293,38 @@ export const useAntennaStore = create<AntennaState>()(
         s.comparisonReference = createComparisonSnapshot(s);
       }),
       clearComparisonReference: () => set((s) => { s.comparisonReference = null; }),
+
+      setTIndex: (v) => set((s) => {
+        if (!Number.isFinite(v)) return;
+        // Clamp to the practical range. Anything outside this is unphysical.
+        s.tIndex = Math.max(-100, Math.min(250, v));
+      }),
+      setLatitude: (deg) => set((s) => {
+        if (deg === null) { s.latitudeDeg = null; return; }
+        if (!Number.isFinite(deg)) return;
+        s.latitudeDeg = Math.max(-90, Math.min(90, deg));
+      }),
+      setLongitude: (deg) => set((s) => {
+        if (deg === null) { s.longitudeDeg = null; return; }
+        if (!Number.isFinite(deg)) return;
+        // Wrap into -180..+180.
+        let v = deg;
+        while (v > 180) v -= 360;
+        while (v < -180) v += 360;
+        s.longitudeDeg = v;
+      }),
+      setMonthOverride: (m) => set((s) => {
+        if (m === null) { s.monthOverride = null; return; }
+        if (!Number.isFinite(m)) return;
+        const i = Math.round(m);
+        s.monthOverride = Math.max(1, Math.min(12, i));
+      }),
+      setUtcHourOverride: (h) => set((s) => {
+        if (h === null) { s.utcHourOverride = null; return; }
+        if (!Number.isFinite(h)) return;
+        s.utcHourOverride = Math.max(0, Math.min(23.99, h));
+      }),
+      setGeolocationStatus: (st) => set((s) => { s.geolocationStatus = st; }),
 
       _setSimulationData: (r, sweep) => set((s) => {
         s.result = r;

--- a/tests/antennaStore.test.ts
+++ b/tests/antennaStore.test.ts
@@ -350,4 +350,68 @@ describe('antennaStore actions', () => {
       expect(offsetAfter).toBeLessThanOrEqual(1.95);
     });
   });
+
+  describe('propagation', () => {
+    it('clamps T-index to the practical range', () => {
+      const store = useAntennaStore.getState();
+      store.setTIndex(99999);
+      expect(useAntennaStore.getState().tIndex).toBe(250);
+      store.setTIndex(-99999);
+      expect(useAntennaStore.getState().tIndex).toBe(-100);
+      store.setTIndex(75);
+      expect(useAntennaStore.getState().tIndex).toBe(75);
+    });
+
+    it('accepts and clears latitude', () => {
+      const store = useAntennaStore.getState();
+      store.setLatitude(51.5);
+      expect(useAntennaStore.getState().latitudeDeg).toBe(51.5);
+      store.setLatitude(null);
+      expect(useAntennaStore.getState().latitudeDeg).toBeNull();
+    });
+
+    it('clamps latitude to ±90', () => {
+      const store = useAntennaStore.getState();
+      store.setLatitude(120);
+      expect(useAntennaStore.getState().latitudeDeg).toBe(90);
+      store.setLatitude(-120);
+      expect(useAntennaStore.getState().latitudeDeg).toBe(-90);
+    });
+
+    it('wraps longitude into ±180', () => {
+      const store = useAntennaStore.getState();
+      store.setLongitude(200);
+      expect(useAntennaStore.getState().longitudeDeg).toBeCloseTo(-160, 5);
+      store.setLongitude(-200);
+      expect(useAntennaStore.getState().longitudeDeg).toBeCloseTo(160, 5);
+    });
+
+    it('clamps month override and accepts null', () => {
+      const store = useAntennaStore.getState();
+      store.setMonthOverride(15);
+      expect(useAntennaStore.getState().monthOverride).toBe(12);
+      store.setMonthOverride(0);
+      expect(useAntennaStore.getState().monthOverride).toBe(1);
+      store.setMonthOverride(null);
+      expect(useAntennaStore.getState().monthOverride).toBeNull();
+    });
+
+    it('clamps UTC hour override and accepts null', () => {
+      const store = useAntennaStore.getState();
+      store.setUtcHourOverride(50);
+      expect(useAntennaStore.getState().utcHourOverride).toBe(23.99);
+      store.setUtcHourOverride(-5);
+      expect(useAntennaStore.getState().utcHourOverride).toBe(0);
+      store.setUtcHourOverride(null);
+      expect(useAntennaStore.getState().utcHourOverride).toBeNull();
+    });
+
+    it('updates geolocation status', () => {
+      const store = useAntennaStore.getState();
+      store.setGeolocationStatus('requesting');
+      expect(useAntennaStore.getState().geolocationStatus).toBe('requesting');
+      store.setGeolocationStatus('denied');
+      expect(useAntennaStore.getState().geolocationStatus).toBe('denied');
+    });
+  });
 });

--- a/tests/propagation.test.ts
+++ b/tests/propagation.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, it } from 'vitest';
+import {
+  estimateFoF2MHz,
+  estimateHmF2Km,
+  estimateLUFMHz,
+  estimateMUFMHz,
+  hopRangeKm,
+  predictPropagation,
+  solarDeclinationDeg,
+  solarZenithDeg,
+} from '../src/physics/propagation';
+
+describe('solarDeclinationDeg', () => {
+  it('is near +23° in late June', () => {
+    expect(solarDeclinationDeg(6)).toBeGreaterThan(20);
+    expect(solarDeclinationDeg(6)).toBeLessThan(24);
+  });
+  it('is near -23° in late December', () => {
+    expect(solarDeclinationDeg(12)).toBeLessThan(-20);
+    expect(solarDeclinationDeg(12)).toBeGreaterThan(-24);
+  });
+  it('is near 0 at the equinoxes (March, September)', () => {
+    expect(Math.abs(solarDeclinationDeg(3))).toBeLessThan(5);
+    expect(Math.abs(solarDeclinationDeg(9))).toBeLessThan(5);
+  });
+});
+
+describe('solarZenithDeg', () => {
+  it('sun is overhead at the equator at local noon, equinox', () => {
+    // March 21 UTC noon, lon=0, lat=0 → sun nearly overhead.
+    const chi = solarZenithDeg(0, 0, 3, 12);
+    expect(chi).toBeLessThan(5);
+  });
+  it('sun is below horizon at the equator at local midnight', () => {
+    const chi = solarZenithDeg(0, 0, 6, 0);
+    expect(chi).toBeGreaterThan(90);
+  });
+  it('higher latitude in winter is dim at noon', () => {
+    // 60°N, December noon → sun very low.
+    const chi = solarZenithDeg(60, 0, 12, 12);
+    expect(chi).toBeGreaterThan(75);
+  });
+});
+
+describe('estimateFoF2MHz', () => {
+  it('is monotonic in T-index at fixed time/lat', () => {
+    const args = [6, 12, 30, 0] as const;
+    const a = estimateFoF2MHz(-50, ...args);
+    const b = estimateFoF2MHz(0, ...args);
+    const c = estimateFoF2MHz(100, ...args);
+    const d = estimateFoF2MHz(200, ...args);
+    expect(a).toBeLessThan(b);
+    expect(b).toBeLessThan(c);
+    expect(c).toBeLessThan(d);
+  });
+  it('is higher at noon than at midnight', () => {
+    const noon = estimateFoF2MHz(50, 6, 12, 30, 0);
+    const midnight = estimateFoF2MHz(50, 6, 0, 30, 0);
+    expect(noon).toBeGreaterThan(midnight);
+  });
+  it('returns a sensible HF value (3..30 MHz) for typical inputs', () => {
+    const v = estimateFoF2MHz(50, 6, 12, 30, 0);
+    expect(v).toBeGreaterThan(3);
+    expect(v).toBeLessThan(30);
+  });
+  it('never falls below the 1.5 MHz floor', () => {
+    const v = estimateFoF2MHz(-100, 12, 0, 89, 0);
+    expect(v).toBeGreaterThanOrEqual(1.5);
+  });
+  it('is reduced at very high latitudes', () => {
+    const equator = estimateFoF2MHz(50, 6, 12, 0, 0);
+    const polar = estimateFoF2MHz(50, 6, 12, 80, 0);
+    expect(polar).toBeLessThan(equator);
+  });
+});
+
+describe('estimateHmF2Km', () => {
+  it('returns daytime height lower than night-time height', () => {
+    const day = estimateHmF2Km(50, 6, 12, 30, 0);
+    const night = estimateHmF2Km(50, 6, 0, 30, 0);
+    expect(day).toBeLessThan(night);
+  });
+  it('stays in physically plausible bounds 220..420 km', () => {
+    for (const tIdx of [-50, 0, 100, 200]) {
+      for (const hour of [0, 6, 12, 18]) {
+        const h = estimateHmF2Km(tIdx, 6, hour, 30, 0);
+        expect(h).toBeGreaterThanOrEqual(220);
+        expect(h).toBeLessThanOrEqual(420);
+      }
+    }
+  });
+});
+
+describe('hopRangeKm', () => {
+  it('range increases as take-off elevation decreases (shallower → longer)', () => {
+    const high = hopRangeKm(60, 300);
+    const mid = hopRangeKm(20, 300);
+    const low = hopRangeKm(5, 300);
+    expect(low).toBeGreaterThan(mid);
+    expect(mid).toBeGreaterThan(high);
+  });
+  it('one hop at ~10° take-off, hmF2=300km is in the canonical 2000–3500 km range', () => {
+    const r = hopRangeKm(10, 300);
+    expect(r).toBeGreaterThan(2000);
+    expect(r).toBeLessThan(3500);
+  });
+  it('vertical incidence (90°) gives near-zero range', () => {
+    const r = hopRangeKm(89, 300);
+    expect(r).toBeLessThan(15);
+  });
+  it('grazing (0.5°) gives a long but finite range', () => {
+    const r = hopRangeKm(0.5, 300);
+    expect(r).toBeGreaterThan(3500);
+    expect(r).toBeFinite();
+  });
+});
+
+describe('estimateMUFMHz', () => {
+  it('MUF >= foF2 for all non-vertical incidence', () => {
+    const fof2 = 8;
+    for (const eps of [0.5, 5, 10, 30, 60, 89]) {
+      expect(estimateMUFMHz(fof2, eps, 300)).toBeGreaterThanOrEqual(fof2 - 1e-6);
+    }
+  });
+  it('MUF approaches foF2 at near-vertical take-off', () => {
+    const fof2 = 8;
+    const muf = estimateMUFMHz(fof2, 89, 300);
+    expect(muf).toBeLessThan(fof2 * 1.2);
+  });
+  it('MUF is much higher than foF2 at low take-off', () => {
+    const fof2 = 8;
+    const muf = estimateMUFMHz(fof2, 5, 300);
+    expect(muf).toBeGreaterThan(fof2 * 2);
+  });
+});
+
+describe('estimateLUFMHz', () => {
+  it('is higher at local noon than at midnight', () => {
+    const noon = estimateLUFMHz(50, 6, 12, 30, 0);
+    const night = estimateLUFMHz(50, 6, 0, 30, 0);
+    expect(noon).toBeGreaterThan(night);
+  });
+  it('rises with T-index at fixed time', () => {
+    const quiet = estimateLUFMHz(0, 6, 12, 30, 0);
+    const active = estimateLUFMHz(150, 6, 12, 30, 0);
+    expect(active).toBeGreaterThan(quiet);
+  });
+  it('stays in physical bounds 1..12 MHz', () => {
+    for (const tIdx of [-50, 0, 100, 200]) {
+      for (const hour of [0, 6, 12, 18]) {
+        const v = estimateLUFMHz(tIdx, 6, hour, 30, 0);
+        expect(v).toBeGreaterThanOrEqual(1.0);
+        expect(v).toBeLessThanOrEqual(12.0);
+      }
+    }
+  });
+});
+
+describe('predictPropagation', () => {
+  const baseInput = {
+    frequencyMHz: 14.150,
+    tIndex: 50,
+    takeoffElevationDeg: 15,
+    month: 6,
+    utcHour: 12,
+    latitudeDeg: 30,
+    longitudeDeg: 0,
+  };
+
+  it('returns three hops with strictly increasing range', () => {
+    const p = predictPropagation(baseInput);
+    expect(p.hops.length).toBe(3);
+    expect(p.hops[1].rangeKm).toBeGreaterThan(p.hops[0].rangeKm);
+    expect(p.hops[2].rangeKm).toBeGreaterThan(p.hops[1].rangeKm);
+  });
+
+  it('marks hops as closed when frequency far exceeds MUF', () => {
+    const p = predictPropagation({ ...baseInput, frequencyMHz: 50 });
+    for (const h of p.hops) {
+      expect(h.status).toBe('closed');
+      expect(h.reason).toMatch(/> MUF/);
+    }
+  });
+
+  it('marks hops as closed when frequency is below LUF (daytime, active)', () => {
+    const p = predictPropagation({
+      ...baseInput,
+      frequencyMHz: 1.9,
+      tIndex: 200,
+    });
+    expect(p.hops[0].status).toBe('closed');
+    expect(p.hops[0].reason).toMatch(/< LUF/);
+  });
+
+  it('marks hops as open between LUF and MUF for a typical 20m daytime path', () => {
+    const p = predictPropagation(baseInput);
+    expect(p.foF2MHz).toBeGreaterThan(5);
+    expect(p.mufMHz).toBeGreaterThan(p.foF2MHz);
+    // At 14.15 MHz, midday, T=50, mid-latitudes: usually open.
+    if (p.mufMHz > baseInput.frequencyMHz && p.lufMHz < baseInput.frequencyMHz) {
+      expect(p.hops[0].status).toMatch(/open|marginal/);
+    }
+  });
+
+  it('flips hops from closed to open as T-index rises', () => {
+    // Pick a frequency above the quiet-sun MUF for our geometry.
+    const probe = { ...baseInput, frequencyMHz: 18, tIndex: -50 };
+    const quiet = predictPropagation(probe);
+    const active = predictPropagation({ ...probe, tIndex: 200 });
+    // foF2 must rise with T-index.
+    expect(active.foF2MHz).toBeGreaterThan(quiet.foF2MHz);
+    // MUF must rise with T-index.
+    expect(active.mufMHz).toBeGreaterThan(quiet.mufMHz);
+    // If quiet was closed at this frequency, active should be at least marginal.
+    if (quiet.hops[0].status === 'closed' && active.mufMHz >= probe.frequencyMHz) {
+      expect(active.hops[0].status).not.toBe('closed');
+    }
+  });
+
+  it('handles edge inputs without throwing or producing NaN', () => {
+    const cases = [
+      { ...baseInput, tIndex: -50, latitudeDeg: -90, takeoffElevationDeg: 0.5 },
+      { ...baseInput, tIndex: 200, latitudeDeg: 90, takeoffElevationDeg: 89.5 },
+      { ...baseInput, frequencyMHz: 1.8 },
+      { ...baseInput, frequencyMHz: 30 },
+      { ...baseInput, utcHour: 0 },
+      { ...baseInput, utcHour: 23.99 },
+    ];
+    for (const c of cases) {
+      const p = predictPropagation(c);
+      expect(Number.isFinite(p.foF2MHz)).toBe(true);
+      expect(Number.isFinite(p.hmF2Km)).toBe(true);
+      expect(Number.isFinite(p.mufMHz)).toBe(true);
+      expect(Number.isFinite(p.lufMHz)).toBe(true);
+      for (const h of p.hops) {
+        expect(Number.isFinite(h.rangeKm)).toBe(true);
+        expect(h.rangeKm).toBeGreaterThan(0);
+      }
+    }
+  });
+});


### PR DESCRIPTION
Adds a new Propagation panel section with manual Australian IPS T-index entry, plus a top-down 'radar' SVG visualisation of estimated 1/2/3-hop ground range. Frequency, T-index, take-off angle, month/UTC, and latitude all feed into the calculation; ranges and open/marginal/closed status update live as the user changes any input.

The propagation model is a closed-form approximation (foF2 from T-index + solar zenith angle + latitude, hmF2 from a day/night sinusoid, MUF via the secant law with a curved-Earth correction, LUF as a D-layer absorption heuristic). It is deliberately not IRI/ASAPS/VOACAP — the model assumptions and LUF caveats are surfaced in the UI.

No backend, no fetches: the deployment stays as a static Cloudflare assets-only Worker. Geolocation is opt-in (only requested when the user clicks 'Use my location'); permission denial is non-blocking and falls back to manual latitude entry.