### PR TITLE
Fix t-index input clearing bug

### DIFF
--- a/src/components/Panel/PropagationControl.tsx
+++ b/src/components/Panel/PropagationControl.tsx
@@ -31,6 +31,41 @@ export function PropagationControl() {
   const [showAssumptions, setShowAssumptions] = useState(false);
   const [showTimeOverride, setShowTimeOverride] = useState(false);
 
+  // Local buffers for numeric inputs to allow natural typing.
+  const [localTIndex, setLocalTIndex] = useState(tIndex.toString());
+  const [isTIndexFocused, setIsTIndexFocused] = useState(false);
+
+  const [prevTIndex, setPrevTIndex] = useState(tIndex);
+  if (tIndex !== prevTIndex) {
+    setPrevTIndex(tIndex);
+    if (!isTIndexFocused) {
+      setLocalTIndex(tIndex.toString());
+    }
+  }
+
+  const [localLat, setLocalLat] = useState(latitudeDeg?.toString() ?? '');
+  const [isLatFocused, setIsLatFocused] = useState(false);
+
+  const [prevLat, setPrevLat] = useState(latitudeDeg);
+  if (latitudeDeg !== prevLat) {
+    setPrevLat(latitudeDeg);
+    if (!isLatFocused) {
+      setLocalLat(latitudeDeg?.toString() ?? '');
+    }
+  }
+
+
+  const [localUtcHour, setLocalUtcHour] = useState(utcHourOverride?.toString() ?? '');
+  const [isUtcHourFocused, setIsUtcHourFocused] = useState(false);
+
+  const [prevUtcHour, setPrevUtcHour] = useState(utcHourOverride);
+  if (utcHourOverride !== prevUtcHour) {
+    setPrevUtcHour(utcHourOverride);
+    if (!isUtcHourFocused) {
+      setLocalUtcHour(utcHourOverride?.toString() ?? '');
+    }
+  }
+
   // Resolve "now" once per render. We deliberately don't memoise on a
   // ticking clock — propagation conditions change on the order of minutes,
   // so the panel just refreshes on the next render trigger (e.g. user
@@ -73,11 +108,18 @@ export function PropagationControl() {
           min={-100}
           max={250}
           step={1}
-          value={tIndex}
+          value={localTIndex}
           aria-label="Ionospheric T-index"
+          onFocus={() => setIsTIndexFocused(true)}
           onChange={(e) => {
-            const v = parseFloat(e.target.value);
+            const s = e.target.value;
+            setLocalTIndex(s);
+            const v = parseFloat(s);
             if (!isNaN(v)) setTIndex(v);
+          }}
+          onBlur={() => {
+            setIsTIndexFocused(false);
+            setLocalTIndex(tIndex.toString());
           }}
         />
       </div>
@@ -95,12 +137,19 @@ export function PropagationControl() {
           min={-90}
           max={90}
           step={0.1}
-          value={latitudeDeg ?? ''}
+          value={localLat}
           placeholder="0.0"
           aria-label="Latitude in degrees"
+          onFocus={() => setIsLatFocused(true)}
           onChange={(e) => {
-            const v = parseFloat(e.target.value);
+            const s = e.target.value;
+            setLocalLat(s);
+            const v = parseFloat(s);
             setLatitude(isNaN(v) ? null : v);
+          }}
+          onBlur={() => {
+            setIsLatFocused(false);
+            setLocalLat(latitudeDeg?.toString() ?? '');
           }}
         />
         <button
@@ -156,11 +205,18 @@ export function PropagationControl() {
             max={23.99}
             step={0.5}
             placeholder="UTC hour"
-            value={utcHourOverride ?? ''}
+            value={localUtcHour}
             aria-label="UTC hour override"
+            onFocus={() => setIsUtcHourFocused(true)}
             onChange={(e) => {
-              const v = parseFloat(e.target.value);
+              const s = e.target.value;
+              setLocalUtcHour(s);
+              const v = parseFloat(s);
               setUtcHourOverride(isNaN(v) ? null : v);
+            }}
+            onBlur={() => {
+              setIsUtcHourFocused(false);
+              setLocalUtcHour(utcHourOverride?.toString() ?? '');
             }}
           />
         </div>

--- a/tests/PropagationControl.test.tsx
+++ b/tests/PropagationControl.test.tsx
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/react';
+import { PropagationControl } from '../src/components/Panel/PropagationControl';
+import { useAntennaStore } from '../src/store/antennaStore';
+
+// Mock the store
+vi.mock('../src/store/antennaStore', async () => {
+  const actual = await vi.importActual('../src/store/antennaStore');
+  return {
+    ...actual,
+    useAntennaStore: vi.fn(),
+  };
+});
+
+// Mock the radar component to avoid deep rendering issues
+vi.mock('../src/components/Charts/PropagationRadar', () => ({
+  PropagationRadar: () => <div data-testid="radar" />,
+}));
+
+describe('PropagationControl - T-index Input Bug', () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('fails to allow clearing the T-index input when directly bound', () => {
+    const setTIndex = vi.fn();
+    let currentTIndex = 30;
+
+    // We simulate the store behavior: when setTIndex is called, the component re-renders with the new value.
+    // If the input is directly bound to `tIndex`, and `parseFloat('')` is NaN,
+    // then `setTIndex` might not be called, and the input `value={tIndex}` will still show '30'.
+
+    vi.mocked(useAntennaStore).mockImplementation((selector: any) => {
+      const state = {
+        frequency: 7.1,
+        tIndex: currentTIndex,
+        setTIndex: (v: number) => {
+          currentTIndex = v;
+          setTIndex(v);
+        },
+        latitudeDeg: null,
+        longitudeDeg: null,
+        setLatitude: vi.fn(),
+        monthOverride: null,
+        utcHourOverride: null,
+        setMonthOverride: vi.fn(),
+        setUtcHourOverride: vi.fn(),
+        result: null,
+        units: 'metric',
+      };
+      return selector(state);
+    });
+
+    const { rerender } = render(<PropagationControl />);
+    const tInput = document.getElementById('t-index-input') as HTMLInputElement;
+
+    expect(tInput.value).toBe('30');
+
+    // Simulate user backspacing to clear the input
+    fireEvent.change(tInput, { target: { value: '' } });
+
+    // In the current broken implementation, if the input is value={tIndex},
+    // and onChange does nothing for empty string (isNaN(v) is true),
+    // then the input value remains '30' because of the value={tIndex} binding.
+    // Wait, if fireEvent.change is called, does the DOM element value update before React re-render?
+    // In a controlled component, it should stick to the prop value.
+
+    // Actually, if it's value={tIndex}, and we do fireEvent.change(tInput, { target: { value: '' } }),
+    // Now with the fix, it SHOULD be empty because we use a local buffer.
+    fireEvent.focus(tInput);
+    fireEvent.change(tInput, { target: { value: '' } });
+
+    expect(tInput.value).toBe('');
+  });
+
+  it('allows clearing the T-index input with the local buffer pattern', () => {
+    const setTIndex = vi.fn();
+    let currentTIndex = 30;
+
+    vi.mocked(useAntennaStore).mockImplementation((selector: any) => {
+      const state = {
+        frequency: 7.1,
+        tIndex: currentTIndex,
+        setTIndex: (v: number) => {
+          currentTIndex = v;
+          setTIndex(v);
+        },
+        latitudeDeg: null,
+        longitudeDeg: null,
+        setLatitude: vi.fn(),
+        monthOverride: null,
+        utcHourOverride: null,
+        setMonthOverride: vi.fn(),
+        setUtcHourOverride: vi.fn(),
+        result: null,
+        units: 'metric',
+      };
+      return selector(state);
+    });
+
+    render(<PropagationControl />);
+    const tInput = document.getElementById('t-index-input') as HTMLInputElement;
+
+    expect(tInput.value).toBe('30');
+
+    // Focus first
+    fireEvent.focus(tInput);
+    // Simulate user backspacing to clear the input
+    fireEvent.change(tInput, { target: { value: '' } });
+
+    // Now it should be empty
+    expect(tInput.value).toBe('');
+
+    // Store should not have been updated with NaN
+    expect(setTIndex).not.toHaveBeenCalledWith(NaN);
+
+    // On blur, it should snap back to the store value
+    fireEvent.blur(tInput);
+    expect(tInput.value).toBe('30');
+  });
+});

--- a/tests/PropagationControl.test.tsx
+++ b/tests/PropagationControl.test.tsx
@@ -17,22 +17,33 @@ vi.mock('../src/components/Charts/PropagationRadar', () => ({
   PropagationRadar: () => <div data-testid="radar" />,
 }));
 
+interface MockPropagationState {
+  frequency: number;
+  tIndex: number;
+  setTIndex: (v: number) => void;
+  latitudeDeg: number | null;
+  longitudeDeg: number | null;
+  setLatitude: (v: number | null) => void;
+  monthOverride: number | null;
+  utcHourOverride: number | null;
+  setMonthOverride: (v: number | null) => void;
+  setUtcHourOverride: (v: number | null) => void;
+  result: unknown | null;
+  units: 'metric' | 'imperial';
+}
+
 describe('PropagationControl - T-index Input Bug', () => {
   beforeEach(() => {
     cleanup();
     vi.clearAllMocks();
   });
 
-  it('fails to allow clearing the T-index input when directly bound', () => {
+  it('allows clearing the T-index input (via local buffer)', () => {
     const setTIndex = vi.fn();
     let currentTIndex = 30;
 
-    // We simulate the store behavior: when setTIndex is called, the component re-renders with the new value.
-    // If the input is directly bound to `tIndex`, and `parseFloat('')` is NaN,
-    // then `setTIndex` might not be called, and the input `value={tIndex}` will still show '30'.
-
-    vi.mocked(useAntennaStore).mockImplementation((selector: any) => {
-      const state = {
+    vi.mocked(useAntennaStore).mockImplementation((selector: (s: MockPropagationState) => unknown) => {
+      const state: MockPropagationState = {
         frequency: 7.1,
         tIndex: currentTIndex,
         setTIndex: (v: number) => {
@@ -52,64 +63,15 @@ describe('PropagationControl - T-index Input Bug', () => {
       return selector(state);
     });
 
-    const { rerender } = render(<PropagationControl />);
-    const tInput = document.getElementById('t-index-input') as HTMLInputElement;
+    const { getByLabelText } = render(<PropagationControl />);
+    const tInput = getByLabelText('Ionospheric T-index') as HTMLInputElement;
 
     expect(tInput.value).toBe('30');
 
-    // Simulate user backspacing to clear the input
-    fireEvent.change(tInput, { target: { value: '' } });
-
-    // In the current broken implementation, if the input is value={tIndex},
-    // and onChange does nothing for empty string (isNaN(v) is true),
-    // then the input value remains '30' because of the value={tIndex} binding.
-    // Wait, if fireEvent.change is called, does the DOM element value update before React re-render?
-    // In a controlled component, it should stick to the prop value.
-
-    // Actually, if it's value={tIndex}, and we do fireEvent.change(tInput, { target: { value: '' } }),
-    // Now with the fix, it SHOULD be empty because we use a local buffer.
+    // Focus and clear
     fireEvent.focus(tInput);
     fireEvent.change(tInput, { target: { value: '' } });
 
-    expect(tInput.value).toBe('');
-  });
-
-  it('allows clearing the T-index input with the local buffer pattern', () => {
-    const setTIndex = vi.fn();
-    let currentTIndex = 30;
-
-    vi.mocked(useAntennaStore).mockImplementation((selector: any) => {
-      const state = {
-        frequency: 7.1,
-        tIndex: currentTIndex,
-        setTIndex: (v: number) => {
-          currentTIndex = v;
-          setTIndex(v);
-        },
-        latitudeDeg: null,
-        longitudeDeg: null,
-        setLatitude: vi.fn(),
-        monthOverride: null,
-        utcHourOverride: null,
-        setMonthOverride: vi.fn(),
-        setUtcHourOverride: vi.fn(),
-        result: null,
-        units: 'metric',
-      };
-      return selector(state);
-    });
-
-    render(<PropagationControl />);
-    const tInput = document.getElementById('t-index-input') as HTMLInputElement;
-
-    expect(tInput.value).toBe('30');
-
-    // Focus first
-    fireEvent.focus(tInput);
-    // Simulate user backspacing to clear the input
-    fireEvent.change(tInput, { target: { value: '' } });
-
-    // Now it should be empty
     expect(tInput.value).toBe('');
 
     // Store should not have been updated with NaN
@@ -118,5 +80,38 @@ describe('PropagationControl - T-index Input Bug', () => {
     // On blur, it should snap back to the store value
     fireEvent.blur(tInput);
     expect(tInput.value).toBe('30');
+  });
+
+  it('syncs local buffer with store when store changes externally (and not focused)', () => {
+    const setTIndex = vi.fn();
+    let currentTIndex = 30;
+
+    vi.mocked(useAntennaStore).mockImplementation((selector: (s: MockPropagationState) => unknown) => {
+      const state: MockPropagationState = {
+        frequency: 7.1,
+        tIndex: currentTIndex,
+        setTIndex,
+        latitudeDeg: null,
+        longitudeDeg: null,
+        setLatitude: vi.fn(),
+        monthOverride: null,
+        utcHourOverride: null,
+        setMonthOverride: vi.fn(),
+        setUtcHourOverride: vi.fn(),
+        result: null,
+        units: 'metric',
+      };
+      return selector(state);
+    });
+
+    const { getByLabelText, rerender } = render(<PropagationControl />);
+    const tInput = getByLabelText('Ionospheric T-index') as HTMLInputElement;
+    expect(tInput.value).toBe('30');
+
+    // Simulate external store update
+    currentTIndex = 45;
+    rerender(<PropagationControl />);
+
+    expect(tInput.value).toBe('45');
   });
 });


### PR DESCRIPTION
The T-index and other numeric inputs in the Propagation panel were difficult to edit because they were directly bound to numeric state in the store. Clearing the input would cause `parseFloat("")` to return `NaN`, which the store would reject, causing the input to snap back to its previous value.

I introduced a local string buffer pattern (consistent with other panels like Frequency and Dipole) that holds the raw user input while focused. This allows intermediate states like empty strings or partial decimals. The store is updated whenever the input is a valid number, and the local buffer is synced back to the store value only on blur or when the store value changes externally.

Fixes #84

---
*PR created automatically by Jules for task [8946634879430200614](https://jules.google.com/task/8946634879430200614) started by @2fst4u*