### PR TITLE
Always show propagation time override inputs

### DIFF
--- a/src/components/Panel/PropagationControl.tsx
+++ b/src/components/Panel/PropagationControl.tsx
@@ -29,15 +29,29 @@ export function PropagationControl() {
   const { status: geoStatus, requestLocation } = useGeolocation();
 
   const [showAssumptions, setShowAssumptions] = useState(false);
-  const [showTimeOverride, setShowTimeOverride] = useState(false);
 
   // Resolve "now" once per render. We deliberately don't memoise on a
   // ticking clock — propagation conditions change on the order of minutes,
   // so the panel just refreshes on the next render trigger (e.g. user
   // input). Adding a 60s ticker is easy if needed later.
   const now = new Date();
-  const month = monthOverride ?? (now.getUTCMonth() + 1);
-  const utcHour = utcHourOverride ?? (now.getUTCHours() + now.getUTCMinutes() / 60);
+  const autoMonth = now.getUTCMonth() + 1;
+  const autoUtcHour = now.getUTCHours() + now.getUTCMinutes() / 60;
+
+  const month = monthOverride ?? autoMonth;
+  const utcHour = utcHourOverride ?? autoUtcHour;
+
+  // Local state for UTC hour input (controlled local buffer pattern)
+  const [localUtcHour, setLocalUtcHour] = useState(utcHour.toFixed(1));
+  const [isHourFocused, setIsHourFocused] = useState(false);
+  const [prevUtcHour, setPrevUtcHour] = useState(utcHour);
+
+  if (utcHour !== prevUtcHour) {
+    setPrevUtcHour(utcHour);
+    if (!isHourFocused) {
+      setLocalUtcHour(utcHour.toFixed(1));
+    }
+  }
 
   const takeoffElevationDeg = result?.takeoffElevationDeg ?? 30;
 
@@ -117,54 +131,61 @@ export function PropagationControl() {
         {geoStatusMessage(geoStatus, latitudeDeg)}
       </p>
 
-      {/* Time / month — auto-filled from browser clock unless overridden */}
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline' }}>
-        <span style={{ fontSize: 11, color: 'var(--text-muted)' }}>
-          {monthOverride === null && utcHourOverride === null
-            ? `Auto: ${MONTH_NAMES[month - 1]}, ${formatUtcHour(utcHour)} UTC`
-            : `Override: ${MONTH_NAMES[month - 1]}, ${formatUtcHour(utcHour)} UTC`}
-        </span>
+      {/* Time & Month — auto-filled from browser clock unless overridden */}
+      <label htmlFor="month-select" style={{ marginTop: 10 }}>Month</label>
+      <div className="row">
+        <select
+          id="month-select"
+          value={monthOverride ?? ''}
+          onChange={(e) => {
+            const v = e.target.value;
+            setMonthOverride(v === '' ? null : parseInt(v, 10));
+          }}
+          aria-label="Month override"
+        >
+          <option value="">Auto ({MONTH_NAMES[autoMonth - 1]})</option>
+          {MONTH_NAMES.map((n, i) => (
+            <option key={n} value={i + 1}>{n}</option>
+          ))}
+        </select>
+      </div>
+
+      <label htmlFor="utc-hour-input" style={{ marginTop: 10 }}>
+        UTC Hour — {formatUtcHour(utcHour)}
+      </label>
+      <div className="row">
+        <input
+          id="utc-hour-input"
+          type="number"
+          min={0}
+          max={23.99}
+          step={0.1}
+          value={localUtcHour}
+          onFocus={() => setIsHourFocused(true)}
+          aria-label="UTC hour override"
+          onChange={(e) => {
+            const s = e.target.value;
+            setLocalUtcHour(s);
+            const val = parseFloat(s);
+            if (!isNaN(val)) {
+              setUtcHourOverride(val);
+            }
+          }}
+          onBlur={() => {
+            setIsHourFocused(false);
+            setLocalUtcHour(utcHour.toFixed(1));
+          }}
+        />
         <button
           type="button"
-          onClick={() => setShowTimeOverride((v) => !v)}
-          style={{
-            background: 'transparent', border: 'none', color: 'var(--accent)',
-            padding: 0, fontSize: 11, cursor: 'pointer',
-          }}
+          onClick={() => setUtcHourOverride(null)}
+          disabled={utcHourOverride === null}
+          style={{ flex: '0 0 auto' }}
+          title="Reset to current UTC time"
         >
-          {showTimeOverride ? 'Hide time override' : 'Override time'}
+          Auto
         </button>
       </div>
-      {showTimeOverride && (
-        <div className="row" style={{ marginTop: 6, gap: 6 }}>
-          <select
-            value={monthOverride ?? ''}
-            onChange={(e) => {
-              const v = e.target.value;
-              setMonthOverride(v === '' ? null : parseInt(v, 10));
-            }}
-            aria-label="Month override"
-          >
-            <option value="">Auto month</option>
-            {MONTH_NAMES.map((n, i) => (
-              <option key={n} value={i + 1}>{n}</option>
-            ))}
-          </select>
-          <input
-            type="number"
-            min={0}
-            max={23.99}
-            step={0.5}
-            placeholder="UTC hour"
-            value={utcHourOverride ?? ''}
-            aria-label="UTC hour override"
-            onChange={(e) => {
-              const v = parseFloat(e.target.value);
-              setUtcHourOverride(isNaN(v) ? null : v);
-            }}
-          />
-        </div>
-      )}
 
       {/* Conditions readout */}
       <hr style={{ border: 0, borderTop: '1px solid var(--border)', margin: '12px 0 8px' }} />

--- a/tests/PropagationControl.test.tsx
+++ b/tests/PropagationControl.test.tsx
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { PropagationControl } from '../src/components/Panel/PropagationControl';
+import { useAntennaStore } from '../src/store/antennaStore';
+
+// Mock the store
+vi.mock('../src/store/antennaStore', async () => {
+  const actual = await vi.importActual('../src/store/antennaStore');
+  return {
+    ...actual,
+    useAntennaStore: vi.fn(),
+  };
+});
+
+// Mock PropagationRadar since it might involve complex rendering
+vi.mock('../src/components/Charts/PropagationRadar', () => ({
+  PropagationRadar: () => <div data-testid="propagation-radar" />,
+}));
+
+interface MockState {
+  frequency: number;
+  tIndex: number;
+  latitudeDeg: number | null;
+  longitudeDeg: number | null;
+  monthOverride: number | null;
+  utcHourOverride: number | null;
+  units: 'metric' | 'imperial';
+  result: any;
+  setTIndex: (v: number) => void;
+  setLatitude: (v: number | null) => void;
+  setMonthOverride: (v: number | null) => void;
+  setUtcHourOverride: (v: number | null) => void;
+  geolocationStatus: string;
+}
+
+describe('PropagationControl', () => {
+  const mockSetMonthOverride = vi.fn();
+  const mockSetUtcHourOverride = vi.fn();
+
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  const setupMockStore = (overrides: Partial<MockState> = {}) => {
+    vi.mocked(useAntennaStore).mockImplementation((selector: (s: MockState) => unknown) => {
+      const state: MockState = {
+        frequency: 7.1,
+        tIndex: 30,
+        latitudeDeg: null,
+        longitudeDeg: null,
+        monthOverride: null,
+        utcHourOverride: null,
+        units: 'metric',
+        result: null,
+        setTIndex: vi.fn(),
+        setLatitude: vi.fn(),
+        setMonthOverride: mockSetMonthOverride,
+        setUtcHourOverride: mockSetUtcHourOverride,
+        geolocationStatus: 'idle',
+        ...overrides,
+      };
+      return selector(state);
+    });
+  };
+
+  it('renders Month and UTC Hour inputs by default', () => {
+    setupMockStore();
+    render(<PropagationControl />);
+
+    expect(screen.getByLabelText('Month override')).toBeDefined();
+    expect(screen.getByLabelText('UTC hour override')).toBeDefined();
+  });
+
+  it('updates month override when select changes', () => {
+    setupMockStore();
+    render(<PropagationControl />);
+
+    const monthSelect = screen.getByLabelText('Month override') as HTMLSelectElement;
+    fireEvent.change(monthSelect, { target: { value: '5' } });
+
+    expect(mockSetMonthOverride).toHaveBeenCalledWith(5);
+  });
+
+  it('updates UTC hour override when input changes', () => {
+    setupMockStore();
+    render(<PropagationControl />);
+
+    const hourInput = screen.getByLabelText('UTC hour override') as HTMLInputElement;
+    fireEvent.change(hourInput, { target: { value: '14.5' } });
+
+    expect(mockSetUtcHourOverride).toHaveBeenCalledWith(14.5);
+  });
+
+  it('resets UTC hour override when Auto button is clicked', () => {
+    setupMockStore({ utcHourOverride: 10 });
+    render(<PropagationControl />);
+
+    const autoButton = screen.getByRole('button', { name: 'Auto' });
+    fireEvent.click(autoButton);
+
+    expect(mockSetUtcHourOverride).toHaveBeenCalledWith(null);
+  });
+
+  it('disables Auto button when no UTC hour override is set', () => {
+    setupMockStore({ utcHourOverride: null });
+    render(<PropagationControl />);
+
+    const autoButton = screen.getByRole('button', { name: 'Auto' }) as HTMLButtonElement;
+    expect(autoButton.disabled).toBe(true);
+  });
+});

--- a/tests/PropagationControl.test.tsx
+++ b/tests/PropagationControl.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, cleanup } from '@testing-library/react';
 import { PropagationControl } from '../src/components/Panel/PropagationControl';
 import { useAntennaStore } from '../src/store/antennaStore';
+import type { SimulationResult } from '../src/physics/types';
 
 // Mock the store
 vi.mock('../src/store/antennaStore', async () => {
@@ -25,7 +26,7 @@ interface MockState {
   monthOverride: number | null;
   utcHourOverride: number | null;
   units: 'metric' | 'imperial';
-  result: any;
+  result: SimulationResult | null;
   setTIndex: (v: number) => void;
   setLatitude: (v: number | null) => void;
   setMonthOverride: (v: number | null) => void;


### PR DESCRIPTION
The propagation time override inputs (Month and UTC Hour) are now always visible in the Propagation panel, as requested. They are automatically populated with the current UTC time/month by default. I've also improved the user experience by using a local state buffer for the UTC hour input to prevent jumping during typing and added a convenient 'Auto' button to clear overrides. A new test file `tests/PropagationControl.test.tsx` covers these changes.

Fixes #85

---
*PR created automatically by Jules for task [8508902679175669329](https://jules.google.com/task/8508902679175669329) started by @2fst4u*