### PR TITLE
🔭 Scout: Fix heading hierarchy in control panel

### DIFF
--- a/src/components/Charts/PolarPlots.tsx
+++ b/src/components/Charts/PolarPlots.tsx
@@ -162,7 +162,8 @@ export function PolarPlots() {
 
   return (
     <div className="panel-section">
-      <h3>Polar cuts</h3>
+      {/* SEO: Use sequential heading tags (H2) to follow document outline initiated by H1 */}
+      <h2>Polar cuts</h2>
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(130px, 1fr))', gap: 8 }}>
         <div style={{ minWidth: 0 }}>
           <div style={{ fontSize: 11, color: 'var(--text-dim)', textAlign: 'center' }}>

--- a/src/components/Charts/SWRChart.tsx
+++ b/src/components/Charts/SWRChart.tsx
@@ -247,7 +247,8 @@ export function SWRChart() {
   if (!result || sweep.length === 0) {
     return (
       <div className="panel-section" style={{ minHeight: 220 }}>
-        <h3>SWR sweep</h3>
+        {/* SEO: Use sequential heading tags (H2) to follow document outline initiated by H1 */}
+        <h2>SWR sweep</h2>
         <div style={{ color: 'var(--text-muted)', fontSize: 12 }}>Computing frequency sweep…</div>
       </div>
     );
@@ -255,7 +256,8 @@ export function SWRChart() {
 
   return (
     <div className="panel-section" style={{ minHeight: 220 }}>
-      <h3>SWR sweep</h3>
+      {/* SEO: Use sequential heading tags (H2) to follow document outline initiated by H1 */}
+      <h2>SWR sweep</h2>
       <div style={{ height: 130 }}>
         <Line data={data} options={options} />
       </div>

--- a/src/components/Panel/ComparisonControl.tsx
+++ b/src/components/Panel/ComparisonControl.tsx
@@ -18,7 +18,8 @@ export function ComparisonControl() {
 
   return (
     <div className="panel-section">
-      <h3>Comparison</h3>
+      {/* SEO: Use sequential heading tags (H2) to follow document outline initiated by H1 */}
+      <h2>Comparison</h2>
       <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>
         Freeze the current antenna as the left-hand reference, then change the live controls to compare against it.
       </div>

--- a/src/components/Panel/DipoleControl.tsx
+++ b/src/components/Panel/DipoleControl.tsx
@@ -58,7 +58,8 @@ export function DipoleControl() {
 
   return (
     <div className="panel-section">
-      <h3>Dipole</h3>
+      {/* SEO: Use sequential heading tags (H2) to follow document outline initiated by H1 */}
+      <h2>Dipole</h2>
 
       <label htmlFor="dipole-length">Length ({unit})</label>
       <div className="row">

--- a/src/components/Panel/DisplayControl.tsx
+++ b/src/components/Panel/DisplayControl.tsx
@@ -21,7 +21,8 @@ export function DisplayControl() {
 
   return (
     <div className="panel-section">
-      <h3>Display</h3>
+      {/* SEO: Use sequential heading tags (H2) to follow document outline initiated by H1 */}
+      <h2>Display</h2>
       <label id="colormap-label">Colormap</label>
       <div className="button-group" role="group" aria-labelledby="colormap-label">
         {COLORMAPS.map((c) => (

--- a/src/components/Panel/FeedlineControl.tsx
+++ b/src/components/Panel/FeedlineControl.tsx
@@ -46,7 +46,8 @@ export function FeedlineControl() {
 
   return (
     <div className="panel-section">
-      <h3>Feedline</h3>
+      {/* SEO: Use sequential heading tags (H2) to follow document outline initiated by H1 */}
+      <h2>Feedline</h2>
       <label htmlFor="feedline-preset">Cable</label>
       <select
         id="feedline-preset"

--- a/src/components/Panel/FrequencyControl.tsx
+++ b/src/components/Panel/FrequencyControl.tsx
@@ -24,7 +24,8 @@ export function FrequencyControl() {
 
   return (
     <div className="panel-section">
-      <h3>Frequency <span className="badge">{frequency.toFixed(3)} MHz</span></h3>
+      {/* SEO: Use sequential heading tags (H2) to follow document outline initiated by H1 */}
+      <h2>Frequency <span className="badge">{frequency.toFixed(3)} MHz</span></h2>
       <div className="row">
         <input
           type="number"

--- a/src/components/Panel/GroundControl.tsx
+++ b/src/components/Panel/GroundControl.tsx
@@ -33,7 +33,8 @@ export function GroundControl() {
 
   return (
     <div className="panel-section">
-      <h3>
+      {/* SEO: Use sequential heading tags (H2) to follow document outline initiated by H1 */}
+      <h2>
         Ground
         <button
           style={{ padding: '2px 8px', fontSize: 11 }}
@@ -43,7 +44,7 @@ export function GroundControl() {
         >
           {expanded ? 'Simple' : 'Custom'}
         </button>
-      </h3>
+      </h2>
       <select aria-label="Ground preset" value={groundId} onChange={(e) => setGround(e.target.value)}>
         {GROUND_PRESETS.map((g) => (
           <option key={g.id} value={g.id}>{g.label}</option>

--- a/src/components/Panel/ModeSelector.tsx
+++ b/src/components/Panel/ModeSelector.tsx
@@ -12,7 +12,8 @@ export function ModeSelector() {
   const setMode = useAntennaStore((s) => s.setMode);
   return (
     <div className="panel-section">
-      <h3 id="mode-selector-heading">Mode</h3>
+      {/* SEO: Use sequential heading tags (H2) to follow document outline initiated by H1 */}
+      <h2 id="mode-selector-heading">Mode</h2>
       <div className="button-group" role="group" aria-labelledby="mode-selector-heading">
         {MODES.map((m) => (
           <button

--- a/src/components/Panel/PropagationControl.tsx
+++ b/src/components/Panel/PropagationControl.tsx
@@ -59,10 +59,11 @@ export function PropagationControl() {
 
   return (
     <div className="panel-section">
-      <h3>
+      {/* SEO: Use sequential heading tags (H2) to follow document outline initiated by H1 */}
+      <h2>
         Propagation
         <span className="badge">T = {tIndex.toFixed(0)}</span>
-      </h3>
+      </h2>
 
       {/* T-index input */}
       <label htmlFor="t-index-input">T-index</label>

--- a/src/components/Panel/StatsReadout.tsx
+++ b/src/components/Panel/StatsReadout.tsx
@@ -7,14 +7,16 @@ export function StatsReadout() {
   if (!result) {
     return (
       <div className="panel-section">
-        <h3>Results</h3>
+        {/* SEO: Use sequential heading tags (H2) to follow document outline initiated by H1 */}
+        <h2>Results</h2>
         <div style={{ color: 'var(--text-muted)', fontSize: 12 }}>Computing…</div>
       </div>
     );
   }
   return (
     <div className="panel-section">
-      <h3>Results <span className="badge">{result.computeTimeMs.toFixed(0)} ms</span></h3>
+      {/* SEO: Use sequential heading tags (H2) to follow document outline initiated by H1 */}
+      <h2>Results <span className="badge">{result.computeTimeMs.toFixed(0)} ms</span></h2>
       <div className="stat">
         <span className="stat-label">Max gain</span>
         <span className="stat-value accent">{result.maxGainDbi.toFixed(2)} dBi</span>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -172,7 +172,7 @@ label {
   margin-bottom: 10px;
 }
 
-.panel-section h3 {
+.panel-section h2 {
   font-size: 12px;
   font-weight: 700;
   text-transform: uppercase;


### PR DESCRIPTION
* 💡 What: Upgraded `<h3` heading tags to `<h2` across 11 control panel components, and updated the corresponding `.panel-section h2` CSS rule to maintain visual consistency. Added explanatory inline comments for the changes.
* 🎯 Why: The document outline previously skipped from `<h1` directly to `<h3` in the control panel sidebar, causing a semantic heading hierarchy violation that degrades understanding for search engine crawlers and screen reader accessibility.
* 📊 Value: Improves semantic structure and structural indexing without any visual layout changes.
* 🔬 Measurement: Verify in the DOM that the `h1` element containing "HF GAIN VISUALIZER" is followed logically by `h2` elements for the panel sections.

---
*PR created automatically by Jules for task [9291913414521943009](https://jules.google.com/task/9291913414521943009) started by @2fst4u*