### PR TITLE
Move Propagation card below polar plots card

### DIFF
--- a/src/components/Panel/ControlPanel.tsx
+++ b/src/components/Panel/ControlPanel.tsx
@@ -42,9 +42,9 @@ export function ControlPanel() {
       <GroundControl />
       <FeedlineControl />
       <StatsReadout />
-      <PropagationControl />
       <SWRChart />
       <PolarPlots />
+      <PropagationControl />
       <DisplayControl />
 
       <div style={{


### PR DESCRIPTION
Reordered the sidebar components in `src/components/Panel/ControlPanel.tsx` to move the Propagation control card below the Polar Plots card. Verified the change visually via automated screenshots and ensured all existing tests pass.

Fixes #91

---
*PR created automatically by Jules for task [2913156260818355857](https://jules.google.com/task/2913156260818355857) started by @2fst4u*