### PR TITLE
🎨 Palette: Improve propagation control accessibility (ARIA hints and live regions)

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -9,3 +9,7 @@
 ## 2024-05-04 - Keyboard Navigation Focus Indicators
 **Learning:** Found that keyboard navigation was lacking explicit visual feedback (`:focus-visible`) across the UI, particularly for interactive elements like buttons, inputs, and selects. Adding global `:focus-visible` styles with a high-contrast accent color greatly improves keyboard accessibility without negatively impacting mouse users.
 **Action:** Always verify keyboard accessibility and add clear `:focus-visible` styles to interactive elements when building out new UIs or auditing existing ones.
+
+## 2024-05-05 - Propagation Control ARIA Additions
+**Learning:** In complex control panels, async UI state (like geolocation requesting) requires explicit `aria-live` and `aria-busy` announcements so screen readers know a background action is pending and eventually completed. Furthermore, supplementary help text near inputs must be explicitly linked via `aria-describedby` so it isn't skipped when users tab directly to the input field.
+**Action:** Always verify `aria-busy` and `aria-live` are present for async button interactions, and link form hints to their associated inputs using matching `id` and `aria-describedby` attributes.

--- a/src/components/Panel/PropagationControl.tsx
+++ b/src/components/Panel/PropagationControl.tsx
@@ -113,6 +113,7 @@ export function PropagationControl() {
           step={1}
           value={localTIndex}
           aria-label="Ionospheric T-index"
+          aria-describedby="t-index-hint"
           onFocus={() => setIsTIndexFocused(true)}
           onChange={(e) => {
             const s = e.target.value;
@@ -126,7 +127,7 @@ export function PropagationControl() {
           }}
         />
       </div>
-      <p style={{ fontSize: 11, color: 'var(--text-muted)', margin: '4px 0 10px' }}>
+      <p id="t-index-hint" style={{ fontSize: 11, color: 'var(--text-muted)', margin: '4px 0 10px' }}>
         Australian IPS T-index. ~30 = quiet, ~100 = active. Look up today&apos;s
         value from your usual space-weather source.
       </p>
@@ -143,6 +144,7 @@ export function PropagationControl() {
           value={localLat}
           placeholder="0.0"
           aria-label="Latitude in degrees"
+          aria-describedby="lat-hint"
           onFocus={() => setIsLatFocused(true)}
           onChange={(e) => {
             const s = e.target.value;
@@ -159,13 +161,14 @@ export function PropagationControl() {
           type="button"
           onClick={() => { void requestLocation(); }}
           disabled={geoStatus === 'requesting'}
+          aria-busy={geoStatus === 'requesting'}
           style={{ flex: '0 0 auto' }}
           title="Use the browser geolocation API to populate latitude. Asks for permission only when clicked."
         >
           {geoStatus === 'requesting' ? 'Locating…' : 'Use my location'}
         </button>
       </div>
-      <p style={{ fontSize: 11, color: 'var(--text-muted)', margin: '4px 0 10px' }}>
+      <p id="lat-hint" aria-live="polite" style={{ fontSize: 11, color: 'var(--text-muted)', margin: '4px 0 10px' }}>
         {geoStatusMessage(geoStatus, latitudeDeg)}
       </p>
 
@@ -289,6 +292,8 @@ export function PropagationControl() {
       <button
         type="button"
         onClick={() => setShowAssumptions((v) => !v)}
+        aria-expanded={showAssumptions}
+        aria-controls="assumptions-panel"
         style={{
           marginTop: 10, background: 'transparent', border: 'none',
           color: 'var(--accent)', padding: 0, fontSize: 11, cursor: 'pointer',
@@ -297,7 +302,7 @@ export function PropagationControl() {
         {showAssumptions ? 'Hide model assumptions' : 'Model & assumptions'}
       </button>
       {showAssumptions && (
-        <div style={{ fontSize: 11, color: 'var(--text-muted)', marginTop: 6, lineHeight: 1.5 }}>
+        <div id="assumptions-panel" style={{ fontSize: 11, color: 'var(--text-muted)', marginTop: 6, lineHeight: 1.5 }}>
           <p style={{ marginTop: 0 }}>
             This is a closed-form approximation, not IRI / ASAPS / VOACAP.
             It captures the right monotonic behaviours (foF2 rises with


### PR DESCRIPTION
This PR introduces several semantic accessibility improvements to the `PropagationControl` component based on standard UI patterns:

1. **Input Hints:** The T-index and Latitude inputs now use `aria-describedby` to link to their respective help text and status paragraphs, ensuring screen reader users hear this context when focusing the inputs.
2. **Async Feedback:** The geolocation button now receives `aria-busy` while requesting, and the resulting status text paragraph uses `aria-live="polite"` so the user is informed when the location is successfully found (or fails).
3. **Disclosure Toggle:** The "Model & assumptions" button correctly implements `aria-expanded` and `aria-controls` to associate it with the expandable content panel.

These are zero-risk, HTML-attribute-only changes that significantly improve the experience for assistive technology users without altering visual styles or core logic.

---
*PR created automatically by Jules for task [18198247382282728529](https://jules.google.com/task/18198247382282728529) started by @2fst4u*