### PR TITLE
🧹 Sweep: Remove unused exports from antennaStore.ts

### DIFF
--- a/src/store/antennaStore.ts
+++ b/src/store/antennaStore.ts
@@ -397,7 +397,7 @@ export const FEEDLINE_SHIELD_TAG = 4; // coax shield (radiating outer surface)
  * is well-defined; small enough to keep NEC fast but large enough to
  * resolve common-mode current variation along a multi-wavelength run.
  */
-export const FEEDLINE_SHIELD_SEGMENTS = 11;
+const FEEDLINE_SHIELD_SEGMENTS = 11;
 
 /**
  * Physical length of the source bridge — the small wire segment that
@@ -406,7 +406,7 @@ export const FEEDLINE_SHIELD_SEGMENTS = 11;
  * but long enough to satisfy NEC's segment-vs-radius geometry rules at
  * typical HF wire radii (≤ ~5 mm).
  */
-export const FEEDLINE_BRIDGE_LENGTH_M = 0.05;
+const FEEDLINE_BRIDGE_LENGTH_M = 0.05;
 
 /** Minimum gap (m) between the bottom of the shield wire and the ground
  * plane, to avoid NEC's "wire touching ground" warning. */


### PR DESCRIPTION
💡 What:
Removed the `export` keyword from `FEEDLINE_SHIELD_SEGMENTS` and `FEEDLINE_BRIDGE_LENGTH_M` in `src/store/antennaStore.ts`.

🎯 Why:
These constants are only used internally within `src/store/antennaStore.ts` and in a comment within `tests/nec2Engine.integration.test.ts`. Exposing them externally via `export` increases the module's public API surface area unnecessarily, cluttering the codebase.

🔬 Verification:
Used `npx knip` to verify these exports were unused. 
After removing the exports, reran `npx knip` which confirmed they are no longer reported as unused.
Reran `npm run lint`, `npm run build`, and `npm run test` to verify that this cleanup was safe and introduced no breaking changes.

---
*PR created automatically by Jules for task [11922121907354741374](https://jules.google.com/task/11922121907354741374) started by @2fst4u*