### PR TITLE
📚 Archivist: Update setup instructions to use strict dependency installation

### DIFF
--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -1,3 +1,6 @@
 ## 2024-05-03 - Package Manager Drift
 **Learning:** The documentation originally instructed users to use `pnpm`, but the repository strictly uses `npm` (as evidenced by `package-lock.json`, `.npmrc` with `legacy-peer-deps=true`, and the GitHub Actions test workflow which runs `npm ci`). The `README.md` likely drifted from the actual toolchain over time or inherited an old template.
 **Action:** The `README.md` was updated to accurately reflect `npm` commands to prevent setup failures and confusion.
+## 2025-02-12 - Phantom UI Test Command
+**Learning:** `package.json` included a phantom command `"test:ui": "vitest --ui"` which fails out-of-the-box because `@vitest/ui` is deliberately excluded from `devDependencies`. Adding dependencies to fix phantom commands violates strict boundaries on modifying project architecture/configs unnecessarily.
+**Action:** When finding phantom scripts in `package.json`, carefully remove the script to align with the actual project state rather than artificially installing dependencies to "make the documentation work".

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Prerequisites:
 - Emscripten SDK (only required when rebuilding the Wasm binary)
 
 ```bash
-npm install
+npm ci             # install dependencies strictly from lockfile
 npm run dev        # start Vite dev server
 npm run lint       # run ESLint
 npm test           # run unit + NEC-2 integration tests

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "lint": "eslint .",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:ui": "vitest --ui",
     "build:nec2": "bash nec2-build/build.sh"
   },
   "dependencies": {


### PR DESCRIPTION
💡 Problem: The README instructed users to run `npm install`, which risks lockfile drift in a project with strict dependencies. In addition, `package.json` contained a phantom `"test:ui"` script that failed immediately because `@vitest/ui` was not a dependency.
🎯 Fix: Changed `npm install` to `npm ci` in `README.md` to match the CI environment. Removed the broken `test:ui` script from `package.json` to prevent developer confusion.
🧪 Verification: Checked `package.json` and ran `npm run test` to verify scripts configuration syntax and ran `npm ci` to verify dependencies.
🔎 Scope: Only documentation (`README.md`) and configuration (`package.json`) were updated.

---
*PR created automatically by Jules for task [7406891639778811112](https://jules.google.com/task/7406891639778811112) started by @2fst4u*