### PR TITLE
🛡️ Sentinel: [Security Improvement] Enhance Security Headers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,7 @@
 **Vulnerability:** Found 3 high-severity vulnerabilities in a transitive development dependency (`serialize-javascript` via `vite-plugin-pwa`).
 **Learning:** `npm audit fix` successfully resolves transitively vulnerable packages without requiring overrides, by correctly bumping the lockfile entries for the dependents (`@rollup/plugin-terser` -> `workbox-build`). This emphasizes that build-time dependencies should also be kept secure to maintain a healthy project state.
 **Prevention:** Regularly run `npm audit` and use `npm audit fix` to maintain lockfile security, confirming success via tests before submission.
+## 2026-05-06 - Enhance Permissions-Policy and add Cross-Origin-Opener-Policy
+**Vulnerability:** Weak default Permissions-Policy and missing Cross-Origin-Opener-Policy in public/_headers
+**Learning:** Adding a more comprehensive Permissions-Policy restricting sensitive APIs (camera, microphone, payment) and ensuring geolocation is restricted to (self), as well as adding Cross-Origin-Opener-Policy, creates strong defense-in-depth against unauthorized API access and side-channel attacks for WASM apps.
+**Prevention:** Always verify if new device APIs need explicit opt-out in Permissions-Policy, especially for applications dealing with WASM execution, and ensure strong process isolation.

--- a/public/_headers
+++ b/public/_headers
@@ -8,6 +8,8 @@
   # Protect sensitive information in the referrer header
   Referrer-Policy: strict-origin-when-cross-origin
   # Opt-out of FLoC and restricts sensitive APIs, acting as a defense-in-depth measure
-  Permissions-Policy: interest-cohort=()
+  Permissions-Policy: accelerometer=(), camera=(), geolocation=(self), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=(), interest-cohort=()
   # Content Security Policy to enforce secure content delivery and prevent XSS
   Content-Security-Policy: default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; worker-src 'self' blob:; object-src 'none';
+  # Isolate the browsing context to same-origin to prevent cross-origin info leaks
+  Cross-Origin-Opener-Policy: same-origin


### PR DESCRIPTION
Enhances the application's defense-in-depth posture by explicitly restricting sensitive APIs (e.g., camera, microphone, payment) in the `Permissions-Policy` header, whilst preserving necessary `geolocation=(self)` access. Adds `Cross-Origin-Opener-Policy: same-origin` to ensure correct process isolation which is highly recommended for applications executing WebAssembly (WASM).

---
*PR created automatically by Jules for task [7802494100697844661](https://jules.google.com/task/7802494100697844661) started by @2fst4u*