### PR TITLE
🎨 Palette: [UX improvement] Link form helper text using aria-describedby

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -13,3 +13,6 @@
 ## 2024-05-05 - Propagation Control ARIA Additions
 **Learning:** In complex control panels, async UI state (like geolocation requesting) requires explicit `aria-live` and `aria-busy` announcements so screen readers know a background action is pending and eventually completed. Furthermore, supplementary help text near inputs must be explicitly linked via `aria-describedby` so it isn't skipped when users tab directly to the input field.
 **Action:** Always verify `aria-busy` and `aria-live` are present for async button interactions, and link form hints to their associated inputs using matching `id` and `aria-describedby` attributes.
+## 2024-05-06 - Dynamic Form Hints and ARIA describedby
+**Learning:** Adding dynamic, contextual helper text below form controls (like `<select>` dropdowns or `<input>` ranges) is a common pattern in the side panels. However, without an explicit `aria-describedby` mapping, screen reader users miss this critical context when they navigate directly to the input via keyboard tabbing.
+**Action:** Always wrap supplementary helper text in a `div` or `span` with a unique `id`, and link it to the associated interactive control using the `aria-describedby` attribute. This ensures screen readers announce the helper text alongside the input label.

--- a/src/components/Panel/FeedlineControl.tsx
+++ b/src/components/Panel/FeedlineControl.tsx
@@ -53,12 +53,13 @@ export function FeedlineControl() {
         id="feedline-preset"
         value={feedlineId}
         onChange={(e) => setFeedline(e.target.value)}
+        aria-describedby="feedline-hint"
       >
         {FEEDLINE_PRESETS.map((f) => (
           <option key={f.id} value={f.id}>{f.label}</option>
         ))}
       </select>
-      <div style={{ marginTop: 6, fontSize: 11, color: 'var(--text-muted)' }}>
+      <div id="feedline-hint" style={{ marginTop: 6, fontSize: 11, color: 'var(--text-muted)' }}>
         {preset.hint}
       </div>
 
@@ -100,6 +101,7 @@ export function FeedlineControl() {
               max={dispOffsetLimit}
               step={units === 'metric' ? 0.05 : 0.25}
               value={dispOffset}
+              aria-describedby="feedline-offset-hint"
               onChange={(e) => {
                 const val = parseFloat(e.target.value);
                 if (!isNaN(val)) setFeedlineOffset(fromDisplayLength(val, units));
@@ -114,7 +116,7 @@ export function FeedlineControl() {
               Centre
             </button>
           </div>
-          <div style={{ marginTop: 4, fontSize: 11, color: 'var(--text-muted)' }}>
+          <div id="feedline-offset-hint" style={{ marginTop: 4, fontSize: 11, color: 'var(--text-muted)' }}>
             {Math.abs(feedlineOffset) < 1e-6
               ? 'Centred (perfectly balanced — no common-mode current).'
               : `Shifted ${Math.abs(dispOffset).toFixed(2)} ${unit} ${feedlineOffset > 0 ? '+ axis' : '− axis'}; common-mode current will flow on the shield.`}
@@ -135,11 +137,12 @@ export function FeedlineControl() {
               type="checkbox"
               checked={balunEnabled}
               onChange={(e) => setBalunEnabled(e.target.checked)}
+              aria-describedby="balun-hint"
               style={{ width: 'auto' }}
             />
             <span>1:1 current (choke) balun at feedpoint</span>
           </label>
-          <div style={{ marginTop: 4, fontSize: 11, color: 'var(--text-muted)' }}>
+          <div id="balun-hint" style={{ marginTop: 4, fontSize: 11, color: 'var(--text-muted)' }}>
             {balunEnabled
               ? 'Suppresses common-mode current on shield (~2 kΩ choke).'
               : 'Unchoked: shield can radiate. Pattern may distort.'}

--- a/src/components/Panel/GroundControl.tsx
+++ b/src/components/Panel/GroundControl.tsx
@@ -45,13 +45,13 @@ export function GroundControl() {
           {expanded ? 'Simple' : 'Custom'}
         </button>
       </h2>
-      <select aria-label="Ground preset" value={groundId} onChange={(e) => setGround(e.target.value)}>
+      <select aria-label="Ground preset" value={groundId} onChange={(e) => setGround(e.target.value)} aria-describedby="ground-hint">
         {GROUND_PRESETS.map((g) => (
           <option key={g.id} value={g.id}>{g.label}</option>
         ))}
         <option value="custom">Custom…</option>
       </select>
-      <div aria-live="polite" style={{ marginTop: 6, fontSize: 11, color: 'var(--text-muted)' }}>
+      <div id="ground-hint" aria-live="polite" style={{ marginTop: 6, fontSize: 11, color: 'var(--text-muted)' }}>
         {GROUND_PRESETS.find((g) => g.id === groundId)?.hint ?? 'Custom ground parameters.'}
       </div>
       {(expanded || groundId === 'custom') && (

--- a/src/components/Panel/ModeSelector.tsx
+++ b/src/components/Panel/ModeSelector.tsx
@@ -14,7 +14,7 @@ export function ModeSelector() {
     <div className="panel-section">
       {/* SEO: Use sequential heading tags (H2) to follow document outline initiated by H1 */}
       <h2 id="mode-selector-heading">Mode</h2>
-      <div className="button-group" role="group" aria-labelledby="mode-selector-heading">
+      <div className="button-group" role="group" aria-labelledby="mode-selector-heading" aria-describedby="mode-hint">
         {MODES.map((m) => (
           <button
             key={m.id}
@@ -25,7 +25,7 @@ export function ModeSelector() {
           >{m.label}</button>
         ))}
       </div>
-      <div aria-live="polite" style={{ marginTop: 6, fontSize: 11, color: 'var(--text-muted)' }}>
+      <div id="mode-hint" aria-live="polite" style={{ marginTop: 6, fontSize: 11, color: 'var(--text-muted)' }}>
         {MODES.find((m) => m.id === mode)!.hint}
       </div>
     </div>


### PR DESCRIPTION
This PR improves screen reader accessibility across the application's control panels by correctly linking helper text to their corresponding form inputs.

**What was changed:**
* **GroundControl**: Added `id="ground-hint"` to the preset helper text and linked it via `aria-describedby` to the `<select>`.
* **FeedlineControl**: Added `id`s for the cable hint, offset hint, and balun hint, linking them to their respective inputs (`<select>`, range `<input>`, and checkbox).
* **ModeSelector**: Added an `id` to the active mode hint text and linked the `role="group"` button group to it using `aria-describedby`.

**Why:**
Helper text provides vital context (e.g., explaining that offset causes common-mode current, or what a "Sea water" ground preset implies). Before this change, screen reader users tabbing directly to the inputs would not hear this supplementary text. This change fulfills standard accessibility (a11y) requirements and provides a much better audio-navigable experience.

---
*PR created automatically by Jules for task [9773979655482793254](https://jules.google.com/task/9773979655482793254) started by @2fst4u*