### PR TITLE
🧪 Spec: Add useGeolocation hook tests

### DIFF
--- a/.jules/spec.md
+++ b/.jules/spec.md
@@ -13,3 +13,6 @@
 **Learning:** Testing component behaviour interacting directly with Zustand state via `useAntennaStore.setState()` ensures we evaluate application effects rather than isolated mocks. Also, it might be necessary to reset state with `cleanup()` or `afterEach()` hooks when doing continuous updates to components to prevent pollution of consecutive tests.
 
 **Action:** Write test scenarios mapping closely user flows (like toggling an option off and verifying the opposite behaviour occurs and the classname reflects this correctly) instead of internal behaviour.
+## 2026-05-07 - useGeolocation Coverage Bump
+**Learning:** Testing custom React hooks that interact directly with browser APIs like `navigator.geolocation` in Vitest requires mocking global objects. Also, the hooks can be successfully tested by using `renderHook` and `act` from `@testing-library/react`.
+**Action:** Added tests covering successful cases, permission denied, timeouts, and unhandled errors for the geolocation API hook and ensured store state updates align correctly.

--- a/tests/useGeolocation.test.ts
+++ b/tests/useGeolocation.test.ts
@@ -45,7 +45,7 @@ describe('useGeolocation', () => {
 
   it('handles successful geolocation', async () => {
     const mockGeolocation = {
-      getCurrentPosition: vi.fn().mockImplementation((success, error, options) => {
+      getCurrentPosition: vi.fn().mockImplementation((success) => {
         success({
           coords: {
             latitude: 51.5074,
@@ -76,7 +76,7 @@ describe('useGeolocation', () => {
 
   it('handles permission denied', async () => {
     const mockGeolocation = {
-      getCurrentPosition: vi.fn().mockImplementation((success, error, options) => {
+      getCurrentPosition: vi.fn().mockImplementation((_success, error) => {
         error({ code: 1, message: 'User denied geolocation prompt' });
       }),
     };
@@ -100,7 +100,7 @@ describe('useGeolocation', () => {
 
   it('handles timeout error', async () => {
     const mockGeolocation = {
-      getCurrentPosition: vi.fn().mockImplementation((success, error, options) => {
+      getCurrentPosition: vi.fn().mockImplementation((_success, error) => {
         error({ code: 3, message: 'Timeout' });
       }),
     };
@@ -124,7 +124,7 @@ describe('useGeolocation', () => {
 
   it('handles unknown/other error', async () => {
     const mockGeolocation = {
-      getCurrentPosition: vi.fn().mockImplementation((success, error, options) => {
+      getCurrentPosition: vi.fn().mockImplementation((_success, error) => {
         error({ code: 2, message: 'Position unavailable' });
       }),
     };

--- a/tests/useGeolocation.test.ts
+++ b/tests/useGeolocation.test.ts
@@ -1,0 +1,148 @@
+import { renderHook, act, cleanup } from '@testing-library/react';
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import { useGeolocation } from '../src/hooks/useGeolocation';
+import { useAntennaStore } from '../src/store/antennaStore';
+
+describe('useGeolocation', () => {
+  beforeEach(() => {
+    useAntennaStore.setState({
+      geolocationStatus: 'idle',
+      latitudeDeg: null,
+      longitudeDeg: null,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    cleanup();
+  });
+
+  it('handles unsupported geolocation', async () => {
+    const originalNavigator = global.navigator;
+    Object.defineProperty(global, 'navigator', {
+      value: { ...originalNavigator, geolocation: undefined },
+      writable: true,
+      configurable: true,
+    });
+
+    const { result } = renderHook(() => useGeolocation());
+
+    let res;
+    await act(async () => {
+      res = await result.current.requestLocation();
+    });
+
+    expect(res).toEqual({ ok: false, reason: 'unsupported' });
+    expect(useAntennaStore.getState().geolocationStatus).toBe('unsupported');
+
+    // Restore navigator
+    Object.defineProperty(global, 'navigator', {
+      value: originalNavigator,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  it('handles successful geolocation', async () => {
+    const mockGeolocation = {
+      getCurrentPosition: vi.fn().mockImplementation((success, error, options) => {
+        success({
+          coords: {
+            latitude: 51.5074,
+            longitude: -0.1278,
+          },
+        });
+      }),
+    };
+
+    Object.defineProperty(global.navigator, 'geolocation', {
+      value: mockGeolocation,
+      writable: true,
+      configurable: true,
+    });
+
+    const { result } = renderHook(() => useGeolocation());
+
+    let res;
+    await act(async () => {
+      res = await result.current.requestLocation();
+    });
+
+    expect(res).toEqual({ ok: true, latitudeDeg: 51.5074, longitudeDeg: -0.1278 });
+    expect(useAntennaStore.getState().geolocationStatus).toBe('granted');
+    expect(useAntennaStore.getState().latitudeDeg).toBe(51.5074);
+    expect(useAntennaStore.getState().longitudeDeg).toBe(-0.1278);
+  });
+
+  it('handles permission denied', async () => {
+    const mockGeolocation = {
+      getCurrentPosition: vi.fn().mockImplementation((success, error, options) => {
+        error({ code: 1, message: 'User denied geolocation prompt' });
+      }),
+    };
+
+    Object.defineProperty(global.navigator, 'geolocation', {
+      value: mockGeolocation,
+      writable: true,
+      configurable: true,
+    });
+
+    const { result } = renderHook(() => useGeolocation());
+
+    let res;
+    await act(async () => {
+      res = await result.current.requestLocation();
+    });
+
+    expect(res).toEqual({ ok: false, reason: 'denied' });
+    expect(useAntennaStore.getState().geolocationStatus).toBe('denied');
+  });
+
+  it('handles timeout error', async () => {
+    const mockGeolocation = {
+      getCurrentPosition: vi.fn().mockImplementation((success, error, options) => {
+        error({ code: 3, message: 'Timeout' });
+      }),
+    };
+
+    Object.defineProperty(global.navigator, 'geolocation', {
+      value: mockGeolocation,
+      writable: true,
+      configurable: true,
+    });
+
+    const { result } = renderHook(() => useGeolocation());
+
+    let res;
+    await act(async () => {
+      res = await result.current.requestLocation();
+    });
+
+    expect(res).toEqual({ ok: false, reason: 'timeout' });
+    expect(useAntennaStore.getState().geolocationStatus).toBe('error');
+  });
+
+  it('handles unknown/other error', async () => {
+    const mockGeolocation = {
+      getCurrentPosition: vi.fn().mockImplementation((success, error, options) => {
+        error({ code: 2, message: 'Position unavailable' });
+      }),
+    };
+
+    Object.defineProperty(global.navigator, 'geolocation', {
+      value: mockGeolocation,
+      writable: true,
+      configurable: true,
+    });
+
+    const { result } = renderHook(() => useGeolocation());
+
+    let res;
+    await act(async () => {
+      res = await result.current.requestLocation();
+    });
+
+    expect(res).toEqual({ ok: false, reason: 'error' });
+    expect(useAntennaStore.getState().geolocationStatus).toBe('error');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,10 +9,10 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       thresholds: {
-        statements: 49,
-        branches: 35,
-        functions: 54,
-        lines: 62,
+        statements: 53,
+        branches: 40,
+        functions: 58,
+        lines: 68,
       }
     }
   },


### PR DESCRIPTION
💡 What: Added comprehensive unit tests for `useGeolocation.ts` to mock browser geolocation API states (granted, denied, unsupported, timeout, error).
🎯 Why: `useGeolocation.ts` had zero test coverage despite being critical for propagation modeling UX. This fortifies the project.
📈 Maturity Impact: Bumped overall global coverage thresholds in `vitest.config.ts`: Statements (49->53), Branches (35->40), Functions (54->58), Lines (62->68) to lock in progress toward business standards.

---
*PR created automatically by Jules for task [4367355105014525683](https://jules.google.com/task/4367355105014525683) started by @2fst4u*