### PR TITLE
🔭 Scout: Add canonical URL to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,9 @@
     <meta name="color-scheme" content="dark light" />
     <meta name="description" content="HF antenna gain visualiser — 3D radiation patterns powered by NEC-2 WebAssembly." />
 
+    <!-- SEO: Define canonical URL to prevent duplicate content indexing -->
+    <link rel="canonical" href="https://www.gain.observer/" />
+
     <!-- Open Graph Metadata -->
     <meta property="og:title" content="HF Gain Visualiser" />
     <meta property="og:description" content="HF antenna gain visualiser — 3D radiation patterns powered by NEC-2 WebAssembly." />


### PR DESCRIPTION
### 💡 What
Added a `<link rel="canonical" href="https://www.gain.observer/" />` tag to the `<head>` section of `index.html`.

### 🎯 Why
To explicitly define the preferred URL for search engines. This prevents duplicate content issues that can dilute search rankings if the site is accessible via different variations (e.g., query parameters, non-www).

### 📊 Value
Improves search engine indexing clarity, ensuring that the primary domain (`https://www.gain.observer/`) consolidates all ranking signals and avoids duplicate content penalties.

### 🔬 Measurement
Verify the DOM output of `index.html` contains `<link rel="canonical" href="https://www.gain.observer/" />` in the `<head>` block.

---
*PR created automatically by Jules for task [7297925542868003945](https://jules.google.com/task/7297925542868003945) started by @2fst4u*