### PR TITLE
🛡️ Sentinel: [MEDIUM] Add input validation for localstorage writes

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -10,3 +10,7 @@
 **Vulnerability:** Weak default Permissions-Policy and missing Cross-Origin-Opener-Policy in public/_headers
 **Learning:** Adding a more comprehensive Permissions-Policy restricting sensitive APIs (camera, microphone, payment) and ensuring geolocation is restricted to (self), as well as adding Cross-Origin-Opener-Policy, creates strong defense-in-depth against unauthorized API access and side-channel attacks for WASM apps.
 **Prevention:** Always verify if new device APIs need explicit opt-out in Permissions-Policy, especially for applications dealing with WASM execution, and ensure strong process isolation.
+## 2026-05-07 - Add Input Validation to LocalStorage Writes
+**Vulnerability:** Unvalidated state was being written to `localStorage` via `window.localStorage.setItem` using the Zustand store state. If an attacker managed to poison the store state, they could write excessively large payloads or malicious strings into `localStorage`.
+**Learning:** React hooks orchestrating persistence (`useTheme.ts`, `useUnits.ts`) validated data read from `localStorage`, but trusted internal state blindly when writing. This breaks the defense-in-depth security principle that all input boundaries, including internal ones persisting state, should be validated.
+**Prevention:** Always validate all data being serialized to `localStorage` even if it originates from an internal store. Enforce exact type or allowed-value checks before calling `setItem`.

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -21,6 +21,8 @@ export function useTheme(): void {
   // Apply + persist.
   useEffect(() => {
     document.documentElement.dataset.theme = theme;
-    window.localStorage.setItem(STORAGE_KEY, theme);
+    if (theme === 'dark' || theme === 'light') {
+      window.localStorage.setItem(STORAGE_KEY, theme);
+    }
   }, [theme]);
 }

--- a/src/hooks/useUnits.ts
+++ b/src/hooks/useUnits.ts
@@ -15,6 +15,8 @@ export function useUnitsPersistence(): void {
   }, [setUnits]);
 
   useEffect(() => {
-    window.localStorage.setItem(STORAGE_KEY, units);
+    if (units === 'metric' || units === 'imperial') {
+      window.localStorage.setItem(STORAGE_KEY, units);
+    }
   }, [units]);
 }


### PR DESCRIPTION
🛡️ Sentinel: Add explicit value validation boundaries before committing the application's Zustand state to the browser's persistent `localStorage`. This prevents state poisoning attacks from spilling over into storage exhaustion and follows defense-in-depth security principles.

- **useTheme.ts**: Validate theme state is either `dark` or `light` before `setItem`.
- **useUnits.ts**: Validate units state is either `metric` or `imperial` before `setItem`.

---
*PR created automatically by Jules for task [11499407799155354386](https://jules.google.com/task/11499407799155354386) started by @2fst4u*