### PR TITLE
🧪 Spec: Add tests for FrequencyControl

### DIFF
--- a/.jules/spec.md
+++ b/.jules/spec.md
@@ -16,3 +16,6 @@
 ## 2026-05-07 - useGeolocation Coverage Bump
 **Learning:** Testing custom React hooks that interact directly with browser APIs like `navigator.geolocation` in Vitest requires mocking global objects. Also, the hooks can be successfully tested by using `renderHook` and `act` from `@testing-library/react`.
 **Action:** Added tests covering successful cases, permission denied, timeouts, and unhandled errors for the geolocation API hook and ensured store state updates align correctly.
+## 2025-02-12 - Local string buffer synchronization test failure
+**Learning:** In `FrequencyControl.tsx`, typing an invalid value like 'abc' keeps the local string state as 'abc' but doesn't update the numeric store value. Our test asserted the input reverted to the store value, but our component's onBlur correctly synchronizes the store value which turns an invalid number to `''` or `NaN`, because `toFixed(3)` on the existing store value makes it revert to `14.150` but the test was checking for 'abc'.
+**Action:** Fixed the assertion to check that the local input reverts to the valid store value on blur.

--- a/tests/FrequencyControl.test.tsx
+++ b/tests/FrequencyControl.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { beforeEach, afterEach, describe, expect, it } from 'vitest';
+import { FrequencyControl } from '../src/components/Panel/FrequencyControl';
+import { useAntennaStore } from '../src/store/antennaStore';
+import { HF_BAND_PRESETS, halfWaveLength } from '../src/physics/constants';
+
+describe('FrequencyControl', () => {
+  beforeEach(() => {
+    useAntennaStore.setState({
+      frequency: 14.150,
+      length: halfWaveLength(14.150)
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders with the current frequency', () => {
+    render(<FrequencyControl />);
+    const input = screen.getByLabelText('Frequency in MHz') as HTMLInputElement;
+    expect(input.value).toBe('14.150');
+  });
+
+  it('updates local state on change but syncs with store on blur', () => {
+    render(<FrequencyControl />);
+    const input = screen.getByLabelText('Frequency in MHz') as HTMLInputElement;
+
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: '14.2' } });
+
+    expect(useAntennaStore.getState().frequency).toBe(14.2);
+    expect(input.value).toBe('14.2');
+
+    fireEvent.blur(input);
+    expect(input.value).toBe('14.200');
+  });
+
+  it('handles clicking a band preset', () => {
+    render(<FrequencyControl />);
+
+    // Find the button for a specific preset, e.g., '10m'
+    const preset10m = HF_BAND_PRESETS.find(b => b.name === '10m')!;
+    const bandButton = screen.getByText('10m');
+    fireEvent.click(bandButton);
+
+    expect(useAntennaStore.getState().frequency).toBe(preset10m.mhz);
+    expect(useAntennaStore.getState().length).toBe(halfWaveLength(preset10m.mhz));
+  });
+
+  it('syncs localVal when store frequency changes externally', () => {
+    const { rerender } = render(<FrequencyControl />);
+
+    useAntennaStore.setState({ frequency: 28.5 });
+
+    rerender(<FrequencyControl />);
+
+    const input = screen.getByLabelText('Frequency in MHz') as HTMLInputElement;
+    expect(input.value).toBe('28.500');
+  });
+
+  it('ignores invalid number input', () => {
+    render(<FrequencyControl />);
+    const input = screen.getByLabelText('Frequency in MHz') as HTMLInputElement;
+
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: 'abc' } });
+
+    // Frequency should remain the original value 14.150
+    expect(useAntennaStore.getState().frequency).toBe(14.150);
+    expect(input.value).toBe('');
+
+    fireEvent.blur(input);
+    expect(input.value).toBe('14.150');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
         statements: 53,
         branches: 40,
         functions: 58,
-        lines: 68,
+        lines: 69,
       }
     }
   },


### PR DESCRIPTION
💡 What: Added unit tests for `FrequencyControl.tsx` and bumped global coverage lines threshold from 68% to 69%.
🎯 Why: `FrequencyControl.tsx` was entirely untested. This control logic validates input syncing logic and ensures band preset behavior functions correctly. 
📈 Maturity Impact: Bumped coverage threshold from 68% to 69% to lock in progress toward business standards.

---
*PR created automatically by Jules for task [15304030742887533474](https://jules.google.com/task/15304030742887533474) started by @2fst4u*