### PR TITLE
🧪 Spec: Add GroundControl test

### DIFF
--- a/.jules/spec.md
+++ b/.jules/spec.md
@@ -19,3 +19,9 @@
 ## 2025-02-12 - Local string buffer synchronization test failure
 **Learning:** In `FrequencyControl.tsx`, typing an invalid value like 'abc' keeps the local string state as 'abc' but doesn't update the numeric store value. Our test asserted the input reverted to the store value, but our component's onBlur correctly synchronizes the store value which turns an invalid number to `''` or `NaN`, because `toFixed(3)` on the existing store value makes it revert to `14.150` but the test was checking for 'abc'.
 **Action:** Fixed the assertion to check that the local input reverts to the valid store value on blur.
+## 2025-02-12 - Missing tests for GroundControl.tsx
+**Learning:** Component test files must cover interactions like expanding custom ground menus and changing nested field inputs (, ) when 'custom' ground preset is active.
+**Action:** Created  and increased  and  test coverage limits in .
+## 2025-02-12 - Missing tests for GroundControl.tsx
+**Learning:** Component test files must cover interactions like expanding custom ground menus and changing nested field inputs (groundSigma, groundEpsilon) when 'custom' ground preset is active.
+**Action:** Created tests/GroundControl.test.tsx and increased branches and functions test coverage limits in vitest.config.ts.

--- a/tests/GroundControl.test.tsx
+++ b/tests/GroundControl.test.tsx
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { GroundControl } from '../src/components/Panel/GroundControl';
+import { useAntennaStore } from '../src/store/antennaStore';
+
+// Mock the store
+vi.mock('../src/store/antennaStore', async () => {
+  const actual = await vi.importActual('../src/store/antennaStore');
+  return {
+    ...actual,
+    useAntennaStore: vi.fn(),
+  };
+});
+
+interface MockState {
+  groundId: string;
+  groundSigma: number;
+  groundEpsilon: number;
+  setGround: (id: string) => void;
+  setCustomGround: (sigma: number, epsilon: number) => void;
+}
+
+describe('GroundControl', () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('updates groundId when selection changes', () => {
+    const setGround = vi.fn();
+    vi.mocked(useAntennaStore).mockImplementation((selector: (s: MockState) => unknown) => {
+      const state: MockState = {
+        groundId: 'pastoral',
+        groundSigma: 0.005,
+        groundEpsilon: 13,
+        setGround,
+        setCustomGround: vi.fn(),
+      };
+      return selector(state);
+    });
+
+    render(<GroundControl />);
+
+    const select = screen.getByRole('combobox', { name: 'Ground preset' });
+    fireEvent.change(select, { target: { value: 'sea' } });
+
+    expect(setGround).toHaveBeenCalledWith('sea');
+  });
+
+  it('shows custom inputs and updates them when custom is selected', () => {
+    const setCustomGround = vi.fn();
+    vi.mocked(useAntennaStore).mockImplementation((selector: (s: MockState) => unknown) => {
+      const state: MockState = {
+        groundId: 'custom',
+        groundSigma: 0.005,
+        groundEpsilon: 13,
+        setGround: vi.fn(),
+        setCustomGround,
+      };
+      return selector(state);
+    });
+
+    render(<GroundControl />);
+
+    const sigmaInput = screen.getByLabelText('Conductivity σ (S/m)');
+    fireEvent.change(sigmaInput, { target: { value: '0.01' } });
+    expect(setCustomGround).toHaveBeenCalledWith(0.01, 13);
+
+    const epsilonInput = screen.getByLabelText('Permittivity εr');
+    fireEvent.change(epsilonInput, { target: { value: '15' } });
+    expect(setCustomGround).toHaveBeenCalledWith(0.005, 15);
+  });
+
+  it('shows custom inputs when expanded button is clicked', () => {
+    vi.mocked(useAntennaStore).mockImplementation((selector: (s: MockState) => unknown) => {
+      const state: MockState = {
+        groundId: 'pastoral',
+        groundSigma: 0.005,
+        groundEpsilon: 13,
+        setGround: vi.fn(),
+        setCustomGround: vi.fn(),
+      };
+      return selector(state);
+    });
+
+    render(<GroundControl />);
+
+    // Initially custom inputs are not visible
+    expect(screen.queryByLabelText('Conductivity σ (S/m)')).toBeNull();
+    expect(screen.queryByLabelText('Permittivity εr')).toBeNull();
+
+    const expandButton = screen.getByRole('button', { name: /Custom/i });
+    fireEvent.click(expandButton);
+
+    // After clicking, they should be visible
+    expect(screen.getByLabelText('Conductivity σ (S/m)')).toBeDefined();
+    expect(screen.getByLabelText('Permittivity εr')).toBeDefined();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,8 +10,8 @@ export default defineConfig({
       provider: 'v8',
       thresholds: {
         statements: 53,
-        branches: 40,
-        functions: 58,
+        branches: 41,
+        functions: 59,
         lines: 69,
       }
     }


### PR DESCRIPTION
💡 What: Created a new robust test file for `GroundControl.tsx` that uses the `useAntennaStore` mocking strategy. It ensures the standard ground presets update correctly and that custom conductivity and permittivity fields can be edited and toggled.
🎯 Why: `GroundControl.tsx` lacked test coverage, which left its complex custom input toggling logic uncovered. This fix helps ensure CI doesn't miss regressions during refactors.
📈 Maturity Impact: Bumped global functions coverage threshold from 58% to 59%, and branches from 40% to 41% to lock in progress toward business standards.

---
*PR created automatically by Jules for task [8797537257460041859](https://jules.google.com/task/8797537257460041859) started by @2fst4u*