### PR TITLE
🎨 Palette: Fix accessibility for Comparison Control button group

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -19,3 +19,7 @@
 ## 2024-05-08 - Dynamic Tooltips for Disabled States
 **Learning:** In dense control panels (like this app), disabling utility buttons without explanation causes user friction. Users often cannot tell why an action (like "Capture Reference" or "Centre Feedline") is unavailable. Providing dynamic tooltips on disabled buttons significantly improves discoverability and clarifies system state.
 **Action:** Always add dynamic `title` or `aria-label` properties that change when a button is `disabled`, clearly explaining the constraint.
+
+## 2024-05-18 - Missing Button Group Roles
+**Learning:** The `ComparisonControl.tsx` had a `.button-group` component lacking the `role="group"` and `aria-label` attribute, which prevented screen readers from correctly announcing the options as part of a coherent group.
+**Action:** Always ensure `.button-group` elements have the required ARIA grouping attributes.

--- a/src/components/Panel/ComparisonControl.tsx
+++ b/src/components/Panel/ComparisonControl.tsx
@@ -23,7 +23,7 @@ export function ComparisonControl() {
       <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>
         Freeze the current antenna as the left-hand reference, then change the live controls to compare against it.
       </div>
-      <div className="button-group" style={{ marginTop: 10 }}>
+      <div className="button-group" role="group" aria-label="Comparison Actions" style={{ marginTop: 10 }}>
         <button
           className="primary"
           onClick={captureReference}


### PR DESCRIPTION
🎨 Palette: Fix accessibility for Comparison Control button group

💡 What: Added `role="group"` and `aria-label="Comparison Actions"` to the button group in `ComparisonControl.tsx`.
🎯 Why: Without these ARIA attributes, screen readers do not announce the buttons ("Use current as reference" and "Clear reference") as part of a coherent group, hindering discoverability and context for visually impaired users.
♿ Accessibility: Improves WCAG compliance and standardizes toggle group behavior within the sidebar panels.

---
*PR created automatically by Jules for task [17999557170957887318](https://jules.google.com/task/17999557170957887318) started by @2fst4u*