### PR TITLE
🧹 Sweep: Remove leftover debug logs from physics worker

### DIFF
--- a/src/workers/physicsWorker.ts
+++ b/src/workers/physicsWorker.ts
@@ -29,7 +29,6 @@ self.addEventListener('unhandledrejection', (ev: PromiseRejectionEvent) => {
   console.error('[worker unhandledrejection]', ev.reason);
 });
 
-console.log('[worker] booting, creating engine');
 
 const engine = new Nec2Engine({
   // The worker is served from the same origin as the app, so "/" resolves
@@ -43,7 +42,6 @@ const SWEEP_SPAN_FRACTION = 0.2;
 engine
   .init()
   .then(() => {
-    console.log('[worker] engine init complete, posting ready');
     ctx.postMessage({ type: 'ready' } satisfies WorkerResponse);
   })
   .catch((err: unknown) => {


### PR DESCRIPTION
### What
Removed stray `console.log` statements in `src/workers/physicsWorker.ts` that were logging `[worker] booting, creating engine` and `[worker] engine init complete, posting ready`.

### Why
These logs were leftover debug artifacts from development and do not provide value in the production application. Removing them reduces console noise and aligns with Sweep's objective to eliminate dead code or artifacts without refactoring active logic.

### Verification
- Searched for `console.log` across the `src` directory to find leftover artifacts: `grep -rn "\bconsole.log\b" src/`
- Removed the target lines.
- Verified the build succeeds with `npm run build`.
- Verified the test suite passes with `npm run test` ensuring the removal of the logs had no side effects.

---
*PR created automatically by Jules for task [7589681167798789928](https://jules.google.com/task/7589681167798789928) started by @2fst4u*