### PR TITLE
📚 Archivist: Fix canonical domain URL drift in documentation

### DIFF
--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -4,3 +4,6 @@
 ## 2025-02-12 - Phantom UI Test Command
 **Learning:** `package.json` included a phantom command `"test:ui": "vitest --ui"` which fails out-of-the-box because `@vitest/ui` is deliberately excluded from `devDependencies`. Adding dependencies to fix phantom commands violates strict boundaries on modifying project architecture/configs unnecessarily.
 **Action:** When finding phantom scripts in `package.json`, carefully remove the script to align with the actual project state rather than artificially installing dependencies to "make the documentation work".
+## 2025-05-10 - Canonical Domain URL Drift
+**Learning:** The documentation and agent guidelines referenced the root domain `https://gain.observer` as the hosted URL, but the site's metadata (`index.html` canonical/og links) strictly enforces the `www` subdomain (`https://www.gain.observer/`). Inconsistent domain documentation can cause SEO confusion and duplicate indexing.
+**Action:** Ensure all documentation links pointing to the production application match the exact `rel="canonical"` URL defined in the application's main HTML entry point.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ These instructions are intended for AI tools and agents working on this reposito
 
 ## Application Hosting and Usage
 
-This application is primarily intended to be used at its hosted URL: **[gain.observer](https://gain.observer)**.
+This application is primarily intended to be used at its hosted URL: **[www.gain.observer](https://www.gain.observer/)**.
 
 While developers may fork or clone the repository to run it locally, you should **direct users to the live URL in the first instance** rather than focusing on local development instructions unless explicitly asked to help with local setup or contribution.
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # HF Antenna Gain Visualiser
 
-**Live App:** [gain.observer](https://gain.observer)
+**Live App:** [www.gain.observer](https://www.gain.observer/)
 
 A 3D, responsive, physics-accurate visualiser for HF antenna radiation patterns, powered by NEC-2 compiled to WebAssembly.
 
-While this repository is fully open source and developers are welcome to fork or clone it to run locally, the primary way to use the application is via the hosted URL at **[gain.observer](https://gain.observer)**.
+While this repository is fully open source and developers are welcome to fork or clone it to run locally, the primary way to use the application is via the hosted URL at **[www.gain.observer](https://www.gain.observer/)**.
 
 Current scope (Phase 1): horizontal dipoles, 1.8–30 MHz, real-ground support, offset feed points, feedlines & baluns, NVIS and comparison modes, SWR/polar cut charts, dark/light theming, metric/imperial toggle.
 


### PR DESCRIPTION
Updated the canonical URL from `https://gain.observer` to `https://www.gain.observer/` in both `README.md` and `AGENTS.md`, matching the `index.html` metadata. This resolves domain documentation drift. Also logged this learning in `.jules/archivist.md`.

---
*PR created automatically by Jules for task [860417017399686933](https://jules.google.com/task/860417017399686933) started by @2fst4u*