### PR TITLE
🔭 Scout: Add JSON-LD WebApplication Schema

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,24 @@
     <meta name="twitter:image" content="https://www.gain.observer/favicon.svg" />
 
     <title>HF Gain Visualiser</title>
+
+    <!-- SEO: Add JSON-LD structured data to help search engines understand the application type and core features -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "WebApplication",
+        "name": "HF Gain Visualiser",
+        "url": "https://www.gain.observer/",
+        "description": "HF antenna gain visualiser — 3D radiation patterns powered by NEC-2 WebAssembly.",
+        "applicationCategory": "DeveloperApplication",
+        "browserRequirements": "Requires WebAssembly support",
+        "softwareHelp": "https://github.com/2fst4u/gain-observer",
+        "offers": {
+          "@type": "Offer",
+          "price": "0"
+        }
+      }
+    </script>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
This PR adds `WebApplication` JSON-LD schema to `index.html` to improve the application's SEO discoverability.

### 💡 What
A `<script type="application/ld+json">` tag has been injected into the document `<head>`, populated with standard schema.org properties defining this site as a developer application utilizing WebAssembly.

### 🎯 Why
Search engines use structured data to better understand the content and purpose of a page. By explicitly defining the application context, we improve the chances of generating rich snippets in search engine result pages (SERPs) and provide clearer semantic meaning to crawlers.

### 📊 Value
Improves rich snippets in SERP and makes the purpose of the application unambiguously clear to search indexing bots, all without modifying the user-facing visual design or routing logic.

### 🔬 Measurement
Inspect the `<head>` of the built document to verify the `<script type="application/ld+json">` block is present and contains valid JSON. Tools like Google's Rich Results Test can be used to validate the schema.

---
*PR created automatically by Jules for task [831428849555839723](https://jules.google.com/task/831428849555839723) started by @2fst4u*