### PR TITLE
🔭 Scout: Semantic HTML upgrade for 3D scene panes

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -1,0 +1,3 @@
+## 2025-05-11 - [Inline Styles for SEO Semantics Overriding CSS]
+**Learning:** When upgrading a generic `<div>` to a semantic `<h2>` tag, attempting to fully clear browser default styles using inline styles (e.g. `style={{ fontSize: 'inherit' }}`) can inadvertently create a CSS specificity issue where the inline style aggressively overrides the component's actual target CSS class rules.
+**Action:** Only use inline styles to reset properties you know aren't governed by a local CSS class (e.g. `margin: 0`), and leave properties like `fontSize` alone so the `.class` rules can apply normally.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -98,14 +98,17 @@ function ScenePane({
   result: import('./physics/types').SimulationResult | null;
 }) {
   return (
-    <div className="scene-pane">
-      <div className="scene-pane-header">
-        <div className="scene-pane-title">{title}</div>
+    /* SEO: Upgrade div to section for better structural outline */
+    <section className="scene-pane" aria-labelledby={`scene-pane-title-${title.replace(/\s+/g, '-').toLowerCase()}`}>
+      {/* SEO: Use header for logical grouping of pane title */}
+      <header className="scene-pane-header">
+        {/* SEO: Use h2 to maintain proper heading hierarchy after h1 in ControlPanel */}
+        <h2 id={`scene-pane-title-${title.replace(/\s+/g, '-').toLowerCase()}`} className="scene-pane-title" style={{ margin: 0 }}>{title}</h2>
         <div className="scene-pane-subtitle">{subtitle}</div>
-      </div>
+      </header>
       <ColormapLegend result={result} />
       {children}
-    </div>
+    </section>
   );
 }
 


### PR DESCRIPTION
### 💡 What:
Upgraded `ScenePane` inside `src/App.tsx` from generic `<divs>` to semantic HTML5 structure `<section>`, `<header>`, and `<h2>`.

### 🎯 Why:
To provide search engines with a proper outline for the document, explicitly structuring the live visualization / comparison panes within the semantic meaning. The `<h1>` resides in `ControlPanel`, so replacing the generic div titles with `<h2 id="...">` restores a healthy, continuous header hierarchy.

### 📊 Value:
Improves indexability and accessibility for screen readers and bots parsing the application structure by giving clear regions and document outlining elements.

### 🔬 Measurement:
Observe the DOM output for `scene-pane`. You will now see `<section className="scene-pane" aria-labelledby="...">` followed by `<header>`, inside which an `<h2 id="..." className="scene-pane-title" style="margin: 0px;">` is present, visually identical to the original layout but semantically correct.

---
*PR created automatically by Jules for task [664896797528275584](https://jules.google.com/task/664896797528275584) started by @2fst4u*