### PR TITLE
🎨 Palette: Add proper tooltips and fix Label in Name violations

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -23,3 +23,7 @@
 ## 2024-05-18 - Missing Button Group Roles
 **Learning:** The `ComparisonControl.tsx` had a `.button-group` component lacking the `role="group"` and `aria-label` attribute, which prevented screen readers from correctly announcing the options as part of a coherent group.
 **Action:** Always ensure `.button-group` elements have the required ARIA grouping attributes.
+
+## 2024-05-24 - Resolving WCAG 2.5.3 Label in Name Violations
+**Learning:** Using an `aria-label` that completely overrides the visible text of a button (like `aria-label="Meters"` for a button showing "m") violates WCAG 2.5.3 (Label in Name). Speech recognition users might say "Click m" which won't work if the accessible name doesn't contain "m".
+**Action:** Always ensure the visible text is included within the `aria-label` (e.g., `aria-label="m (Meters)"`), and use the `title` attribute to provide the expanded tooltip for mouse users.

--- a/src/components/Panel/DipoleControl.tsx
+++ b/src/components/Panel/DipoleControl.tsx
@@ -86,7 +86,7 @@ export function DipoleControl() {
         <button
           onClick={setHalfWaveLength}
           title="Set length to resonant ½λ"
-          aria-label="Set length to resonant half wavelength"
+          aria-label="½λ (Set length to resonant half wavelength)"
         >
           ½λ
         </button>

--- a/src/components/Panel/UnitToggle.tsx
+++ b/src/components/Panel/UnitToggle.tsx
@@ -9,13 +9,15 @@ export function UnitToggle() {
         className={units === 'metric' ? 'active' : ''}
         onClick={() => setUnits('metric')}
         aria-pressed={units === 'metric'}
-        aria-label="Meters"
+        title="Meters"
+        aria-label="m (Meters)"
       >m</button>
       <button
         className={units === 'imperial' ? 'active' : ''}
         onClick={() => setUnits('imperial')}
         aria-pressed={units === 'imperial'}
-        aria-label="Feet"
+        title="Feet"
+        aria-label="ft (Feet)"
       >ft</button>
     </div>
   );

--- a/tests/UnitToggle.test.tsx
+++ b/tests/UnitToggle.test.tsx
@@ -15,8 +15,8 @@ describe('UnitToggle', () => {
 
   it('renders with metric as active by default', () => {
     render(<UnitToggle />);
-    const metricButton = screen.getByRole('button', { name: 'Meters' });
-    const imperialButton = screen.getByRole('button', { name: 'Feet' });
+    const metricButton = screen.getByRole('button', { name: 'm (Meters)' });
+    const imperialButton = screen.getByRole('button', { name: 'ft (Feet)' });
 
     expect(metricButton.className).toContain('active');
     expect(metricButton.getAttribute('aria-pressed')).toBe('true');
@@ -27,7 +27,7 @@ describe('UnitToggle', () => {
 
   it('toggles to imperial when clicked', () => {
     render(<UnitToggle />);
-    const imperialButton = screen.getByRole('button', { name: 'Feet' });
+    const imperialButton = screen.getByRole('button', { name: 'ft (Feet)' });
 
     fireEvent.click(imperialButton);
 
@@ -37,7 +37,7 @@ describe('UnitToggle', () => {
   it('toggles back to metric when clicked', () => {
     useAntennaStore.setState({ units: 'imperial' });
     render(<UnitToggle />);
-    const metricButton = screen.getByRole('button', { name: 'Meters' });
+    const metricButton = screen.getByRole('button', { name: 'm (Meters)' });
 
     fireEvent.click(metricButton);
 
@@ -47,8 +47,8 @@ describe('UnitToggle', () => {
   it('reflects state changes', () => {
     useAntennaStore.setState({ units: 'imperial' });
     render(<UnitToggle />);
-    const metricButton = screen.getByRole('button', { name: 'Meters' });
-    const imperialButton = screen.getByRole('button', { name: 'Feet' });
+    const metricButton = screen.getByRole('button', { name: 'm (Meters)' });
+    const imperialButton = screen.getByRole('button', { name: 'ft (Feet)' });
 
     expect(imperialButton.className).toContain('active');
     expect(metricButton.className).not.toContain('active');


### PR DESCRIPTION
Fixed a WCAG 2.5.3 Label in Name violation across UnitToggle and DipoleControl where aria-labels overrode the visible text ("m", "ft", "½λ"), confusing speech control users. Added titles as tooltips and ensured aria-labels include the visible text to comply with the accessibility standard.

---
*PR created automatically by Jules for task [13036584617829622529](https://jules.google.com/task/13036584617829622529) started by @2fst4u*