### PR TITLE
🧹 Sweep: Remove leftover console.log artifacts from physics worker

### DIFF
--- a/src/workers/physicsWorker.ts
+++ b/src/workers/physicsWorker.ts
@@ -29,7 +29,6 @@ self.addEventListener('unhandledrejection', (ev: PromiseRejectionEvent) => {
   console.error('[worker unhandledrejection]', ev.reason);
 });
 
-console.log('[worker] booting, creating engine');
 
 const engine = new Nec2Engine({
   // The worker is served from the same origin as the app, so "/" resolves
@@ -43,7 +42,6 @@ const SWEEP_SPAN_FRACTION = 0.2;
 engine
   .init()
   .then(() => {
-    console.log('[worker] engine init complete, posting ready');
     ctx.postMessage({ type: 'ready' } satisfies WorkerResponse);
   })
   .catch((err: unknown) => {


### PR DESCRIPTION
🧹 Sweep: Remove leftover console.log artifacts from physics worker

💡 What: Removed two hardcoded `console.log` statements from `src/workers/physicsWorker.ts`.
🎯 Why: These were leftover debugging logs (`[worker] booting...` and `[worker] engine init complete...`) that clutter the browser console in production. They are completely unused by the application.
🔬 Verification: Searched for `console.log` in the `src/` directory. Verified clean builds, format, and passing tests with `tsc -b`, `npm run lint`, and `npm run test -- --run`.

---
*PR created automatically by Jules for task [582067104609669930](https://jules.google.com/task/582067104609669930) started by @2fst4u*