### PR TITLE
🧪 Spec: Fix broken app-mount test and add PropagationRadar coverage

### DIFF
--- a/tests/PropagationRadar.test.tsx
+++ b/tests/PropagationRadar.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { PropagationRadar } from '../src/components/Charts/PropagationRadar';
+import type { PropagationPrediction } from '../src/physics/propagation';
+
+describe('PropagationRadar', () => {
+  it('renders radar with rings', () => {
+    const prediction: PropagationPrediction = {
+      mode: 'skywave',
+      criticalFreqMhz: 10,
+      hops: [
+        { n: 1, rangeKm: 1000, status: 'open', linkQuality: 'useful' },
+        { n: 2, rangeKm: 2000, status: 'marginal', linkQuality: 'weak' },
+      ],
+    };
+    render(<PropagationRadar prediction={prediction} units="metric" size={300} />);
+    expect(screen.getByRole('img', { name: /radar plot/i })).toBeTruthy();
+  });
+
+  it('renders azimuthal hop wedges', () => {
+    const prediction: PropagationPrediction = {
+      mode: 'skywave',
+      criticalFreqMhz: 10,
+      hops: [
+        { n: 1, rangeKm: 1000, status: 'open', linkQuality: 'useful' },
+      ],
+      azimuthalHops: [
+        { phiDeg: 0, rangeKm: [1000], status: 'open', linkQuality: 'useful' },
+        { phiDeg: 90, rangeKm: [1000], status: 'marginal', linkQuality: 'weak' },
+        { phiDeg: 180, rangeKm: [1000], status: 'open', linkQuality: 'useful' },
+        { phiDeg: 270, rangeKm: [1000], status: 'closed', linkQuality: 'unusable' },
+      ],
+    };
+    const { container } = render(<PropagationRadar prediction={prediction} units="metric" size={300} />);
+    // Look for wedges
+    const polygons = container.querySelectorAll('polygon');
+    expect(polygons.length).toBe(4);
+  });
+});

--- a/tests/app-mount.test.tsx
+++ b/tests/app-mount.test.tsx
@@ -3,8 +3,8 @@
 // WebGL canvas or Web Worker — those need a real browser — but it still
 // reveals a surprising number of bugs.
 
-import { describe, it, expect, vi } from 'vitest';
-import { render } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
 import { App } from '../src/App';
 
 // Stub Worker since jsdom doesn't implement it with module support.
@@ -22,8 +22,13 @@ globalThis.Worker = StubWorker;
 HTMLCanvasElement.prototype.getContext = vi.fn(() => null) as never;
 
 describe('App mount', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
   it('renders without throwing', () => {
-    const { container } = render(<App />);
+    const { container, unmount } = render(<App />);
     expect(container).toBeTruthy();
+    unmount();
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,10 +9,10 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       thresholds: {
-        statements: 53,
-        branches: 41,
-        functions: 59,
-        lines: 70,
+        statements: 55,
+        branches: 43,
+        functions: 61,
+        lines: 73,
       }
     }
   },


### PR DESCRIPTION
Fixes the failing CI build caused by `app-mount.test.tsx` state pollution and implements test coverage for `PropagationRadar.tsx`. Coverage thresholds were appropriately bumped to lock in the improvement.

---
*PR created automatically by Jules for task [16460357317406265513](https://jules.google.com/task/16460357317406265513) started by @2fst4u*