### PR TITLE
🎨 Palette: Add ARIA roles to loading and error overlays

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -27,3 +27,7 @@
 ## 2024-05-24 - Resolving WCAG 2.5.3 Label in Name Violations
 **Learning:** Using an `aria-label` that completely overrides the visible text of a button (like `aria-label="Meters"` for a button showing "m") violates WCAG 2.5.3 (Label in Name). Speech recognition users might say "Click m" which won't work if the accessible name doesn't contain "m".
 **Action:** Always ensure the visible text is included within the `aria-label` (e.g., `aria-label="m (Meters)"`), and use the `title` attribute to provide the expanded tooltip for mouse users.
+
+## 2024-05-25 - ARIA Roles for Loading and Error Overlays
+**Learning:** Global application states like "Loading WebAssembly" or solver errors use custom overlay divs (`.loading-overlay`, `.error-banner`). Without explicit ARIA roles and live regions, screen readers are unaware when the application transitions between these states. This leads to a confusing experience where the UI appears frozen to assistive technologies.
+**Action:** Always add `role="status"` and `aria-live="polite"` to loading overlays, and add `role="alert"` and `aria-live="assertive"` to error banners. Additionally, mark purely decorative animation elements like spinners with `aria-hidden="true"`.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,17 +41,17 @@ export function App() {
                 <AntennaScene />
               </ErrorBoundary>
               {!engineReady && (
-                <div className="loading-overlay">
-                  <div className="spinner" /> Loading NEC-2 WebAssembly…
+                <div className="loading-overlay" role="status" aria-live="polite">
+                  <div className="spinner" aria-hidden="true" /> Loading NEC-2 WebAssembly…
                 </div>
               )}
               {engineReady && loading && (
-                <div className="loading-overlay">
-                  <div className="spinner" /> Solving…
+                <div className="loading-overlay" role="status" aria-live="polite">
+                  <div className="spinner" aria-hidden="true" /> Solving…
                 </div>
               )}
               {error && (
-                <div className="error-banner">
+                <div className="error-banner" role="alert" aria-live="assertive">
                   <strong>Solver error:</strong> {error}
                 </div>
               )}
@@ -63,17 +63,17 @@ export function App() {
               <AntennaScene />
             </ErrorBoundary>
             {!engineReady && (
-              <div className="loading-overlay">
-                <div className="spinner" /> Loading NEC-2 WebAssembly…
+              <div className="loading-overlay" role="status" aria-live="polite">
+                <div className="spinner" aria-hidden="true" /> Loading NEC-2 WebAssembly…
               </div>
             )}
             {engineReady && loading && (
-              <div className="loading-overlay">
-                <div className="spinner" /> Solving…
+              <div className="loading-overlay" role="status" aria-live="polite">
+                <div className="spinner" aria-hidden="true" /> Solving…
               </div>
             )}
             {error && (
-              <div className="error-banner">
+              <div className="error-banner" role="alert" aria-live="assertive">
                 <strong>Solver error:</strong> {error}
               </div>
             )}


### PR DESCRIPTION
This PR adds necessary accessibility roles and live regions to the `loading-overlay` and `error-banner` elements in `src/App.tsx`. Screen readers will now be able to appropriately announce to users when the application is busy loading the WebAssembly module or processing calculations, as well as announce any solver errors, eliminating the previous silent experience during these dynamic application states. It also hides the `.spinner` animation from the accessibility tree.

---
*PR created automatically by Jules for task [17663774988249713519](https://jules.google.com/task/17663774988249713519) started by @2fst4u*