### PR TITLE
🧹 Sweep: remove unused `Theme` export from `themeColors.ts`

### DIFF
--- a/.jules/sweep.md
+++ b/.jules/sweep.md
@@ -1,0 +1,3 @@
+## 2024-05-13 - Knip Unused Export Removal
+**Learning:** `knip` correctly identifies types that are unused outside of the file they are defined in, but removing the `export` keyword can break TypeScript builds if the types are referenced internally by other *exported* interfaces in the same file. I need to be careful when removing `export` from types and verify that they aren't part of an exported interface's signature.
+**Action:** Always check internal usages of a type within the file, especially if it's used in the signature of other exported entities, before deciding to drop the `export` keyword. Run `npm run build` to guarantee safety.

--- a/src/utils/themeColors.ts
+++ b/src/utils/themeColors.ts
@@ -1,4 +1,4 @@
-export type Theme = 'dark' | 'light';
+type Theme = 'dark' | 'light';
 
 export interface ThemeColors {
   background: string;


### PR DESCRIPTION
🧹 Sweep: remove unused `Theme` export from `themeColors.ts`

💡 What:
Removed the `export` keyword from `type Theme` in `src/utils/themeColors.ts`.

🎯 Why:
The `Theme` type in `src/utils/themeColors.ts` is only used internally within that file to type the `THEME_COLORS` record. It was flagged as unused by `knip`. The rest of the application imports a similarly named `Theme` type from `src/store/antennaStore.ts`. Removing this export cleans up the module's public API.

🔬 Verification:
Ran `npx knip` which flagged the type.
Ran `git grep "import.*Theme.*themeColors"` which yielded no results.
Ran `npm run build` to guarantee it does not break typescript compilation.
Ran `npm run test -- --run` to ensure no regressions.

---
*PR created automatically by Jules for task [6101930378326277601](https://jules.google.com/task/6101930378326277601) started by @2fst4u*