### PR TITLE
🔭 Scout: Add robots.txt and sitemap.xml for search crawlability

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://www.gain.observer/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- SEO: Help search engines efficiently discover and index the main application URL -->
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://www.gain.observer/</loc>
+    <lastmod>2024-05-13</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
### 💡 What
Added `robots.txt` and `sitemap.xml` directly into the `public/` directory so they are served from the domain root. 

### 🎯 Why
Search crawlers actively look for `/robots.txt` first to see their crawling permissions, and a sitemap provides the canonical URL (`https://www.gain.observer/`) for indexation without them needing to guess.

### 📊 Value
Improves SEO discovery, ensures single-page site indexation points explicitly to the canonical URL, and avoids 404s when crawlers check for these files.

### 🔬 Measurement
Verify that `/robots.txt` and `/sitemap.xml` exist and have valid structure in the `public` folder. They do not alter React/UI logic or CSS.

---
*PR created automatically by Jules for task [2928690791432662946](https://jules.google.com/task/2928690791432662946) started by @2fst4u*