### PR TITLE
🛡️ Sentinel: [Security Enhancement] Add explicit radix to parseInt calls

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,7 @@
 **Vulnerability:** Unvalidated state was being written to `localStorage` via `window.localStorage.setItem` using the Zustand store state. If an attacker managed to poison the store state, they could write excessively large payloads or malicious strings into `localStorage`.
 **Learning:** React hooks orchestrating persistence (`useTheme.ts`, `useUnits.ts`) validated data read from `localStorage`, but trusted internal state blindly when writing. This breaks the defense-in-depth security principle that all input boundaries, including internal ones persisting state, should be validated.
 **Prevention:** Always validate all data being serialized to `localStorage` even if it originates from an internal store. Enforce exact type or allowed-value checks before calling `setItem`.
+## 2026-05-13 - Defensive Programming: Explicit Radix in `parseInt`
+**Vulnerability:** Unspecified radix in `parseInt` calls processing UI string inputs can lead to unexpected numeric evaluation (e.g. interpreting leading zeros as octal in legacy or non-strict environments).
+**Learning:** Relying on implicit base-10 parsing is a classic defensive programming weakness. Specifying radix 10 explicitly guarantees correct parsing behavior and satisfies SAST tools and strict linters, reinforcing input handling correctness.
+**Prevention:** Always provide the radix argument explicitly when using `parseInt`, e.g., `parseInt(value, 10)`.

--- a/src/components/Panel/DisplayControl.tsx
+++ b/src/components/Panel/DisplayControl.tsx
@@ -40,7 +40,7 @@ export function DisplayControl() {
         id="dynamic-range"
         type="range" min={10} max={50} step={1}
         value={dbRange}
-        onChange={(e) => setDbRange(parseInt(e.target.value))}
+        onChange={(e) => setDbRange(parseInt(e.target.value, 10))}
       />
 
       <label htmlFor="color-max" style={{ marginTop: 8 }}>Color max — {colorMaxDb} dBi</label>
@@ -48,7 +48,7 @@ export function DisplayControl() {
         id="color-max"
         type="range" min={-20} max={30} step={1}
         value={colorMaxDb}
-        onChange={(e) => setColorMaxDb(parseInt(e.target.value))}
+        onChange={(e) => setColorMaxDb(parseInt(e.target.value, 10))}
       />
 
       <label htmlFor="pattern-scale" style={{ marginTop: 8 }}>Pattern scale — {patternScale.toFixed(2)}×</label>


### PR DESCRIPTION
🛡️ Sentinel: [Security Enhancement] Add explicit radix to parseInt calls

Adds base-10 radix argument to parseInt() calls processing user input
to prevent unexpected octal parsing and harden input evaluation logic.

---
*PR created automatically by Jules for task [18391117329492703364](https://jules.google.com/task/18391117329492703364) started by @2fst4u*