### PR TITLE
🎨 Palette: Add loading spinner to geolocation button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -31,3 +31,6 @@
 ## 2024-05-25 - ARIA Roles for Loading and Error Overlays
 **Learning:** Global application states like "Loading WebAssembly" or solver errors use custom overlay divs (`.loading-overlay`, `.error-banner`). Without explicit ARIA roles and live regions, screen readers are unaware when the application transitions between these states. This leads to a confusing experience where the UI appears frozen to assistive technologies.
 **Action:** Always add `role="status"` and `aria-live="polite"` to loading overlays, and add `role="alert"` and `aria-live="assertive"` to error banners. Additionally, mark purely decorative animation elements like spinners with `aria-hidden="true"`.
+## 2026-05-13 - Loading Spinner Alignment
+**Learning:** Adding a spinner to a button with text requires adjusting the display properties to `flex` and aligning items to the center, along with a gap, to prevent the spinner from sitting awkwardly above or below the text.
+**Action:** When adding inline spinners to buttons, ensure the button has `display: 'flex', alignItems: 'center', gap: '6px'` to maintain visual balance and layout.

--- a/src/components/Panel/PropagationControl.tsx
+++ b/src/components/Panel/PropagationControl.tsx
@@ -162,9 +162,10 @@ export function PropagationControl() {
           onClick={() => { void requestLocation(); }}
           disabled={geoStatus === 'requesting'}
           aria-busy={geoStatus === 'requesting'}
-          style={{ flex: '0 0 auto' }}
+          style={{ flex: '0 0 auto', display: 'flex', alignItems: 'center', gap: '6px' }}
           title="Use the browser geolocation API to populate latitude. Asks for permission only when clicked."
         >
+          {geoStatus === 'requesting' && <div className="spinner" aria-hidden="true" />}
           {geoStatus === 'requesting' ? 'Locating…' : 'Use my location'}
         </button>
       </div>


### PR DESCRIPTION
This PR implements a micro-UX enhancement for the Propagation panel. It adds a visual `.spinner` element to the "Use my location" button during the `requesting` geolocation state. Flexbox inline styles were applied to ensure proper horizontal alignment of the text and spinner. The spinner is hidden from screen readers using `aria-hidden="true"` since the button's `aria-busy` state provides the equivalent context.

---
*PR created automatically by Jules for task [1910892653313219657](https://jules.google.com/task/1910892653313219657) started by @2fst4u*