### PR TITLE
Add NEC card inspection helpers for topology regression tests

### DIFF
--- a/tests/necInspect.test.ts
+++ b/tests/necInspect.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+import { buildNecCards } from '../src/physics/necCard';
+import {
+  getNecLines,
+  parseGwLine,
+  parseLdLine,
+  parseTlLine,
+  expectNoGroundTouchingWires,
+  expectExcitation
+} from './necInspect';
+import type { SimulationInput } from '../src/physics/types';
+
+describe('necInspect helpers', () => {
+  const dipoleInput: SimulationInput = {
+    frequencyMHz: 14.15,
+    wires: [
+      {
+        tag: 1,
+        start: [0, -5, 10],
+        end: [0, 5, 10],
+        radius: 0.001,
+        segments: 11,
+      },
+    ],
+    ground: { type: 'free' },
+    excitation: {
+      wireTag: 1,
+      segment: 6,
+    },
+    patternResolution: {
+      thetaSteps: 37,
+      phiSteps: 73,
+    },
+    loads: [
+        { type: 4, wireTag: 1, segmentStart: 1, segmentEnd: 1, param1: 50, param2: 0 }
+    ],
+    transmissionLines: [
+        { fromTag: 1, fromSegment: 6, toTag: 2, toSegment: 1, z0: 50, lengthM: 10 }
+    ]
+  };
+
+  it('getNecLines extracts correct cards', () => {
+    const deck = buildNecCards(dipoleInput);
+    const gwLines = getNecLines(deck, 'GW');
+    expect(gwLines).toHaveLength(1);
+    expect(gwLines[0]).toContain('GW 1 11');
+  });
+
+  it('parseGwLine parses GW correctly', () => {
+    const line = 'GW 1 11 0.00000 -5.00000 10.00000 0.00000 5.00000 10.00000 0.00100';
+    const gw = parseGwLine(line);
+    expect(gw.tag).toBe(1);
+    expect(gw.segments).toBe(11);
+    expect(gw.z1).toBe(10);
+    expect(gw.radius).toBe(0.001);
+  });
+
+  it('parseLdLine parses LD correctly', () => {
+    const line = 'LD 4 1 1 1 50.00000 0.00000';
+    const ld = parseLdLine(line);
+    expect(ld.type).toBe(4);
+    expect(ld.tag).toBe(1);
+    expect(ld.p1).toBe(50);
+  });
+
+  it('parseTlLine parses TL correctly', () => {
+    const line = 'TL 1 6 2 1 50.0000 10.00000 0.000000 0.000000 0.000000 0.000000';
+    const tl = parseTlLine(line);
+    expect(tl.tag1).toBe(1);
+    expect(tl.seg1).toBe(6);
+    expect(tl.z0).toBe(50);
+    expect(tl.length).toBe(10);
+  });
+
+  it('expectNoGroundTouchingWires passes for high dipole', () => {
+    const deck = buildNecCards(dipoleInput);
+    expect(() => expectNoGroundTouchingWires(deck)).not.toThrow();
+  });
+
+  it('expectNoGroundTouchingWires fails for wire touching ground', () => {
+    const lowDipole: SimulationInput = {
+        ...dipoleInput,
+        wires: [{ ...dipoleInput.wires[0], start: [0, -5, 0] }]
+    };
+    const deck = buildNecCards(lowDipole);
+    expect(() => expectNoGroundTouchingWires(deck)).toThrow(/touches or is below ground/);
+  });
+
+  it('expectExcitation correctly finds excitation', () => {
+    const deck = buildNecCards(dipoleInput);
+    expect(() => expectExcitation(deck, 1, 6)).not.toThrow();
+    expect(() => expectExcitation(deck, 1, 5)).toThrow(/Excitation not found/);
+  });
+});

--- a/tests/necInspect.ts
+++ b/tests/necInspect.ts
@@ -1,0 +1,96 @@
+import { expect } from 'vitest';
+
+/**
+ * Returns all lines in the NEC deck that start with the given card mnemonic.
+ */
+export function getNecLines(deck: string, cardName: string): string[] {
+  return deck.split('\n').filter((line) => line.trim().startsWith(cardName));
+}
+
+/**
+ * Parses a GW (Geometry Wire) card line.
+ * Format: GW tag nseg x1 y1 z1 x2 y2 z2 radius
+ */
+export function parseGwLine(line: string) {
+  const parts = line.trim().split(/\s+/);
+  if (parts[0] !== 'GW') {
+    throw new Error(`Not a GW line: ${line}`);
+  }
+  return {
+    tag: parseInt(parts[1], 10),
+    segments: parseInt(parts[2], 10),
+    x1: parseFloat(parts[3]),
+    y1: parseFloat(parts[4]),
+    z1: parseFloat(parts[5]),
+    x2: parseFloat(parts[6]),
+    y2: parseFloat(parts[7]),
+    z2: parseFloat(parts[8]),
+    radius: parseFloat(parts[9]),
+  };
+}
+
+/**
+ * Parses an LD (Loading) card line.
+ * Format: LD type tag seg_start seg_end P1 P2 P3
+ */
+export function parseLdLine(line: string) {
+  const parts = line.trim().split(/\s+/);
+  if (parts[0] !== 'LD') {
+    throw new Error(`Not an LD line: ${line}`);
+  }
+  return {
+    type: parseInt(parts[1], 10),
+    tag: parseInt(parts[2], 10),
+    segmentStart: parseInt(parts[3], 10),
+    segmentEnd: parseInt(parts[4], 10),
+    p1: parseFloat(parts[5]),
+    p2: parseFloat(parts[6]),
+    p3: parts[7] ? parseFloat(parts[7]) : undefined,
+  };
+}
+
+/**
+ * Parses a TL (Transmission Line) card line.
+ * Format: TL tag1 seg1 tag2 seg2 Z0 length [Y1r Y1i Y2r Y2i]
+ */
+export function parseTlLine(line: string) {
+  const parts = line.trim().split(/\s+/);
+  if (parts[0] !== 'TL') {
+    throw new Error(`Not a TL line: ${line}`);
+  }
+  return {
+    tag1: parseInt(parts[1], 10),
+    seg1: parseInt(parts[2], 10),
+    tag2: parseInt(parts[3], 10),
+    seg2: parseInt(parts[4], 10),
+    z0: parseFloat(parts[5]),
+    length: parseFloat(parts[6]),
+  };
+}
+
+/**
+ * Asserts that no wires in the deck have endpoints at or below z=0.
+ * Useful for verifying height regressions.
+ */
+export function expectNoGroundTouchingWires(deck: string) {
+  const gwLines = getNecLines(deck, 'GW');
+  for (const line of gwLines) {
+    const gw = parseGwLine(line);
+    expect(gw.z1, `Wire tag ${gw.tag} end 1 touches or is below ground (z=${gw.z1})`).toBeGreaterThan(0);
+    expect(gw.z2, `Wire tag ${gw.tag} end 2 touches or is below ground (z=${gw.z2})`).toBeGreaterThan(0);
+  }
+}
+
+/**
+ * Asserts that an excitation (EX) card exists for the given tag and segment.
+ */
+export function expectExcitation(deck: string, tag: number, segment: number) {
+  const exLines = getNecLines(deck, 'EX');
+  const found = exLines.some((line) => {
+    const parts = line.trim().split(/\s+/);
+    // EX type tag seg ...
+    // type 0 is voltage source
+    return parseInt(parts[2], 10) === tag && parseInt(parts[3], 10) === segment;
+  });
+  expect(found, `Excitation not found on tag ${tag} segment ${segment}`).toBe(true);
+}


### PR DESCRIPTION
This PR introduces a suite of test utility helpers for inspecting generated NEC card decks. These helpers allow for granular assertions on Geometry (GW), Loading (LD), Transmission Line (TL), and Excitation (EX) cards without requiring full nec2c execution in unit tests.

Key additions:
- `getNecLines(deck, mnemonic)`: Filters a deck for specific cards.
- `parseGwLine(line)`, `parseLdLine(line)`, `parseTlLine(line)`: Robustly parse space-separated NEC fields.
- `expectNoGroundTouchingWires(deck)`: Assertion to prevent height regressions.
- `expectExcitation(deck, tag, segment)`: Verifies feedpoint placement.

These helpers are verified by a new test suite (`tests/necInspect.test.ts`) and are ready to be used in future topology-specific regression tests.

Fixes #139

---
*PR created automatically by Jules for task [13834215422460019235](https://jules.google.com/task/13834215422460019235) started by @2fst4u*