### PR TITLE
Add NEC NT card emitter and NetworkLoad types

### DIFF
--- a/src/physics/necCard.ts
+++ b/src/physics/necCard.ts
@@ -109,6 +109,16 @@ export function buildNecCards(input: SimulationInput, opts: BuildNecCardsOptions
     }
   }
 
+  // Network cards (NT): non-radiating two-port networks.
+  for (const nt of input.networks ?? []) {
+    const y11i = nt.y11Imag ?? 0;
+    const y12i = nt.y12Imag ?? 0;
+    const y22i = nt.y22Imag ?? 0;
+    lines.push(
+      `NT ${nt.fromTag} ${nt.fromSegment} ${nt.toTag} ${nt.toSegment} ${n(nt.y11Real, 6)} ${n(y11i, 6)} ${n(nt.y12Real, 6)} ${n(y12i, 6)} ${n(nt.y22Real, 6)} ${n(y22i, 6)}`,
+    );
+  }
+
   // Transmission-line cards (TL): differential signal in coax/parallel
   // line. NEC's TL card is lossless and non-radiating by definition.
   for (const tl of input.transmissionLines ?? []) {

--- a/src/physics/types.ts
+++ b/src/physics/types.ts
@@ -88,6 +88,34 @@ export interface SegmentLoad {
   readonly param3?: number;
 }
 
+/**
+ * NEC-2 two-port network (NT) card.
+ *
+ * This models a non-radiating two-port network between two segments.
+ * We use it primarily for lumped resistors between wire segments
+ * (e.g. termination for a sloping-V).
+ *
+ * Admittance matrix convention:
+ * I1 = Y11*V1 + Y12*V2
+ * I2 = Y12*V1 + Y22*V2
+ *
+ * For a resistor R between port 1 and port 2:
+ * Y11 = Y22 = 1/R
+ * Y12 = -1/R
+ */
+export interface NetworkLoad {
+  readonly fromTag: number;
+  readonly fromSegment: number;
+  readonly toTag: number;
+  readonly toSegment: number;
+  readonly y11Real: number;
+  readonly y11Imag?: number;
+  readonly y12Real: number;
+  readonly y12Imag?: number;
+  readonly y22Real: number;
+  readonly y22Imag?: number;
+}
+
 export interface SimulationInput {
   readonly wires: readonly Wire[];
   readonly frequencyMHz: number;
@@ -102,6 +130,8 @@ export interface SimulationInput {
   readonly transmissionLines?: readonly TransmissionLine[];
   /** Optional NEC LD cards (e.g. choke balun, end-fed terminator). */
   readonly loads?: readonly SegmentLoad[];
+  /** Optional NEC NT cards (two-port networks). */
+  readonly networks?: readonly NetworkLoad[];
 }
 
 /**

--- a/tests/necCard.test.ts
+++ b/tests/necCard.test.ts
@@ -222,10 +222,51 @@ describe('buildNecCards', () => {
       expect(exIdx).toBeGreaterThan(tlIdx);
     });
 
-    it('emits no LD/TL cards when arrays are absent', () => {
+    it('emits no LD/TL/NT cards when arrays are absent', () => {
       const out = buildNecCards(defaultInput);
       expect(out).not.toContain('\nLD ');
       expect(out).not.toContain('\nTL ');
+      expect(out).not.toContain('\nNT ');
+    });
+
+    it('emits an NT network card when requested', () => {
+      const out = buildNecCards({
+        ...defaultInput,
+        networks: [
+          {
+            fromTag: 1,
+            fromSegment: 1,
+            toTag: 1,
+            toSegment: 11,
+            y11Real: 0.02,
+            y12Real: -0.02,
+            y22Real: 0.02,
+          },
+        ],
+      });
+      // NT tag1 seg1 tag2 seg2 Y11r Y11i Y12r Y12i Y22r Y22i
+      expect(out).toMatch(/^NT 1 1 1 11 0\.020000 0\.000000 -0\.020000 0\.000000 0\.020000 0\.000000/m);
+    });
+
+    it('correctly models a resistor as an NT card', () => {
+      const R = 500;
+      const G = 1 / R;
+      const out = buildNecCards({
+        ...defaultInput,
+        networks: [
+          {
+            fromTag: 1,
+            fromSegment: 1,
+            toTag: 1,
+            toSegment: 11,
+            y11Real: G,
+            y12Real: -G,
+            y22Real: G,
+          },
+        ],
+      });
+      // 1/500 = 0.002
+      expect(out).toContain('NT 1 1 1 11 0.002000 0.000000 -0.002000 0.000000 0.002000 0.000000');
     });
 
     it('emits a series-RLC LD card (type 0) when requested', () => {


### PR DESCRIPTION
This PR adds the necessary infrastructure to support NEC-2 NT (Network) cards in the physics engine. NT cards are used to model non-radiating two-port networks between segments.

Key changes:
- Defined `NetworkLoad` in `src/physics/types.ts` using the admittance matrix convention.
- Added `networks` to `SimulationInput` in `src/physics/types.ts`.
- Updated `buildNecCards` in `src/physics/necCard.ts` to generate `NT` lines in the NEC deck.
- Added comprehensive tests in `tests/necCard.test.ts` to verify the emitter and the resistor-to-admittance conversion.

This is a prerequisite for more advanced modeling like terminated sloping-V antennas.

Fixes #150

---
*PR created automatically by Jules for task [16001489235947251625](https://jules.google.com/task/16001489235947251625) started by @2fst4u*