### PR TITLE
Clarify raw 50 Ω SWR and feedpoint impedance in UI/readouts

### DIFF
--- a/src/components/Charts/SWRChart.tsx
+++ b/src/components/Charts/SWRChart.tsx
@@ -75,7 +75,7 @@ export function SWRChart() {
     }
 
     datasets.push({
-      label: comparisonActive ? 'Current' : 'SWR (50 Ω)',
+      label: comparisonActive ? 'Current' : 'SWR (raw 50 Ω)',
       data: sweep.map((point) => ({ x: point.frequencyMHz, y: point.swr })),
       borderColor: accent,
       backgroundColor: currentFill,
@@ -218,7 +218,7 @@ export function SWRChart() {
           max: yMax,
           ticks: { color: chartText },
           grid: { color: chartGrid },
-          title: { display: true, text: 'SWR', color: chartText },
+          title: { display: true, text: 'SWR (raw 50 Ω)', color: chartText },
         },
         x: {
           type: 'linear',

--- a/src/components/Panel/StatsReadout.tsx
+++ b/src/components/Panel/StatsReadout.tsx
@@ -30,13 +30,13 @@ export function StatsReadout() {
         <span className="stat-value">{result.takeoffAzimuthDeg.toFixed(0)}°</span>
       </div>
       <div className="stat">
-        <span className="stat-label">Impedance</span>
+        <span className="stat-label">Feedpoint (R + jX)</span>
         <span className="stat-value">
           {result.impedance.R.toFixed(1)} {result.impedance.X >= 0 ? '+' : '−'}j{Math.abs(result.impedance.X).toFixed(1)} Ω
         </span>
       </div>
       <div className="stat">
-        <span className="stat-label">SWR (50 Ω)</span>
+        <span className="stat-label">SWR (raw 50 Ω)</span>
         <span className="stat-value" style={{
           color: result.swr > 2 ? 'var(--danger)' : result.swr > 1.5 ? 'var(--warning)' : 'var(--success)',
         }}>{result.swr.toFixed(2)}:1</span>
@@ -47,6 +47,10 @@ export function StatsReadout() {
       {mode === 'nvis' && (
         <NvisStats />
       )}
+      <div style={{ marginTop: 12, fontSize: 11, color: 'var(--text-muted)', lineHeight: 1.4 }}>
+        <strong>Note:</strong> Termination reduces reflections along the antenna wire.
+        It does not guarantee a 50 Ω feedpoint impedance.
+      </div>
     </div>
   );
 }
@@ -73,7 +77,7 @@ function ComparisonStats({
         <span className="stat-value">{formatSigned(current.takeoffElevationDeg - reference.takeoffElevationDeg, 1)}°</span>
       </div>
       <div className="stat">
-        <span className="stat-label">SWR delta</span>
+        <span className="stat-label">SWR delta (raw 50 Ω)</span>
         <span className="stat-value">{formatSigned(current.swr - reference.swr, 2)}</span>
       </div>
       <div className="stat">

--- a/src/physics/impedance.ts
+++ b/src/physics/impedance.ts
@@ -20,6 +20,10 @@ function reflectionCoefficientMag(z: ImpedanceResult, z0: number = Z0_SYSTEM): n
 
 /**
  * Voltage SWR against the system impedance. Clamped at 999 for display sanity.
+ *
+ * This calculates SWR based on the mismatch between the load impedance (z)
+ * and the system impedance (z0, typically 50 Ω). This represents the
+ * "source reflection" at the feedpoint.
  */
 export function swr(z: ImpedanceResult, z0: number = Z0_SYSTEM): number {
   const gamma = reflectionCoefficientMag(z, z0);

--- a/src/physics/types.ts
+++ b/src/physics/types.ts
@@ -134,7 +134,15 @@ export interface SimulationResult {
   /** Azimuth (deg, 0=+x, 90=+y) of maximum gain direction. */
   readonly takeoffAzimuthDeg: number;
   readonly impedance: ImpedanceResult;
-  /** SWR vs 50 Ω. */
+  /**
+   * SWR at the feedpoint against the 50 Ω system impedance.
+   *
+   * Note: This measures the reflection caused by the mismatch between
+   * the antenna's feedpoint impedance and the source (source reflection).
+   * It is distinct from the travelling-wave reflections along the antenna
+   * wire itself, which may be suppressed by termination without
+   * necessarily resulting in a 50 Ω feedpoint impedance.
+   */
   readonly swr: number;
   /** Radiation efficiency (0..1) when provided by solver; undefined if unknown. */
   readonly efficiency?: number;
@@ -145,6 +153,7 @@ export interface SimulationResult {
 /** Result of a frequency sweep for SWR/impedance analysis. */
 export interface SweepPoint {
   readonly frequencyMHz: number;
+  /** SWR vs 50 Ω at the feedpoint (source reflection). */
   readonly swr: number;
   readonly R: number;
   readonly X: number;


### PR DESCRIPTION
This change addresses user confusion regarding SWR and termination in antennas. It renames generic "SWR" labels to "SWR (raw 50 Ω)" and "Impedance" to "Feedpoint (R + jX)" to make it explicit that these measurements are at the source. It also adds a helpful note explaining that while termination reduces reflections along the antenna wire, it does not guarantee a perfect 50 Ω match at the feedpoint. Documentation in the physics layer has also been updated to reflect these distinctions.

Fixes #138

---
*PR created automatically by Jules for task [5936542404567546441](https://jules.google.com/task/5936542404567546441) started by @2fst4u*