### PR TITLE
Restrict feedline model to dipoles

### DIFF
--- a/src/components/Panel/DipoleControl.tsx
+++ b/src/components/Panel/DipoleControl.tsx
@@ -11,9 +11,11 @@ import {
 
 export function DipoleControl() {
   const units = useAntennaStore((s) => s.units);
+  const antennaType = useAntennaStore((s) => s.antennaType);
   const length = useAntennaStore((s) => s.length);
   const height = useAntennaStore((s) => s.height);
   const orientation = useAntennaStore((s) => s.orientation);
+  const setAntennaType = useAntennaStore((s) => s.setAntennaType);
   const setLength = useAntennaStore((s) => s.setLength);
   const setHalfWaveLength = useAntennaStore((s) => s.setHalfWaveLength);
   const setHeight = useAntennaStore((s) => s.setHeight);
@@ -59,7 +61,21 @@ export function DipoleControl() {
   return (
     <div className="panel-section">
       {/* SEO: Use sequential heading tags (H2) to follow document outline initiated by H1 */}
-      <h2>Dipole</h2>
+      <h2>Antenna</h2>
+
+      <label htmlFor="antenna-type">Type</label>
+      <select
+        id="antenna-type"
+        value={antennaType}
+        onChange={(e) => setAntennaType(e.target.value as any)}
+        style={{ marginBottom: 12 }}
+      >
+        <option value="dipole">Horizontal Dipole</option>
+        <option value="inverted-v">Inverted V</option>
+        <option value="sloping-v">Sloping V</option>
+        <option value="v-beam">V-Beam</option>
+        <option value="delta-loop">Delta Loop</option>
+      </select>
 
       <label htmlFor="dipole-length">Length ({unit})</label>
       <div className="row">

--- a/src/components/Panel/FeedlineControl.tsx
+++ b/src/components/Panel/FeedlineControl.tsx
@@ -13,6 +13,7 @@ import {
 
 export function FeedlineControl() {
   const units = useAntennaStore((s) => s.units);
+  const antennaType = useAntennaStore((s) => s.antennaType);
   const frequency = useAntennaStore((s) => s.frequency);
   const dipoleLength = useAntennaStore((s) => s.length);
   const feedlineId = useAntennaStore((s) => s.feedlineId);
@@ -40,6 +41,10 @@ export function FeedlineControl() {
       setLocalLen(dispLen.toFixed(2));
     }
   }
+
+  // Feedline modelling is restricted to dipoles for now.
+  if (antennaType !== 'dipole') return null;
+
   const offsetLimit = Math.max(0, dipoleLength / 2 - 0.05);
   const dispOffsetLimit = toDisplayLength(offsetLimit, units);
   const lossDb = enabled ? feedlineLossDb(preset, frequency, feedlineLength) : 0;

--- a/src/store/antennaStore.ts
+++ b/src/store/antennaStore.ts
@@ -32,12 +32,14 @@ import type { UnitSystem } from '../physics/units';
 
 export type OrientationPreset = 'EW' | 'NS' | 'NE-SW' | 'NW-SE';
 export type Orientation = OrientationPreset | number;
+export type AntennaType = 'dipole' | 'inverted-v' | 'sloping-v' | 'v-beam' | 'delta-loop';
 export type Theme = 'dark' | 'light';
 export type Mode = 'normal' | 'nvis' | 'comparison';
 export type Colormap = 'viridis' | 'turbo' | 'jet';
 
 export interface ComparisonSnapshot {
   readonly frequency: number;
+  readonly antennaType: AntennaType;
   readonly length: number;
   readonly height: number;
   readonly orientation: Orientation;
@@ -58,6 +60,7 @@ export interface ComparisonSnapshot {
 export interface AntennaState {
   // Antenna geometry (metres, MHz)
   frequency: number;
+  antennaType: AntennaType;
   length: number;
   height: number;
   orientation: Orientation;
@@ -127,6 +130,7 @@ export interface AntennaState {
 
   // Actions — user-facing
   setFrequency(mhz: number): void;
+  setAntennaType(type: AntennaType): void;
   setLength(meters: number): void;
   setHalfWaveLength(): void;
   setHeight(meters: number): void;
@@ -177,6 +181,7 @@ export const useAntennaStore = create<AntennaState>()(
   subscribeWithSelector(
     immer((set) => ({
       frequency: INITIAL_FREQ,
+      antennaType: 'dipole',
       length: INITIAL_LENGTH,
       height: INITIAL_HEIGHT,
       orientation: 'EW',
@@ -220,6 +225,17 @@ export const useAntennaStore = create<AntennaState>()(
       comparisonReference: null,
 
       setFrequency: (mhz) => set((s) => { s.frequency = clampFreq(mhz); }),
+      setAntennaType: (type) => set((s) => {
+        s.antennaType = type;
+        // Restrict feedline model to dipoles: clear stale state when switching
+        // to any non-dipole type.
+        if (type !== 'dipole') {
+          s.feedlineId = 'none';
+          s.feedlineLength = 0;
+          s.feedlineOffset = 0;
+          s.balunEnabled = false;
+        }
+      }),
       setLength: (meters) => set((s) => {
         if (!Number.isFinite(meters)) return;
         s.length = Math.max(0.1, meters);
@@ -461,7 +477,7 @@ function orientationVector(o: Orientation): [number, number] {
  */
 export function buildWires(
   state: Pick<AntennaState, 'length' | 'height' | 'orientation' | 'wireRadius' | 'segments'> &
-    Partial<Pick<AntennaState, 'feedlineId' | 'feedlineLength' | 'feedlineOffset'>>,
+    Partial<Pick<AntennaState, 'antennaType' | 'feedlineId' | 'feedlineLength' | 'feedlineOffset'>>,
 ): Wire[] {
   const half = state.length / 2;
   const h = state.height;
@@ -560,8 +576,11 @@ interface FeedlineLayout {
 
 function computeFeedlineLayout(
   state: Pick<AntennaState, 'length' | 'height'> &
-    Partial<Pick<AntennaState, 'feedlineId' | 'feedlineLength' | 'feedlineOffset'>>,
+    Partial<Pick<AntennaState, 'antennaType' | 'feedlineId' | 'feedlineLength' | 'feedlineOffset'>>,
 ): FeedlineLayout | null {
+  // Feedline modelling is restricted to dipoles only.
+  if (state.antennaType && state.antennaType !== 'dipole') return null;
+
   const id = state.feedlineId;
   if (!id || id === 'none') return null;
   const preset = findFeedlinePreset(id);
@@ -613,7 +632,8 @@ export function selectSimulationInput(state: AntennaState): SimulationInput {
   const wires = buildWires(state);
   const hasShield = wires.some((w) => w.tag === FEEDLINE_SHIELD_TAG);
   const hasBridge = wires.some((w) => w.tag === FEED_BRIDGE_TAG);
-  const feedlineActive = hasBridge; // bridge is added iff feedline is configured
+  // Feedline is only active for dipoles.
+  const feedlineActive = hasBridge && state.antennaType === 'dipole';
 
   // Excitation:
   //   - Feedline active: the EX is at the *rig* end of the coax shield
@@ -687,6 +707,7 @@ function createComparisonSnapshot(state: AntennaState): ComparisonSnapshot | nul
   if (!state.result || state.sweep.length === 0) return null;
   return {
     frequency: state.frequency,
+    antennaType: state.antennaType,
     length: state.length,
     height: state.height,
     orientation: state.orientation,

--- a/tests/antennaStore.test.ts
+++ b/tests/antennaStore.test.ts
@@ -279,6 +279,21 @@ describe('antennaStore selectors', () => {
       expect(ld.param2).toBe(0);
     });
 
+    it('does NOT include feedline logic for non-dipoles even if state is somehow set', () => {
+      const state = useAntennaStore.getState();
+      const input = selectSimulationInput({
+        ...state,
+        antennaType: 'sloping-v',
+        feedlineId: 'rg58',
+        feedlineLength: 10,
+      });
+
+      // Even if feedline state is present, selectSimulationInput should
+      // ignore it for non-dipoles.
+      expect(input.wires.some(w => w.tag === 4)).toBe(false);
+      expect(input.transmissionLines).toBeUndefined();
+    });
+
     it('clamps shield bottom above ground when feedline length exceeds height', () => {
       const state = useAntennaStore.getState();
       const testState = {
@@ -338,6 +353,28 @@ describe('antennaStore actions', () => {
   });
 
   describe('feedline', () => {
+    it('clears feedline state when switching from dipole to non-dipole', () => {
+      const store = useAntennaStore.getState();
+      store.setAntennaType('dipole');
+      store.setFeedline('rg58');
+      store.setFeedlineLength(15);
+      store.setFeedlineOffset(2);
+      store.setBalunEnabled(true);
+
+      expect(useAntennaStore.getState().feedlineId).toBe('rg58');
+
+      // Act
+      store.setAntennaType('sloping-v');
+
+      // Assert
+      const s = useAntennaStore.getState();
+      expect(s.antennaType).toBe('sloping-v');
+      expect(s.feedlineId).toBe('none');
+      expect(s.feedlineLength).toBe(0);
+      expect(s.feedlineOffset).toBe(0);
+      expect(s.balunEnabled).toBe(false);
+    });
+
     it('updates feedline preset id', () => {
       const store = useAntennaStore.getState();
       store.setFeedline('rg213');


### PR DESCRIPTION
This change restricts the application's feedline modeling capabilities strictly to horizontal dipoles. It introduces an `antennaType` state to the store, allowing for future expansion of antenna designs while ensuring that current feedline physics (which are only validated for dipoles) do not inadvertently affect other topologies. When a user switches to a non-dipole antenna type, all feedline-related state is automatically cleared, and the feedline control panel is hidden. Simulation input generation is also guarded to prevent the emission of feedline wires or transmission line cards for non-dipole antennas.

Fixes #137

---
*PR created automatically by Jules for task [14692661905130117166](https://jules.google.com/task/14692661905130117166) started by @2fst4u*