### PR TITLE
📚 Archivist: Clarify supported antenna types in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A 3D, responsive, physics-accurate visualiser for HF antenna radiation patterns,
 
 While this repository is fully open source and developers are welcome to fork or clone it to run locally, the primary way to use the application is via the hosted URL at **[www.gain.observer](https://www.gain.observer/)**.
 
-Current scope (Phase 1): horizontal dipoles, 1.8–30 MHz, real-ground support, offset feed points, feedlines & baluns, NVIS and comparison modes, SWR/polar cut charts, dark/light theming, metric/imperial toggle.
+Current scope (Phase 1): horizontal dipoles, inverted-v, sloping-v, delta-loop, and v-beam antennas, 1.8–30 MHz, real-ground support, offset feed points, feedlines & baluns, NVIS and comparison modes, SWR/polar cut charts, dark/light theming, metric/imperial toggle.
 
 ## Stack
 


### PR DESCRIPTION
# Problem
The `README.md` file incorrectly stated that the application only supported "horizontal dipoles" under its current scope, which contradicts the actual functionality implemented in the code (which supports inverted-v, sloping-v, delta-loop, and v-beam antennas).

# Fix
Updated the "Current scope" section in `README.md` to accurately reflect the full set of antenna topologies supported by the application.

# Verification
Checked `src/store/antennaStore.ts` and `src/physics/types.ts` to confirm these types are indeed available in the current codebase.

# Scope
This PR only contains documentation changes.

---
*PR created automatically by Jules for task [15194047766190920690](https://jules.google.com/task/15194047766190920690) started by @2fst4u*