### PR TITLE
Implement Sloping V geometry and slope clamping

### DIFF
--- a/src/store/antennaStore.ts
+++ b/src/store/antennaStore.ts
@@ -441,7 +441,7 @@ const FEEDLINE_GROUND_GAP_M = 0.1;
  * clamping it so the wire tips stay at or above SLOPING_V_MIN_TIP_Z_M.
  */
 export function computeEffectiveSlope(
-  state: Pick<AntennaState, 'antennaType' | 'length' | 'height' | 'legSlope'>,
+  state: Pick<AntennaState, 'length' | 'height' | 'legSlope'>,
 ) {
   const half = state.length / 2;
   const h = state.height;

--- a/src/store/antennaStore.ts
+++ b/src/store/antennaStore.ts
@@ -30,6 +30,7 @@ import {
   findGroundPreset,
   referenceLength,
   halfWaveLength,
+  wavelengthMeters,
 } from '../physics/constants';
 import type { UnitSystem } from '../physics/units';
 import { buildInvertedVWires, orientationVector, type OrientationPreset, type Orientation } from './antennaGeometry';
@@ -435,6 +436,88 @@ const FEEDLINE_SHIELD_SEGMENTS = 11;
 const FEEDLINE_BRIDGE_LENGTH_M = 0.05;
 const FEEDLINE_GROUND_GAP_M = 0.1;
 
+/**
+ * Calculates the effective downward slope for a V-topology,
+ * clamping it so the wire tips stay at or above SLOPING_V_MIN_TIP_Z_M.
+ */
+export function computeEffectiveSlope(
+  state: Pick<AntennaState, 'antennaType' | 'length' | 'height' | 'legSlope'>,
+) {
+  const half = state.length / 2;
+  const h = state.height;
+  const requestedDeg = state.legSlope;
+
+  const maxSin = half > 0 ? Math.max(0, h - SLOPING_V_MIN_TIP_Z_M) / half : 0;
+  const maxSlopeRad = Math.asin(Math.min(1, maxSin));
+  const requestedRad = (requestedDeg * Math.PI) / 180;
+
+  const clamped = requestedRad > maxSlopeRad + 1e-7;
+  const effectiveRad = Math.min(requestedRad, maxSlopeRad);
+  const effectiveDeg = (effectiveRad * 180) / Math.PI;
+  const tipHeightM = h - half * Math.sin(effectiveRad);
+
+  return {
+    requestedDeg,
+    effectiveDeg,
+    tipHeightM,
+    clamped,
+  };
+}
+
+function buildSlopingVWires(
+  state: Pick<AntennaState, 'length' | 'height' | 'orientation' | 'wireRadius' | 'segments' | 'frequency' | 'vAngle' | 'legSlope'>,
+): Wire[] {
+  const half = state.length / 2;
+  const h = state.height;
+  const { effectiveDeg } = computeEffectiveSlope(state);
+  const effectiveSlopeRad = (effectiveDeg * Math.PI) / 180;
+
+  const [dx, dy] = orientationVector(state.orientation);
+  const [px, py] = [-dy, dx];
+
+  const halfV = ((state.vAngle / 2) * Math.PI) / 180;
+  const cosS = Math.cos(effectiveSlopeRad);
+  const sinS = Math.sin(effectiveSlopeRad);
+  const cosV = Math.cos(halfV);
+  const sinV = Math.sin(halfV);
+
+  function legPointAt(axis: number, side: number): [number, number, number] {
+    const horizontalDist = axis * cosS;
+    const lz = -axis * sinS;
+
+    const la = horizontalDist * cosV;
+    const lp = horizontalDist * sinV * side;
+
+    const wx = dx * la + px * lp;
+    const wy = dy * la + py * lp;
+    const wz = h + lz;
+
+    const cleanZero = (v: number): number => (v === 0 ? 0 : v);
+    return [cleanZero(wx), cleanZero(wy), cleanZero(wz)];
+  }
+
+  const lambda = wavelengthMeters(state.frequency);
+  const minSegPerLeg = Math.ceil((20 * half) / lambda);
+  const segmentsPerLeg = Math.max(9, minSegPerLeg, Math.round(state.segments / 2));
+
+  return [
+    {
+      start: legPointAt(half, -1),
+      end: legPointAt(0, 0),
+      radius: state.wireRadius,
+      segments: segmentsPerLeg,
+      tag: DIPOLE_LEFT_TAG,
+    },
+    {
+      start: legPointAt(0, 0),
+      end: legPointAt(half, 1),
+      radius: state.wireRadius,
+      segments: segmentsPerLeg,
+      tag: DIPOLE_RIGHT_TAG,
+    },
+  ];
+}
+
 export function buildWires(
   state: Pick<AntennaState, 'antennaType' | 'length' | 'height' | 'orientation' | 'wireRadius' | 'segments' | 'frequency' | 'vAngle' | 'legSlope'> &
     Partial<Pick<AntennaState, 'feedlineId' | 'feedlineLength' | 'feedlineOffset'>>,
@@ -455,58 +538,16 @@ export function buildWires(
     });
   }
 
-  const [dx, dy] = orientationVector(state.orientation);
-  const [px, py] = [-dy, dx];
-  const cleanZero = (v: number): number => (v === 0 ? 0 : v);
-
-  const slopeDeg = antennaType === 'sloping-v' ? (state.legSlope ?? 0) : 0;
-  const vAngleDeg = antennaType === 'sloping-v' ? (state.vAngle ?? 180) : 180;
-
-  const maxSin = half > 0 ? (h - SLOPING_V_MIN_TIP_Z_M) / half : 0;
-  const maxSlopeRad = Math.asin(Math.max(0, Math.min(1, maxSin)));
-  const requestedSlopeRad = (slopeDeg * Math.PI) / 180;
-  const effectiveSlopeRad = Math.min(requestedSlopeRad, maxSlopeRad);
-
-  const cosS = Math.cos(effectiveSlopeRad);
-  const sinS = Math.sin(effectiveSlopeRad);
-
-  const openingHalfRad = ((180 - vAngleDeg) / 2 * Math.PI) / 180;
-  const cosV = Math.cos(openingHalfRad);
-  const sinV = Math.sin(openingHalfRad);
-
-  function legPointAt(axis: number, side: number): [number, number, number] {
-    const lx = axis * cosS * cosV * side;
-    const ly = axis * cosS * sinV;
-    const lz = -axis * sinS;
-
-    const wx = dx * lx + px * ly;
-    const wy = dy * lx + py * ly;
-    const wz = h + lz;
-
-    return [cleanZero(wx), cleanZero(wy), cleanZero(wz)];
+  if (antennaType === 'sloping-v') {
+    return buildSlopingVWires(state);
   }
+
+  const [dx, dy] = orientationVector(state.orientation);
+  const cleanZero = (v: number): number => (v === 0 ? 0 : v);
 
   const layout = computeFeedlineLayout(state);
 
   if (!layout) {
-    if (antennaType === 'sloping-v' || vAngleDeg < 180 || slopeDeg > 0) {
-      return [
-        {
-          start: legPointAt(half, -1),
-          end: legPointAt(0, 0),
-          radius: state.wireRadius,
-          segments: Math.max(1, Math.round(state.segments / 2)),
-          tag: DIPOLE_TAG,
-        },
-        {
-          start: legPointAt(0, 0),
-          end: legPointAt(half, 1),
-          radius: state.wireRadius,
-          segments: Math.max(1, Math.round(state.segments / 2)),
-          tag: DIPOLE_TAG,
-        },
-      ];
-    }
     return [{
       start: [cleanZero(-half * dx), cleanZero(-half * dy), h],
       end: [cleanZero(half * dx), cleanZero(half * dy), h],
@@ -518,11 +559,20 @@ export function buildWires(
 
   const offset = layout.offset;
   const bridgeHalf = FEEDLINE_BRIDGE_LENGTH_M / 2;
-  const bridgeStart = legPointAt(offset - bridgeHalf, offset < 0 ? -1 : 1);
-  const bridgeEnd = legPointAt(offset + bridgeHalf, offset < 0 ? -1 : 1);
 
-  const leftTip = legPointAt(half, -1);
-  const rightTip = legPointAt(half, 1);
+  const bridgeStart: [number, number, number] = [
+    cleanZero((offset - bridgeHalf) * dx),
+    cleanZero((offset - bridgeHalf) * dy),
+    h,
+  ];
+  const bridgeEnd: [number, number, number] = [
+    cleanZero((offset + bridgeHalf) * dx),
+    cleanZero((offset + bridgeHalf) * dy),
+    h,
+  ];
+
+  const leftTip: [number, number, number] = [cleanZero(-half * dx), cleanZero(-half * dy), h];
+  const rightTip: [number, number, number] = [cleanZero(half * dx), cleanZero(half * dy), h];
 
   const dist = (p1: [number, number, number], p2: [number, number, number]) =>
     Math.sqrt((p1[0] - p2[0]) ** 2 + (p1[1] - p2[1]) ** 2 + (p1[2] - p2[2]) ** 2);
@@ -636,8 +686,8 @@ export function selectSimulationInput(state: AntennaState): SimulationInput {
     excitation = { wireTag: FEEDLINE_SHIELD_TAG, segment: FEEDLINE_SHIELD_SEGMENTS };
   } else if (feedlineActive) {
     excitation = { wireTag: FEED_BRIDGE_TAG, segment: 1 };
-  } else if (state.antennaType === 'inverted-v') {
-    const leftLeg = wires.find(w => w.tag === DIPOLE_LEFT_TAG)!;
+  } else if (state.antennaType === 'inverted-v' || state.antennaType === 'sloping-v') {
+    const leftLeg = wires.find((w) => w.tag === DIPOLE_LEFT_TAG)!;
     excitation = { wireTag: DIPOLE_LEFT_TAG, segment: leftLeg.segments };
   } else {
     const dipoleCentreSeg = Math.ceil(state.segments / 2);

--- a/tests/antennaStore.test.ts
+++ b/tests/antennaStore.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from 'vitest';
-import { useAntennaStore, buildWires, selectSimulationInput, DIPOLE_LEFT_TAG, DIPOLE_RIGHT_TAG, type AntennaState } from '../src/store/antennaStore';
+import {
+  useAntennaStore,
+  buildWires,
+  selectSimulationInput,
+  computeEffectiveSlope,
+  DIPOLE_LEFT_TAG,
+  DIPOLE_RIGHT_TAG,
+  type AntennaState,
+} from '../src/store/antennaStore';
 
 describe('antennaStore selectors', () => {
   describe('buildWires', () => {
@@ -299,20 +307,31 @@ describe('antennaStore selectors', () => {
       const wires = buildWires(state);
       expect(wires).toHaveLength(2); // Two legs joined at apex
 
-      const apex = wires[0].end;
-      expect(apex).toEqual([0, 0, 10]);
+      // Left leg: Tip to Apex
+      const left = wires.find((w) => w.tag === 1)!;
+      // Right leg: Apex to Tip
+      const right = wires.find((w) => w.tag === 2)!;
+
+      expect(left.end).toEqual([0, 0, 10]);
+      expect(right.start).toEqual([0, 0, 10]);
 
       // tip_z = 10 - 10 * sin(30) = 10 - 10 * 0.5 = 5.
-      expect(wires[0].start[2]).toBeCloseTo(5, 5);
-      expect(wires[1].end[2]).toBeCloseTo(5, 5);
+      expect(left.start[2]).toBeCloseTo(5, 5);
+      expect(right.end[2]).toBeCloseTo(5, 5);
 
-      // check X/Y coordinates for 90 deg opening.
-      // orientation EW -> dx=1, dy=0. px=0, py=1.
-      // openingHalf = 45 deg.
-      // L.x = 10 * cos(30) * cos(45) = 10 * 0.866025 * 0.707107 = 6.123724
-      // L.y = 10 * cos(30) * sin(45) * side = 10 * 0.866025 * 0.707107 * side = 6.123724 * side
-      expect(Math.abs(wires[0].start[0])).toBeCloseTo(6.1237, 4);
-      expect(Math.abs(wires[0].start[1])).toBeCloseTo(6.1237, 4);
+      // check X/Y coordinates for 90 deg opening (vAngle=90).
+      // orientation EW -> dx=1, dy=0.
+      // px = -dy = 0, py = dx = 1.
+      // halfV = 45 deg.
+      // horizontalDist = 10 * cos(30) = 8.66025
+      // la = 8.66025 * cos(45) = 6.1237
+      // lp = 8.66025 * sin(45) * side = 6.1237 * side
+      // wx = dx * la + px * lp = 1 * 6.1237 + 0 = 6.1237
+      // wy = dy * la + py * lp = 0 + 1 * 6.1237 * side = 6.1237 * side
+      expect(left.start[0]).toBeCloseTo(6.1237, 4);
+      expect(left.start[1]).toBeCloseTo(-6.1237, 4);
+      expect(right.end[0]).toBeCloseTo(6.1237, 4);
+      expect(right.end[1]).toBeCloseTo(6.1237, 4);
     });
 
     it('clamps sloping-V slope to prevent tips hitting ground', () => {
@@ -333,8 +352,8 @@ describe('antennaStore selectors', () => {
       // maxSin = (10 - 0.5) / 50 = 9.5 / 50 = 0.19
       // maxSlope = asin(0.19) ≈ 10.95 deg
       // tip_z should be 0.5
-      expect(wires[0].start[2]).toBeCloseTo(0.5, 5);
-      expect(wires[1].end[2]).toBeCloseTo(0.5, 5);
+      expect(wires.find((w) => w.tag === 1)!.start[2]).toBeCloseTo(0.5, 5);
+      expect(wires.find((w) => w.tag === 2)!.end[2]).toBeCloseTo(0.5, 5);
     });
 
     it('adds an LD choke balun on the shield when balun is enabled', () => {
@@ -662,6 +681,62 @@ describe('antennaStore actions', () => {
       expect(useAntennaStore.getState().geolocationStatus).toBe('requesting');
       store.setGeolocationStatus('denied');
       expect(useAntennaStore.getState().geolocationStatus).toBe('denied');
+    });
+  });
+
+  describe('Sloping V Geometry', () => {
+    it('performs the hand-check at 7.1 MHz, height 10m, slope 45 deg', () => {
+      // λ = 299.792458 / 7.1 = 42.2243m.
+      // Sloping V ref length = λ * 2 * 0.95 = 80.2262m.
+      const length = 80.22615;
+      const state = {
+        antennaType: 'sloping-v' as const,
+        length,
+        height: 10,
+        legSlope: 45,
+      };
+
+      const result = computeEffectiveSlope(state);
+
+      // maxSin = (10 - 0.5) / (80.226 / 2) = 9.5 / 40.113 ≈ 0.23683
+      // maxSlope = asin(0.23683) ≈ 13.701 deg
+      expect(result.clamped).toBe(true);
+      expect(result.effectiveDeg).toBeCloseTo(13.701, 2);
+      expect(result.tipHeightM).toBeCloseTo(0.5, 5);
+    });
+
+    it('reports clamped=false when slope is shallow', () => {
+      const state = {
+        antennaType: 'sloping-v' as const,
+        length: 20,
+        height: 10,
+        legSlope: 10,
+      };
+      const result = computeEffectiveSlope(state);
+      expect(result.clamped).toBe(false);
+      expect(result.effectiveDeg).toBe(10);
+    });
+
+    it('sets excitation at the apex of the left leg for sloping-v', () => {
+      const state = {
+        ...useAntennaStore.getState(),
+        antennaType: 'sloping-v' as const,
+        length: 80,
+        height: 10,
+        legSlope: 15,
+        vAngle: 90,
+      };
+      const input = selectSimulationInput(state as AntennaState);
+      expect(input.wires).toHaveLength(2);
+      const leftLeg = input.wires.find((w) => w.tag === DIPOLE_LEFT_TAG)!;
+      const rightLeg = input.wires.find((w) => w.tag === DIPOLE_RIGHT_TAG)!;
+
+      // Left leg should end at apex, right leg should start at apex.
+      expect(leftLeg.end).toEqual([0, 0, 10]);
+      expect(rightLeg.start).toEqual([0, 0, 10]);
+
+      expect(input.excitation.wireTag).toBe(DIPOLE_LEFT_TAG);
+      expect(input.excitation.segment).toBe(leftLeg.segments);
     });
   });
 


### PR DESCRIPTION
This PR implements the Sloping V antenna topology as specified in the project requirements.

Key changes:
- **Geometry builder**: `buildSlopingVWires` generates two leg wires splaying from the orientation axis by ±vAngle/2 and drooping by a calculated effective slope.
- **Slope clamping**: `computeEffectiveSlope` ensures that antenna wire tips never drop below the `SLOPING_V_MIN_TIP_Z_M` (0.5m) threshold, regardless of the user-requested slope.
- **Excitation logic**: Sloping V antennas are excited at the apex (the junction of the two legs), specifically the last segment of the left leg wire.
- **Refactoring**: The general `buildWires` logic was cleaned up and modularized to handle specialized topologies (Inverted V, Sloping V) more robustly.

Testing:
- Verified geometry calculations for various orientations and splay angles.
- Verified slope clamping logic, including the requested 7.1 MHz / 10m height hand-check case.
- Ensured no regressions in standard dipole or Inverted V topologies.
- All tests pass (`npm test`).

Fixes #141

---
*PR created automatically by Jules for task [14512468059337505600](https://jules.google.com/task/14512468059337505600) started by @2fst4u*