### PR TITLE
🧹 Sweep: Remove unused `setType` and `setSlope` legacy wrappers

### DIFF
--- a/src/store/antennaStore.ts
+++ b/src/store/antennaStore.ts
@@ -387,11 +387,6 @@ export const useAntennaStore = create<AntennaState>()(
   ),
 );
 
-/**
- * Legacy setters maintained for backward compatibility.
- */
-export const setType = (t: AntennaType) => useAntennaStore.getState().setAntennaType(t);
-export const setSlope = (deg: number) => useAntennaStore.getState().setLegSlope(deg);
 
 function clampFreq(f: number): number {
   if (!Number.isFinite(f)) return 7.1;


### PR DESCRIPTION
💡 **What**: Removed `setType` and `setSlope` functions and their associated comments from `src/store/antennaStore.ts`.

🎯 **Why**: These are old legacy wrappers that were flagged by `knip` as unused exports. Removing them cleans up dead code.

🔬 **Verification**: Used `grep -rn "setType" src/ tests/` and `grep -rn "setSlope" src/ tests/` to verify they were no longer imported or used anywhere else in the project. Also ran `npm run build`, `npm run lint`, and `npm test` successfully.

---
*PR created automatically by Jules for task [12326875875411156337](https://jules.google.com/task/12326875875411156337) started by @2fst4u*