### PR TITLE
🧪 Spec: Add PolarPlots tests and bump coverage

### DIFF
--- a/.jules/spec.md
+++ b/.jules/spec.md
@@ -1,3 +1,7 @@
 ## 2024-05-10 - Bumping coverage threshold
 **Learning:** Adding new test files can alter the total codebase line count, which may cause a slight reduction in overall `lines` percentage (e.g., from 59% to 58%) even when `branches` or `functions` coverage increases.
 **Action:** Always verify final thresholds using `npm run test -- --coverage` and manually update vitest configuration thresholds (e.g. `lines` coverage from `69` to `70`) rather than chasing individual coverage numbers blindly.
+
+## 2024-05-15 - Bumping coverage threshold for PolarPlots
+**Learning:** React Component Unit Tests for complex charts. When testing ChartJS components that use callbacks in deep properties (like `options.scales.r.ticks.callback`), simulating those specific nested functions in the mocked component allows testing internal branch logic safely without rendering real canvases.
+**Action:** Mock `react-chartjs-2` specifically testing the callbacks if necessary, rather than trying to load the full canvas.

--- a/tests/PolarPlots.test.tsx
+++ b/tests/PolarPlots.test.tsx
@@ -1,0 +1,89 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { PolarPlots } from '../src/components/Charts/PolarPlots';
+import { useAntennaStore } from '../src/store/antennaStore';
+
+vi.mock('react-chartjs-2', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Radar: (props: any) => {
+    // Simulate Chart.js calling the tick callback
+    if (props.options?.scales?.r?.ticks?.callback) {
+      props.options.scales.r.ticks.callback(10);
+    }
+    return <div data-testid="mock-radar-chart" />;
+  },
+}));
+
+describe('PolarPlots', () => {
+  beforeEach(() => {
+    cleanup();
+    useAntennaStore.setState({
+      showPolarCuts: true,
+      orientation: 'NS',
+      dbRange: 40,
+      theme: 'light',
+      result: {
+        swr: 1.5,
+        computeTimeMs: 10,
+        impedance: { R: 50, X: 0 },
+        maxGainDbi: 0,
+        takeoffElevationDeg: 30,
+        takeoffAzimuthDeg: 0,
+        pattern: {
+          data: new Float32Array(0),
+          thetaSteps: 91,
+          phiSteps: 72,
+          dTheta: 1,
+          dPhi: 5,
+        },
+      },
+    });
+  });
+
+  it('renders polar cuts when showPolarCuts is true', () => {
+    const { getAllByTestId } = render(<PolarPlots />);
+    expect(getAllByTestId('mock-radar-chart').length).toBe(3);
+  });
+
+  it('handles EW orientation', () => {
+    useAntennaStore.setState({ orientation: 'EW' });
+    const { getAllByTestId } = render(<PolarPlots />);
+    expect(getAllByTestId('mock-radar-chart').length).toBe(3);
+  });
+
+  it('handles NE-SW orientation', () => {
+    useAntennaStore.setState({ orientation: 'NE-SW' });
+    const { getAllByTestId } = render(<PolarPlots />);
+    expect(getAllByTestId('mock-radar-chart').length).toBe(3);
+  });
+
+  it('handles NW-SE orientation', () => {
+    useAntennaStore.setState({ orientation: 'NW-SE' });
+    const { getAllByTestId } = render(<PolarPlots />);
+    expect(getAllByTestId('mock-radar-chart').length).toBe(3);
+  });
+
+  it('handles numeric orientation', () => {
+    useAntennaStore.setState({ orientation: 45 });
+    const { getAllByTestId } = render(<PolarPlots />);
+    expect(getAllByTestId('mock-radar-chart').length).toBe(3);
+  });
+
+  it('handles dark theme', () => {
+    useAntennaStore.setState({ theme: 'dark' });
+    const { getAllByTestId } = render(<PolarPlots />);
+    expect(getAllByTestId('mock-radar-chart').length).toBe(3);
+  });
+
+  it('returns null when result is null', () => {
+    useAntennaStore.setState({ result: null });
+    const { container } = render(<PolarPlots />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('returns null when showPolarCuts is false', () => {
+    useAntennaStore.setState({ showPolarCuts: false });
+    const { container } = render(<PolarPlots />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,10 +9,10 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       thresholds: {
-        statements: 55,
-        branches: 43,
-        functions: 61,
-        lines: 73,
+        statements: 59,
+        branches: 46,
+        functions: 64,
+        lines: 79,
       }
     }
   },


### PR DESCRIPTION
🧪 Spec: Add PolarPlots tests and bump coverage

💡 **What:** Added tests for the previously untested `src/components/Charts/PolarPlots.tsx` and bumped global coverage metrics. Appended a new key learning to the `spec.md` journal.
🎯 **Why:** To defend critical rendering logic for polar plot cuts, and lock in our overall project maturity baseline.
📈 **Maturity Impact:** Bumped coverage thresholds for statements (to 59%), branches (to 46%), functions (to 64%), and lines (to 79%) to lock in progress toward business standards.

---
*PR created automatically by Jules for task [5676711152120498443](https://jules.google.com/task/5676711152120498443) started by @2fst4u*