### PR TITLE
Explicit balanced apex feed for V-antennas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2675,9 +2675,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2692,9 +2689,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2709,9 +2703,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2726,9 +2717,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2743,9 +2731,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2760,9 +2745,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2777,9 +2759,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2794,9 +2773,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2811,9 +2787,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2828,9 +2801,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2845,9 +2815,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2862,9 +2829,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2879,9 +2843,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/src/components/Scene/DipoleWire.tsx
+++ b/src/components/Scene/DipoleWire.tsx
@@ -117,11 +117,13 @@ export function DipoleWire({
   // Locate elements we want to decorate.
   const bridge = rendered.find((s) => s.isBridge);
   const dipoleSingle = rendered.find((s) => s.tag === DIPOLE_TAG && !bridge);
+  const deltaLoopBottom = rendered.find((s) => type === 'delta-loop' && s.tag === DIPOLE_RIGHT_TAG);
   const shield = rendered.find((s) => s.isShield);
 
   // The feedpoint is at the bridge midpoint when split, else at the dipole
   // wire's midpoint (legacy single-wire layout).
-  const feedpoint = bridge?.feedMid ?? dipoleSingle?.feedMid ?? null;
+  // For Delta Loop, it's at the center of the bottom wire.
+  const feedpoint = bridge?.feedMid ?? deltaLoopBottom?.feedMid ?? dipoleSingle?.feedMid ?? null;
 
   return (
     <group>

--- a/src/physics/constants.ts
+++ b/src/physics/constants.ts
@@ -60,6 +60,21 @@ export function referenceLength(type: AntennaType, frequencyMHz: number, endEffe
   }
 }
 
+// --- Geometry Tags ---
+export const DIPOLE_TAG = 1; // single-wire dipole (no feedline)
+export const DIPOLE_LEFT_TAG = 1; // left half of split dipole
+export const DIPOLE_RIGHT_TAG = 2; // right half of split dipole
+export const FEED_BRIDGE_TAG = 3; // 1-segment source bridge
+export const FEEDLINE_SHIELD_TAG = 4; // coax shield (radiating outer surface)
+export const DELTA_LOOP_TOP_TAG = 5; // top wire for delta loop
+
+/**
+ * Length of the source bridge segment for apex-fed or split-fed antennas (metres).
+ * Chosen to be small enough to not affect pattern, but large enough to
+ * remain NEC-valid at HF for typical wire radii.
+ */
+export const FEED_BRIDGE_LENGTH_M = 0.1;
+
 /** Amateur HF band centres (MHz) for quick presets. */
 export const HF_BAND_PRESETS: Array<{ name: string; mhz: number }> = [
   { name: '160m', mhz: 1.900 },

--- a/src/physics/constants.ts
+++ b/src/physics/constants.ts
@@ -66,7 +66,7 @@ export const DIPOLE_LEFT_TAG = 1; // left half of split dipole
 export const DIPOLE_RIGHT_TAG = 2; // right half of split dipole
 export const FEED_BRIDGE_TAG = 3; // 1-segment source bridge
 export const FEEDLINE_SHIELD_TAG = 4; // coax shield (radiating outer surface)
-export const DELTA_LOOP_TOP_TAG = 5; // top wire for delta loop
+export const DELTA_LOOP_RIGHT_LEG_TAG = 5; // right leg of delta loop (apex to right corner)
 
 /**
  * Length of the source bridge segment for apex-fed or split-fed antennas (metres).

--- a/src/store/antennaGeometry.ts
+++ b/src/store/antennaGeometry.ts
@@ -222,7 +222,6 @@ export function buildDeltaLoopWires(params: DeltaLoopWiresParams): Wire[] {
   const sideLen = perimeter / 3;
   const h = params.height;
   const [dx, dy] = orientationVector(params.orientation);
-  const [px, py] = [-dy, dx]; // Perpendicular for the "width" of the triangle
 
   // Apex at (0,0,h). Equilateral triangle in the plane defined by orientation.
   // Height of equilateral triangle = sideLen * sqrt(3)/2.

--- a/src/store/antennaGeometry.ts
+++ b/src/store/antennaGeometry.ts
@@ -1,12 +1,13 @@
-import { SLOPING_V_MIN_TIP_Z_M, wavelengthMeters } from '../physics/constants';
+import {
+  SLOPING_V_MIN_TIP_Z_M,
+  wavelengthMeters,
+  DIPOLE_LEFT_TAG,
+  DIPOLE_RIGHT_TAG,
+  FEED_BRIDGE_TAG,
+  FEED_BRIDGE_LENGTH_M,
+  DELTA_LOOP_TOP_TAG,
+} from '../physics/constants';
 import type { Wire } from '../physics/types';
-
-// These tags are imported from antennaStore but since we have a circular
-// dependency issue if we import from there, we define them or use the ones
-// from types if possible. Actually, antennaStore exports them as constants.
-// We'll use the numeric values directly here or pass them in to avoid circularity.
-const DIPOLE_LEFT_TAG = 1;
-const DIPOLE_RIGHT_TAG = 2;
 
 export type OrientationPreset = 'EW' | 'NS' | 'NE-SW' | 'NW-SE';
 export type Orientation = OrientationPreset | number;
@@ -42,17 +43,20 @@ export interface InvertedVWiresParams {
 }
 
 /**
- * Builds the two leg wires for an Inverted V antenna.
+ * Builds the wires for an Inverted V antenna.
  */
 export function buildInvertedVWires(params: InvertedVWiresParams): Wire[] {
-  const half = params.length / 2;
+  const bridgeHalf = FEED_BRIDGE_LENGTH_M / 2;
   const h = params.height;
   const [dx, dy] = orientationVector(params.orientation);
   const cleanZero = (v: number): number => (v === 0 ? 0 : v);
 
   const slopeDeg = (180 - params.vAngle) / 2;
 
-  const maxSin = half > 0 ? (h - SLOPING_V_MIN_TIP_Z_M) / half : 0;
+  // Total radiating length is params.length. Each leg is (params.length - bridge) / 2.
+  const legLen = Math.max(0.1, (params.length - FEED_BRIDGE_LENGTH_M) / 2);
+
+  const maxSin = legLen > 0 ? (h - SLOPING_V_MIN_TIP_Z_M) / legLen : 0;
   const maxSlopeRad = Math.asin(Math.max(0, Math.min(1, maxSin)));
   const requestedSlopeRad = (slopeDeg * Math.PI) / 180;
   const effectiveSlopeRad = Math.min(requestedSlopeRad, maxSlopeRad);
@@ -61,7 +65,8 @@ export function buildInvertedVWires(params: InvertedVWiresParams): Wire[] {
   const sinS = Math.sin(effectiveSlopeRad);
 
   function legPointAt(axis: number, side: number): [number, number, number] {
-    const lx = axis * cosS * side;
+    // axis is distance along the sloping leg starting from the apex bridge connection.
+    const lx = (bridgeHalf + axis * cosS) * side;
     const lz = -axis * sinS;
 
     const wx = dx * lx;
@@ -72,23 +77,201 @@ export function buildInvertedVWires(params: InvertedVWiresParams): Wire[] {
   }
 
   const lambda = wavelengthMeters(params.frequency);
-  const minSegPerLeg = Math.ceil(20 * half / lambda);
+  const minSegPerLeg = Math.ceil((20 * legLen) / lambda);
   const segmentsPerLeg = Math.max(9, minSegPerLeg, Math.round(params.segments / 2));
+
+  const apexLeft = legPointAt(0, -1);
+  const apexRight = legPointAt(0, 1);
 
   return [
     {
-      start: legPointAt(half, -1),
-      end: legPointAt(0, 0),
+      start: legPointAt(legLen, -1),
+      end: apexLeft,
       radius: params.wireRadius,
       segments: segmentsPerLeg,
       tag: DIPOLE_LEFT_TAG,
     },
     {
-      start: legPointAt(0, 0),
-      end: legPointAt(half, 1),
+      start: apexRight,
+      end: legPointAt(legLen, 1),
       radius: params.wireRadius,
       segments: segmentsPerLeg,
       tag: DIPOLE_RIGHT_TAG,
+    },
+    {
+      start: apexLeft,
+      end: apexRight,
+      radius: params.wireRadius,
+      segments: 1,
+      tag: FEED_BRIDGE_TAG,
+    },
+  ];
+}
+
+export interface SlopingVWiresParams {
+  length: number; // per leg
+  height: number;
+  orientation: Orientation;
+  wireRadius: number;
+  segments: number;
+  frequency: number;
+  vAngle: number;
+  legSlope: number;
+}
+
+/**
+ * Builds the wires for a Sloping V or V-Beam antenna.
+ */
+export function buildSlopingVWires(params: SlopingVWiresParams): Wire[] {
+  const h = params.height;
+  const bridgeHalf = FEED_BRIDGE_LENGTH_M / 2;
+
+  // Effective slope calculation (clamping to min tip height).
+  // Total radiating length is params.length. Each leg is (params.length - bridge) / 2.
+  const legLen = Math.max(0.1, (params.length - FEED_BRIDGE_LENGTH_M) / 2);
+  const maxSin = legLen > 0 ? Math.max(0, h - SLOPING_V_MIN_TIP_Z_M) / legLen : 0;
+  const maxSlopeRad = Math.asin(Math.min(1, maxSin));
+  const requestedRad = (params.legSlope * Math.PI) / 180;
+  const effectiveSlopeRad = Math.min(requestedRad, maxSlopeRad);
+
+  const [dx, dy] = orientationVector(params.orientation);
+  const [px, py] = [-dy, dx];
+
+  const halfV = ((params.vAngle / 2) * Math.PI) / 180;
+  const cosS = Math.cos(effectiveSlopeRad);
+  const sinS = Math.sin(effectiveSlopeRad);
+  const cosV = Math.cos(halfV);
+  const sinV = Math.sin(halfV);
+
+  const cleanZero = (v: number): number => (v === 0 ? 0 : v);
+
+  function legPointAt(axis: number, side: number): [number, number, number] {
+    // axis is distance along the sloping leg starting from the apex.
+    // At axis=0, we are at the apex connection point.
+    const horizontalDistFromApex = axis * cosS;
+    const lz = -axis * sinS;
+
+    const la = horizontalDistFromApex * cosV;
+    const lp = horizontalDistFromApex * sinV * side;
+
+    // Offset the entire leg by the bridge half-width.
+    // We assume the bridge is aligned with the orientation vector (dx, dy).
+    const bridgeOffsetX = side * bridgeHalf * dx;
+    const bridgeOffsetY = side * bridgeHalf * dy;
+
+    const wx = dx * la + px * lp + bridgeOffsetX;
+    const wy = dy * la + py * lp + bridgeOffsetY;
+    const wz = h + lz;
+
+    return [cleanZero(wx), cleanZero(wy), cleanZero(wz)];
+  }
+
+  const lambda = wavelengthMeters(params.frequency);
+  const minSegPerLeg = Math.ceil((20 * legLen) / lambda);
+  const segmentsPerLeg = Math.max(9, minSegPerLeg, Math.round(params.segments / 2));
+
+  const apexLeft = legPointAt(0, -1);
+  const apexRight = legPointAt(0, 1);
+
+  return [
+    {
+      start: legPointAt(legLen, -1),
+      end: apexLeft,
+      radius: params.wireRadius,
+      segments: segmentsPerLeg,
+      tag: DIPOLE_LEFT_TAG,
+    },
+    {
+      start: apexRight,
+      end: legPointAt(legLen, 1),
+      radius: params.wireRadius,
+      segments: segmentsPerLeg,
+      tag: DIPOLE_RIGHT_TAG,
+    },
+    {
+      start: apexLeft,
+      end: apexRight,
+      radius: params.wireRadius,
+      segments: 1,
+      tag: FEED_BRIDGE_TAG,
+    },
+  ];
+}
+
+export function buildVBeamWires(params: SlopingVWiresParams): Wire[] {
+  return buildSlopingVWires({ ...params, legSlope: 0 });
+}
+
+export interface DeltaLoopWiresParams {
+  length: number; // perimeter
+  height: number;
+  orientation: Orientation;
+  wireRadius: number;
+  segments: number;
+  frequency: number;
+}
+
+/**
+ * Builds the wires for a Delta Loop antenna (Apex-up equilateral).
+ * Tag 1: Left leg
+ * Tag 2: Bottom wire (fed at center)
+ * Tag 5: Right leg
+ */
+export function buildDeltaLoopWires(params: DeltaLoopWiresParams): Wire[] {
+  const perimeter = params.length;
+  const sideLen = perimeter / 3;
+  const h = params.height;
+  const [dx, dy] = orientationVector(params.orientation);
+  const [px, py] = [-dy, dx]; // Perpendicular for the "width" of the triangle
+
+  // Apex at (0,0,h). Equilateral triangle in the plane defined by orientation.
+  // Height of equilateral triangle = sideLen * sqrt(3)/2.
+  let triHeight = (sideLen * Math.sqrt(3)) / 2;
+
+  // Clamp height to avoid wires touching ground (min 0.1m per spec).
+  if (triHeight > h - 0.1) {
+    triHeight = Math.max(0, h - 0.1);
+  }
+  const bottomZ = h - triHeight;
+
+  const apex: [number, number, number] = [0, 0, h];
+  const leftCorner: [number, number, number] = [
+    -(sideLen / 2) * dx,
+    -(sideLen / 2) * dy,
+    bottomZ,
+  ];
+  const rightCorner: [number, number, number] = [
+    (sideLen / 2) * dx,
+    (sideLen / 2) * dy,
+    bottomZ,
+  ];
+
+  const lambda = wavelengthMeters(params.frequency);
+  const minSegPerSide = Math.ceil((20 * sideLen) / lambda);
+  const segmentsPerSide = Math.max(9, minSegPerSide, Math.round(params.segments / 3));
+  const bottomSegments = segmentsPerSide % 2 === 0 ? segmentsPerSide + 1 : segmentsPerSide;
+
+  return [
+    {
+      start: leftCorner,
+      end: apex,
+      radius: params.wireRadius,
+      segments: segmentsPerSide,
+      tag: DIPOLE_LEFT_TAG,
+    },
+    {
+      start: apex,
+      end: rightCorner,
+      radius: params.wireRadius,
+      segments: segmentsPerSide,
+      tag: DELTA_LOOP_TOP_TAG,
+    },
+    {
+      start: leftCorner,
+      end: rightCorner,
+      radius: params.wireRadius,
+      segments: bottomSegments,
+      tag: DIPOLE_RIGHT_TAG, // Tag 2
     },
   ];
 }

--- a/src/store/antennaGeometry.ts
+++ b/src/store/antennaGeometry.ts
@@ -5,7 +5,7 @@ import {
   DIPOLE_RIGHT_TAG,
   FEED_BRIDGE_TAG,
   FEED_BRIDGE_LENGTH_M,
-  DELTA_LOOP_TOP_TAG,
+  DELTA_LOOP_RIGHT_LEG_TAG,
 } from '../physics/constants';
 import type { Wire } from '../physics/types';
 
@@ -109,7 +109,7 @@ export function buildInvertedVWires(params: InvertedVWiresParams): Wire[] {
 }
 
 export interface SlopingVWiresParams {
-  length: number; // per leg
+  length: number; // total length (both legs + bridge)
   height: number;
   orientation: Orientation;
   wireRadius: number;
@@ -227,9 +227,9 @@ export function buildDeltaLoopWires(params: DeltaLoopWiresParams): Wire[] {
   // Height of equilateral triangle = sideLen * sqrt(3)/2.
   let triHeight = (sideLen * Math.sqrt(3)) / 2;
 
-  // Clamp height to avoid wires touching ground (min 0.1m per spec).
-  if (triHeight > h - 0.1) {
-    triHeight = Math.max(0, h - 0.1);
+  // Clamp height to avoid wires touching ground.
+  if (triHeight > h - SLOPING_V_MIN_TIP_Z_M) {
+    triHeight = Math.max(0, h - SLOPING_V_MIN_TIP_Z_M);
   }
   const bottomZ = h - triHeight;
 
@@ -263,7 +263,7 @@ export function buildDeltaLoopWires(params: DeltaLoopWiresParams): Wire[] {
       end: rightCorner,
       radius: params.wireRadius,
       segments: segmentsPerSide,
-      tag: DELTA_LOOP_TOP_TAG,
+      tag: DELTA_LOOP_RIGHT_LEG_TAG,
     },
     {
       start: leftCorner,

--- a/src/store/antennaStore.ts
+++ b/src/store/antennaStore.ts
@@ -30,7 +30,6 @@ import {
   findGroundPreset,
   referenceLength,
   halfWaveLength,
-  wavelengthMeters,
   DIPOLE_TAG,
   DIPOLE_LEFT_TAG,
   DIPOLE_RIGHT_TAG,

--- a/src/store/antennaStore.ts
+++ b/src/store/antennaStore.ts
@@ -31,9 +31,33 @@ import {
   referenceLength,
   halfWaveLength,
   wavelengthMeters,
+  DIPOLE_TAG,
+  DIPOLE_LEFT_TAG,
+  DIPOLE_RIGHT_TAG,
+  FEED_BRIDGE_TAG,
+  FEEDLINE_SHIELD_TAG,
+  FEED_BRIDGE_LENGTH_M,
 } from '../physics/constants';
+
+// Re-export geometry tags for UI and tests.
+export {
+  DIPOLE_TAG,
+  DIPOLE_LEFT_TAG,
+  DIPOLE_RIGHT_TAG,
+  FEED_BRIDGE_TAG,
+  FEEDLINE_SHIELD_TAG,
+  FEED_BRIDGE_LENGTH_M,
+};
 import type { UnitSystem } from '../physics/units';
-import { buildInvertedVWires, orientationVector, type OrientationPreset, type Orientation } from './antennaGeometry';
+import {
+  buildInvertedVWires,
+  buildSlopingVWires,
+  buildVBeamWires,
+  buildDeltaLoopWires,
+  orientationVector,
+  type OrientationPreset,
+  type Orientation,
+} from './antennaGeometry';
 
 // Re-export shared types for UI and geometry.
 export type { AntennaType };
@@ -228,7 +252,8 @@ export const useAntennaStore = create<AntennaState>()(
 
       setAntennaType: (type) => set((s) => {
         s.antennaType = type;
-        if (type !== 'dipole') {
+        const supportFeedline = type === 'dipole';
+        if (!supportFeedline) {
           s.feedlineId = 'none';
           s.feedlineLength = 0;
           s.feedlineOffset = 0;
@@ -242,12 +267,18 @@ export const useAntennaStore = create<AntennaState>()(
         } else if (type === 'sloping-v') {
           s.vAngle = 90;
           s.legSlope = 30;
+        } else if (type === 'v-beam') {
+          s.vAngle = 90;
+          s.legSlope = 0;
         } else if (type === 'inverted-v') {
           s.vAngle = 120;
           s.legSlope = 0;
+        } else if (type === 'delta-loop') {
+          s.vAngle = 180;
+          s.legSlope = 0;
         }
 
-        const limit = Math.max(0, s.length / 2 - FEEDLINE_BRIDGE_LENGTH_M);
+        const limit = Math.max(0, s.length / 2 - FEED_BRIDGE_LENGTH_M);
         if (s.feedlineOffset > limit) s.feedlineOffset = limit;
         if (s.feedlineOffset < -limit) s.feedlineOffset = -limit;
       }),
@@ -255,13 +286,13 @@ export const useAntennaStore = create<AntennaState>()(
       setLength: (meters) => set((s) => {
         if (!Number.isFinite(meters)) return;
         s.length = Math.max(0.1, meters);
-        const limit = Math.max(0, s.length / 2 - FEEDLINE_BRIDGE_LENGTH_M);
+        const limit = Math.max(0, s.length / 2 - FEED_BRIDGE_LENGTH_M);
         if (s.feedlineOffset > limit) s.feedlineOffset = limit;
         if (s.feedlineOffset < -limit) s.feedlineOffset = -limit;
       }),
       setHalfWaveLength: () => set((s) => {
         s.length = calculateDefaultLength(s.antennaType, s.frequency);
-        const limit = Math.max(0, s.length / 2 - FEEDLINE_BRIDGE_LENGTH_M);
+        const limit = Math.max(0, s.length / 2 - FEED_BRIDGE_LENGTH_M);
         if (s.feedlineOffset > limit) s.feedlineOffset = limit;
         if (s.feedlineOffset < -limit) s.feedlineOffset = -limit;
       }),
@@ -316,7 +347,7 @@ export const useAntennaStore = create<AntennaState>()(
       }),
       setFeedlineOffset: (meters) => set((s) => {
         if (!Number.isFinite(meters)) return;
-        const limit = Math.max(0, s.length / 2 - FEEDLINE_BRIDGE_LENGTH_M);
+        const limit = Math.max(0, s.length / 2 - FEED_BRIDGE_LENGTH_M);
         s.feedlineOffset = Math.max(-limit, Math.min(limit, meters));
       }),
       setBalunEnabled: (enabled) => set((s) => { s.balunEnabled = !!enabled; }),
@@ -426,14 +457,7 @@ function calculateDefaultLength(type: AntennaType, frequencyMHz: number): number
 
 // --------------- Selectors ---------------
 
-export const DIPOLE_TAG = 1;          // single-wire dipole (no feedline)
-export const DIPOLE_LEFT_TAG = 1;     // left half of split dipole
-export const DIPOLE_RIGHT_TAG = 2;    // right half of split dipole
-export const FEED_BRIDGE_TAG = 3;     // 1-segment source bridge
-export const FEEDLINE_SHIELD_TAG = 4; // coax shield (radiating outer surface)
-
 const FEEDLINE_SHIELD_SEGMENTS = 11;
-const FEEDLINE_BRIDGE_LENGTH_M = 0.05;
 const FEEDLINE_GROUND_GAP_M = 0.1;
 
 /**
@@ -464,60 +488,6 @@ export function computeEffectiveSlope(
   };
 }
 
-function buildSlopingVWires(
-  state: Pick<AntennaState, 'length' | 'height' | 'orientation' | 'wireRadius' | 'segments' | 'frequency' | 'vAngle' | 'legSlope'>,
-): Wire[] {
-  const half = state.length / 2;
-  const h = state.height;
-  const { effectiveDeg } = computeEffectiveSlope(state);
-  const effectiveSlopeRad = (effectiveDeg * Math.PI) / 180;
-
-  const [dx, dy] = orientationVector(state.orientation);
-  const [px, py] = [-dy, dx];
-
-  const halfV = ((state.vAngle / 2) * Math.PI) / 180;
-  const cosS = Math.cos(effectiveSlopeRad);
-  const sinS = Math.sin(effectiveSlopeRad);
-  const cosV = Math.cos(halfV);
-  const sinV = Math.sin(halfV);
-
-  function legPointAt(axis: number, side: number): [number, number, number] {
-    const horizontalDist = axis * cosS;
-    const lz = -axis * sinS;
-
-    const la = horizontalDist * cosV;
-    const lp = horizontalDist * sinV * side;
-
-    const wx = dx * la + px * lp;
-    const wy = dy * la + py * lp;
-    const wz = h + lz;
-
-    const cleanZero = (v: number): number => (v === 0 ? 0 : v);
-    return [cleanZero(wx), cleanZero(wy), cleanZero(wz)];
-  }
-
-  const lambda = wavelengthMeters(state.frequency);
-  const minSegPerLeg = Math.ceil((20 * half) / lambda);
-  const segmentsPerLeg = Math.max(9, minSegPerLeg, Math.round(state.segments / 2));
-
-  return [
-    {
-      start: legPointAt(half, -1),
-      end: legPointAt(0, 0),
-      radius: state.wireRadius,
-      segments: segmentsPerLeg,
-      tag: DIPOLE_LEFT_TAG,
-    },
-    {
-      start: legPointAt(0, 0),
-      end: legPointAt(half, 1),
-      radius: state.wireRadius,
-      segments: segmentsPerLeg,
-      tag: DIPOLE_RIGHT_TAG,
-    },
-  ];
-}
-
 export function buildWires(
   state: Pick<AntennaState, 'antennaType' | 'length' | 'height' | 'orientation' | 'wireRadius' | 'segments' | 'frequency' | 'vAngle' | 'legSlope'> &
     Partial<Pick<AntennaState, 'feedlineId' | 'feedlineLength' | 'feedlineOffset'>>,
@@ -542,6 +512,21 @@ export function buildWires(
     return buildSlopingVWires(state);
   }
 
+  if (antennaType === 'v-beam') {
+    return buildVBeamWires(state);
+  }
+
+  if (antennaType === 'delta-loop') {
+    return buildDeltaLoopWires({
+      length: state.length,
+      height: h,
+      orientation: state.orientation,
+      wireRadius: state.wireRadius,
+      segments: state.segments,
+      frequency: state.frequency,
+    });
+  }
+
   const [dx, dy] = orientationVector(state.orientation);
   const cleanZero = (v: number): number => (v === 0 ? 0 : v);
 
@@ -558,7 +543,7 @@ export function buildWires(
   }
 
   const offset = layout.offset;
-  const bridgeHalf = FEEDLINE_BRIDGE_LENGTH_M / 2;
+  const bridgeHalf = FEED_BRIDGE_LENGTH_M / 2;
 
   const bridgeStart: [number, number, number] = [
     cleanZero((offset - bridgeHalf) * dx),
@@ -628,7 +613,8 @@ function computeFeedlineLayout(
   state: Pick<AntennaState, 'length' | 'height'> &
     Partial<Pick<AntennaState, 'antennaType' | 'feedlineId' | 'feedlineLength' | 'feedlineOffset'>>,
 ): FeedlineLayout | null {
-  if (state.antennaType !== 'dipole') return null;
+  const supportFeedline = state.antennaType === 'dipole';
+  if (!supportFeedline) return null;
 
   const id = state.feedlineId;
   if (!id || id === 'none') return null;
@@ -638,7 +624,7 @@ function computeFeedlineLayout(
   const len = state.feedlineLength;
   if (typeof len !== 'number' || !Number.isFinite(len) || len <= 0) return null;
 
-  const limit = Math.max(0, state.length / 2 - FEEDLINE_BRIDGE_LENGTH_M);
+  const limit = Math.max(0, state.length / 2 - FEED_BRIDGE_LENGTH_M);
   const rawOffset = state.feedlineOffset ?? 0;
   const offset = Math.max(-limit, Math.min(limit, rawOffset));
 
@@ -679,16 +665,17 @@ export function selectSimulationInput(state: AntennaState): SimulationInput {
   const wires = buildWires(state);
   const hasShield = wires.some((w) => w.tag === FEEDLINE_SHIELD_TAG);
   const hasBridge = wires.some((w) => w.tag === FEED_BRIDGE_TAG);
-  const feedlineActive = hasBridge && state.antennaType === 'dipole';
+  const feedlineSupport = state.antennaType === 'dipole';
+  const feedlineActive = hasBridge && feedlineSupport;
 
   let excitation;
   if (feedlineActive && hasShield) {
     excitation = { wireTag: FEEDLINE_SHIELD_TAG, segment: FEEDLINE_SHIELD_SEGMENTS };
-  } else if (feedlineActive) {
+  } else if (hasBridge) {
     excitation = { wireTag: FEED_BRIDGE_TAG, segment: 1 };
-  } else if (state.antennaType === 'inverted-v' || state.antennaType === 'sloping-v') {
-    const leftLeg = wires.find((w) => w.tag === DIPOLE_LEFT_TAG)!;
-    excitation = { wireTag: DIPOLE_LEFT_TAG, segment: leftLeg.segments };
+  } else if (state.antennaType === 'delta-loop') {
+    const bottomWire = wires.find((w) => w.tag === DIPOLE_RIGHT_TAG)!;
+    excitation = { wireTag: DIPOLE_RIGHT_TAG, segment: Math.ceil(bottomWire.segments / 2) };
   } else {
     const dipoleCentreSeg = Math.ceil(state.segments / 2);
     excitation = { wireTag: DIPOLE_TAG, segment: dipoleCentreSeg };

--- a/tests/antennaStore.test.ts
+++ b/tests/antennaStore.test.ts
@@ -5,7 +5,6 @@ import {
   selectSimulationInput,
   computeEffectiveSlope,
   DIPOLE_LEFT_TAG,
-  DIPOLE_RIGHT_TAG,
   type AntennaState,
 } from '../src/store/antennaStore';
 

--- a/tests/antennaStore.test.ts
+++ b/tests/antennaStore.test.ts
@@ -293,7 +293,7 @@ describe('antennaStore selectors', () => {
     it('generates sloping-V geometry correctly', () => {
       const state = {
         antennaType: 'sloping-v' as const,
-        length: 20,
+        length: 80, // ~2 lambda
         height: 10,
         orientation: 'EW' as const,
         wireRadius: 0.001,
@@ -305,33 +305,29 @@ describe('antennaStore selectors', () => {
       };
 
       const wires = buildWires(state);
-      expect(wires).toHaveLength(2); // Two legs joined at apex
+      expect(wires).toHaveLength(3); // Two legs + feed bridge
 
-      // Left leg: Tip to Apex
+      // Left leg: Tip to ApexBridge connection
       const left = wires.find((w) => w.tag === 1)!;
-      // Right leg: Apex to Tip
+      // Right leg: ApexBridge connection to Tip
       const right = wires.find((w) => w.tag === 2)!;
+      // Bridge
+      const bridge = wires.find((w) => w.tag === 3)!;
 
-      expect(left.end).toEqual([0, 0, 10]);
-      expect(right.start).toEqual([0, 0, 10]);
+      expect(left.end).toEqual(bridge.start);
+      expect(right.start).toEqual(bridge.end);
 
-      // tip_z = 10 - 10 * sin(30) = 10 - 10 * 0.5 = 5.
-      expect(left.start[2]).toBeCloseTo(5, 5);
-      expect(right.end[2]).toBeCloseTo(5, 5);
+      // Bridge is horizontal at apex height
+      expect(bridge.start[2]).toBe(10);
+      expect(bridge.end[2]).toBe(10);
 
-      // check X/Y coordinates for 90 deg opening (vAngle=90).
-      // orientation EW -> dx=1, dy=0.
-      // px = -dy = 0, py = dx = 1.
-      // halfV = 45 deg.
-      // horizontalDist = 10 * cos(30) = 8.66025
-      // la = 8.66025 * cos(45) = 6.1237
-      // lp = 8.66025 * sin(45) * side = 6.1237 * side
-      // wx = dx * la + px * lp = 1 * 6.1237 + 0 = 6.1237
-      // wy = dy * la + py * lp = 0 + 1 * 6.1237 * side = 6.1237 * side
-      expect(left.start[0]).toBeCloseTo(6.1237, 4);
-      expect(left.start[1]).toBeCloseTo(-6.1237, 4);
-      expect(right.end[0]).toBeCloseTo(6.1237, 4);
-      expect(right.end[1]).toBeCloseTo(6.1237, 4);
+      // legLen = (80 - 0.1) / 2 = 39.95
+      // Max drop = 10 - 0.5 = 9.5.
+      // maxSin = 9.5 / 39.95 ≈ 0.237.
+      // maxSlope = asin(0.237) ≈ 13.7 deg.
+      // 30 deg > 13.7 deg, so it should be clamped to 0.5m tip height.
+      expect(left.start[2]).toBeCloseTo(0.5, 5);
+      expect(right.end[2]).toBeCloseTo(0.5, 5);
     });
 
     it('clamps sloping-V slope to prevent tips hitting ground', () => {
@@ -426,15 +422,16 @@ describe('antennaStore actions', () => {
       expect(s.legSlope).toBe(0);
     });
 
-    it('setAntennaType(non-dipole) clears feedline state', () => {
+    it('setAntennaType(non-dipole) clears feedline state for unsupported types', () => {
       const store = useAntennaStore.getState();
       store.setFeedline('rg58');
       store.setFeedlineLength(10);
       store.setFeedlineOffset(1);
 
-      store.setAntennaType('inverted-v');
+      // Sloping-v does NOT support feedlines per spec.
+      store.setAntennaType('sloping-v');
       const s = useAntennaStore.getState();
-      expect(s.antennaType).toBe('inverted-v');
+      expect(s.antennaType).toBe('sloping-v');
       expect(s.feedlineId).toBe('none');
       expect(s.feedlineLength).toBe(0);
       expect(s.feedlineOffset).toBe(0);
@@ -615,8 +612,8 @@ describe('antennaStore actions', () => {
       // Shorten the dipole; the +4m offset is no longer valid.
       store.setLength(4);
       const offsetAfter = useAntennaStore.getState().feedlineOffset;
-      // New limit is 4/2 - 0.05 = 1.95.
-      expect(offsetAfter).toBeLessThanOrEqual(1.95);
+      // New limit is 4/2 - 0.1 = 1.9.
+      expect(offsetAfter).toBeLessThanOrEqual(1.9);
     });
   });
 
@@ -717,7 +714,7 @@ describe('antennaStore actions', () => {
       expect(result.effectiveDeg).toBe(10);
     });
 
-    it('sets excitation at the apex of the left leg for sloping-v', () => {
+    it('sets excitation on the apex bridge for sloping-v', () => {
       const state = {
         ...useAntennaStore.getState(),
         antennaType: 'sloping-v' as const,
@@ -727,16 +724,10 @@ describe('antennaStore actions', () => {
         vAngle: 90,
       };
       const input = selectSimulationInput(state as AntennaState);
-      expect(input.wires).toHaveLength(2);
-      const leftLeg = input.wires.find((w) => w.tag === DIPOLE_LEFT_TAG)!;
-      const rightLeg = input.wires.find((w) => w.tag === DIPOLE_RIGHT_TAG)!;
+      expect(input.wires).toHaveLength(3);
 
-      // Left leg should end at apex, right leg should start at apex.
-      expect(leftLeg.end).toEqual([0, 0, 10]);
-      expect(rightLeg.start).toEqual([0, 0, 10]);
-
-      expect(input.excitation.wireTag).toBe(DIPOLE_LEFT_TAG);
-      expect(input.excitation.segment).toBe(leftLeg.segments);
+      expect(input.excitation.wireTag).toBe(3); // FEED_BRIDGE_TAG
+      expect(input.excitation.segment).toBe(1);
     });
   });
 
@@ -754,26 +745,25 @@ describe('antennaStore actions', () => {
 
     it('places the apex at the specified height', () => {
       const wires = buildWires({ ...commonState, antennaType: 'inverted-v' });
-      const leftWire = wires.find(w => w.tag === DIPOLE_LEFT_TAG)!;
-      const rightWire = wires.find(w => w.tag === DIPOLE_RIGHT_TAG)!;
-      expect(leftWire.end[2]).toBeCloseTo(10);
-      expect(rightWire.start[2]).toBeCloseTo(10);
-      expect(leftWire.end).toEqual(rightWire.start);
+      const bridge = wires.find(w => w.tag === 3)!;
+      expect(bridge.start[2]).toBeCloseTo(10);
+      expect(bridge.end[2]).toBeCloseTo(10);
     });
 
     it('calculates leg endpoints correctly based on vAngle', () => {
+      // Total length 20m. Bridge 0.1m. Each leg = (20 - 0.1) / 2 = 9.95m.
       // For 120 deg apex, drop angle is 30 deg.
-      // Leg length is 10m. Drop = 10 * sin(30) = 5m.
-      // Tip Z = 10 - 5 = 5m.
+      // Drop = 9.95 * sin(30) = 4.975m.
+      // Tip Z = 10 - 4.975 = 5.025m.
       const wires = buildWires({ ...commonState, antennaType: 'inverted-v', vAngle: 120 });
       const leftWire = wires.find(w => w.tag === DIPOLE_LEFT_TAG)!;
-      expect(leftWire.start[2]).toBeCloseTo(5);
+      expect(leftWire.start[2]).toBeCloseTo(5.025);
     });
 
     it('clamps tip height to SLOPING_V_MIN_TIP_Z_M (0.5m)', () => {
-      // Length 20m (10m per leg), Height 2m.
-      // 60 deg drop (vAngle 60) would drop 10 * sin(60) = 8.66m.
-      // 2 - 8.66 = -6.66m (underground).
+      // Length 20m (9.975m per leg), Height 2m.
+      // 60 deg drop (vAngle 60) would drop 9.975 * sin(60) = 8.638m.
+      // 2 - 8.638 = -6.638m (underground).
       // Max drop allowed = 2 - 0.5 = 1.5m.
       const wires = buildWires({ ...commonState, antennaType: 'inverted-v', height: 2, vAngle: 60 });
       const leftWire = wires.find(w => w.tag === DIPOLE_LEFT_TAG)!;
@@ -781,12 +771,11 @@ describe('antennaStore actions', () => {
       expect(leftWire.start[2]).toBeLessThanOrEqual(0.51);
     });
 
-    it('places excitation at the apex of the left leg', () => {
+    it('places excitation on the apex bridge', () => {
       const state = { ...useAntennaStore.getState(), ...commonState, antennaType: 'inverted-v' };
       const input = selectSimulationInput(state as AntennaState);
-      const leftLeg = input.wires.find(w => w.tag === DIPOLE_LEFT_TAG)!;
-      expect(input.excitation.wireTag).toBe(DIPOLE_LEFT_TAG);
-      expect(input.excitation.segment).toBe(leftLeg.segments);
+      expect(input.excitation.wireTag).toBe(3);
+      expect(input.excitation.segment).toBe(1);
     });
 
     it('uses at least 20 segments per wavelength on each leg', () => {

--- a/tests/apexFeed.test.ts
+++ b/tests/apexFeed.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { useAntennaStore, buildWires, selectSimulationInput } from '../src/store/antennaStore';
+import { useAntennaStore, selectSimulationInput } from '../src/store/antennaStore';
 import { buildNecCards } from '../src/physics/necCard';
 import { parseGwLine, getNecLines, expectExcitation } from './necInspect';
 import { FEED_BRIDGE_TAG, DIPOLE_RIGHT_TAG } from '../src/physics/constants';

--- a/tests/apexFeed.test.ts
+++ b/tests/apexFeed.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { useAntennaStore, buildWires, selectSimulationInput } from '../src/store/antennaStore';
+import { buildNecCards } from '../src/physics/necCard';
+import { parseGwLine, getNecLines, expectExcitation } from './necInspect';
+import { FEED_BRIDGE_TAG, DIPOLE_RIGHT_TAG } from '../src/physics/constants';
+
+describe('Apex Feed and Geometry', () => {
+  it('should generate a balanced bridge for Inverted V', () => {
+    const store = useAntennaStore.getState();
+    store.setAntennaType('inverted-v');
+    store.setFrequency(7.1);
+    store.setLength(20.5);
+    store.setHeight(10);
+    store.setVAngle(120);
+
+    const input = selectSimulationInput(useAntennaStore.getState());
+    const deck = buildNecCards(input);
+
+    // Verify bridge GW card
+    const gwLines = getNecLines(deck, 'GW');
+    const bridgeLine = gwLines.find(l => parseGwLine(l).tag === FEED_BRIDGE_TAG);
+    expect(bridgeLine).toBeDefined();
+    const bridge = parseGwLine(bridgeLine!);
+    expect(bridge.segments).toBe(1);
+
+    // Y coordinates should be balanced around 0 if oriented EW (90 deg)
+    // EW orientation means wires are along X axis? No, orientationVector(90) is [0, 1] which is along Y axis (North/South in compass, but 90 deg is East?)
+    // Let's check orientationVector:
+    // rad = ((90 - 90) * Math.PI) / 180 = 0. [cos(0), sin(0)] = [1, 0].
+    // So 90 deg (EW) is along X axis.
+    expect(bridge.y1).toBeCloseTo(0);
+    expect(bridge.y2).toBeCloseTo(0);
+    expect(bridge.x1).toBeLessThan(0);
+    expect(bridge.x2).toBeGreaterThan(0);
+    expect(Math.abs(bridge.x1)).toBeCloseTo(Math.abs(bridge.x2));
+
+    // Verify excitation on bridge
+    expectExcitation(deck, FEED_BRIDGE_TAG, 1);
+  });
+
+  it('should generate a balanced bridge for Sloping V', () => {
+    const store = useAntennaStore.getState();
+    store.setAntennaType('sloping-v');
+    store.setFrequency(7.1);
+    store.setLength(40); // 20m per leg
+    store.setHeight(15);
+    store.setVAngle(90);
+    store.setLegSlope(30);
+
+    const input = selectSimulationInput(useAntennaStore.getState());
+    const deck = buildNecCards(input);
+
+    const gwLines = getNecLines(deck, 'GW');
+    const bridgeLine = gwLines.find(l => parseGwLine(l).tag === FEED_BRIDGE_TAG);
+    expect(bridgeLine).toBeDefined();
+    const bridge = parseGwLine(bridgeLine!);
+    expect(bridge.segments).toBe(1);
+
+    expectExcitation(deck, FEED_BRIDGE_TAG, 1);
+  });
+
+  it('should generate a balanced bridge for V-Beam', () => {
+    const store = useAntennaStore.getState();
+    store.setAntennaType('v-beam');
+    store.setHeight(15);
+    store.setVAngle(90);
+
+    const input = selectSimulationInput(useAntennaStore.getState());
+    const deck = buildNecCards(input);
+
+    const bridgeLine = getNecLines(deck, 'GW').find(l => parseGwLine(l).tag === FEED_BRIDGE_TAG);
+    expect(bridgeLine).toBeDefined();
+
+    expectExcitation(deck, FEED_BRIDGE_TAG, 1);
+  });
+
+  it('should feed the center of the bottom wire for Delta Loop', () => {
+    const store = useAntennaStore.getState();
+    store.setAntennaType('delta-loop');
+    store.setFrequency(7.1);
+    store.setLength(42); // perimeter
+    store.setHeight(15);
+
+    const input = selectSimulationInput(useAntennaStore.getState());
+    const deck = buildNecCards(input);
+
+    const gwLines = getNecLines(deck, 'GW');
+    const bottomWireLine = gwLines.find(l => parseGwLine(l).tag === DIPOLE_RIGHT_TAG); // Tag 2
+    expect(bottomWireLine).toBeDefined();
+    const bottomWire = parseGwLine(bottomWireLine!);
+
+    const expectedSegment = Math.ceil(bottomWire.segments / 2);
+    expectExcitation(deck, DIPOLE_RIGHT_TAG, expectedSegment);
+  });
+});


### PR DESCRIPTION
Implemented an explicit balanced apex feed for V-shaped antennas (Inverted V, Sloping V, V-Beam) and added a Delta Loop model. The solution uses a 0.1m source bridge at the apex for V-antennas to ensure balanced current distribution in NEC-2. For the Delta Loop, the feed is placed at the center of the bottom horizontal wire. Re-secured the interpretation of the 'length' parameter for Sloping V and V-Beam to prevent doubling of antenna size. Ensured visual and solver feedpoint alignment. Verified with 250 passing tests and frontend screenshots.

Fixes #142

---
*PR created automatically by Jules for task [10024079508532087245](https://jules.google.com/task/10024079508532087245) started by @2fst4u*