### PR TITLE
🔭 Scout: Upgrade generic div wrappers to semantic section tags for panel sections

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -1,3 +1,6 @@
 ## 2025-05-11 - [Inline Styles for SEO Semantics Overriding CSS]
 **Learning:** When upgrading a generic `<div>` to a semantic `<h2>` tag, attempting to fully clear browser default styles using inline styles (e.g. `style={{ fontSize: 'inherit' }}`) can inadvertently create a CSS specificity issue where the inline style aggressively overrides the component's actual target CSS class rules.
 **Action:** Only use inline styles to reset properties you know aren't governed by a local CSS class (e.g. `margin: 0`), and leave properties like `fontSize` alone so the `.class` rules can apply normally.
+## 2025-05-13 - [Semantic HTML Structure]
+**Learning:** Upgrading generic `<div>` wrappers to `<section>` tags provides excellent semantic document outlining without requiring changes to CSS styles (assuming classes are applied correctly on the new tags), making it a highly effective and safe SEO boost.
+**Action:** Always verify with `git diff` that the correct opening and closing tags were updated and no CSS classes were lost during the replacement.

--- a/src/components/Charts/PolarPlots.tsx
+++ b/src/components/Charts/PolarPlots.tsx
@@ -173,7 +173,7 @@ export function PolarPlots() {
   if (!showPolarCuts || !result || !azData || !elDataBroadside || !elDataEndOn) return null;
 
   return (
-    <div className="panel-section">
+    <section className="panel-section">
       {/* SEO: Use sequential heading tags (H2) to follow document outline initiated by H1 */}
       <h2>Polar cuts</h2>
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(130px, 1fr))', gap: 8 }}>
@@ -244,6 +244,6 @@ export function PolarPlots() {
           </div>
         </div>
       </div>
-    </div>
+    </section>
   );
 }

--- a/src/components/Charts/SWRChart.tsx
+++ b/src/components/Charts/SWRChart.tsx
@@ -246,16 +246,16 @@ export function SWRChart() {
 
   if (!result || sweep.length === 0) {
     return (
-      <div className="panel-section" style={{ minHeight: 220 }}>
+      <section className="panel-section" style={{ minHeight: 220 }}>
         {/* SEO: Use sequential heading tags (H2) to follow document outline initiated by H1 */}
         <h2>SWR sweep</h2>
         <div style={{ color: 'var(--text-muted)', fontSize: 12 }}>Computing frequency sweep…</div>
-      </div>
+      </section>
     );
   }
 
   return (
-    <div className="panel-section" style={{ minHeight: 220 }}>
+    <section className="panel-section" style={{ minHeight: 220 }}>
       {/* SEO: Use sequential heading tags (H2) to follow document outline initiated by H1 */}
       <h2>SWR sweep</h2>
       <div style={{ height: 130 }}>
@@ -283,7 +283,7 @@ export function SWRChart() {
           </div>
         </div>
       )}
-    </div>
+    </section>
   );
 }
 

--- a/src/components/Panel/ComparisonControl.tsx
+++ b/src/components/Panel/ComparisonControl.tsx
@@ -17,7 +17,8 @@ export function ComparisonControl() {
   const unit = displayLengthUnit(units);
 
   return (
-    <div className="panel-section">
+    /* SEO: Upgrade generic div wrapper to semantic section tag to improve document outlining for search engines */
+    <section className="panel-section">
       {/* SEO: Use sequential heading tags (H2) to follow document outline initiated by H1 */}
       <h2>Comparison</h2>
       <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>
@@ -82,7 +83,7 @@ export function ComparisonControl() {
       ) : (
         <div className="compare-empty">Capture a solved configuration to enable side-by-side comparison.</div>
       )}
-    </div>
+    </section>
   );
 }
 

--- a/src/components/Panel/DipoleControl.tsx
+++ b/src/components/Panel/DipoleControl.tsx
@@ -81,7 +81,7 @@ export function DipoleControl() {
   };
 
   return (
-    <div className="panel-section">
+    <section className="panel-section">
       {/* SEO: Use sequential heading tags (H2) to follow document outline initiated by H1 */}
       <h2>Antenna</h2>
 
@@ -219,7 +219,7 @@ export function DipoleControl() {
           </button>
         ))}
       </div>
-    </div>
+    </section>
   );
 }
 

--- a/src/components/Panel/DisplayControl.tsx
+++ b/src/components/Panel/DisplayControl.tsx
@@ -20,7 +20,7 @@ export function DisplayControl() {
   const setShowPolarCuts = useAntennaStore((s) => s.setShowPolarCuts);
 
   return (
-    <div className="panel-section">
+    <section className="panel-section">
       {/* SEO: Use sequential heading tags (H2) to follow document outline initiated by H1 */}
       <h2>Display</h2>
       <label id="colormap-label">Colormap</label>
@@ -73,6 +73,6 @@ export function DisplayControl() {
           Polar plots
         </label>
       </div>
-    </div>
+    </section>
   );
 }

--- a/src/components/Panel/FeedlineControl.tsx
+++ b/src/components/Panel/FeedlineControl.tsx
@@ -50,7 +50,7 @@ export function FeedlineControl() {
   const lossDb = enabled ? feedlineLossDb(preset, frequency, feedlineLength) : 0;
 
   return (
-    <div className="panel-section">
+    <section className="panel-section">
       {/* SEO: Use sequential heading tags (H2) to follow document outline initiated by H1 */}
       <h2>Feedline</h2>
       <label htmlFor="feedline-preset">Cable</label>
@@ -163,6 +163,6 @@ export function FeedlineControl() {
           </div>
         </>
       )}
-    </div>
+    </section>
   );
 }

--- a/src/components/Panel/FrequencyControl.tsx
+++ b/src/components/Panel/FrequencyControl.tsx
@@ -23,7 +23,7 @@ export function FrequencyControl() {
   }
 
   return (
-    <div className="panel-section">
+    <section className="panel-section">
       {/* SEO: Use sequential heading tags (H2) to follow document outline initiated by H1 */}
       <h2>Frequency <span className="badge">{frequency.toFixed(3)} MHz</span></h2>
       <div className="row">
@@ -67,6 +67,6 @@ export function FrequencyControl() {
           </button>
         ))}
       </div>
-    </div>
+    </section>
   );
 }

--- a/src/components/Panel/GroundControl.tsx
+++ b/src/components/Panel/GroundControl.tsx
@@ -32,7 +32,7 @@ export function GroundControl() {
   }
 
   return (
-    <div className="panel-section">
+    <section className="panel-section">
       {/* SEO: Use sequential heading tags (H2) to follow document outline initiated by H1 */}
       <h2>
         Ground
@@ -100,6 +100,6 @@ export function GroundControl() {
           />
         </>
       )}
-    </div>
+    </section>
   );
 }

--- a/src/components/Panel/ModeSelector.tsx
+++ b/src/components/Panel/ModeSelector.tsx
@@ -11,7 +11,7 @@ export function ModeSelector() {
   const mode = useAntennaStore((s) => s.mode);
   const setMode = useAntennaStore((s) => s.setMode);
   return (
-    <div className="panel-section">
+    <section className="panel-section">
       {/* SEO: Use sequential heading tags (H2) to follow document outline initiated by H1 */}
       <h2 id="mode-selector-heading">Mode</h2>
       <div className="button-group" role="group" aria-labelledby="mode-selector-heading" aria-describedby="mode-hint">
@@ -28,6 +28,6 @@ export function ModeSelector() {
       <div id="mode-hint" aria-live="polite" style={{ marginTop: 6, fontSize: 11, color: 'var(--text-muted)' }}>
         {MODES.find((m) => m.id === mode)!.hint}
       </div>
-    </div>
+    </section>
   );
 }

--- a/src/components/Panel/PropagationControl.tsx
+++ b/src/components/Panel/PropagationControl.tsx
@@ -95,7 +95,7 @@ export function PropagationControl() {
   const haveTakeoff = result !== null;
 
   return (
-    <div className="panel-section">
+    <section className="panel-section">
       {/* SEO: Use sequential heading tags (H2) to follow document outline initiated by H1 */}
       <h2>
         Propagation
@@ -324,7 +324,7 @@ export function PropagationControl() {
           </ul>
         </div>
       )}
-    </div>
+    </section>
   );
 }
 

--- a/src/components/Panel/StatsReadout.tsx
+++ b/src/components/Panel/StatsReadout.tsx
@@ -6,15 +6,15 @@ export function StatsReadout() {
   const reference = useAntennaStore((s) => s.comparisonReference);
   if (!result) {
     return (
-      <div className="panel-section">
+      <section className="panel-section">
         {/* SEO: Use sequential heading tags (H2) to follow document outline initiated by H1 */}
         <h2>Results</h2>
         <div style={{ color: 'var(--text-muted)', fontSize: 12 }}>Computing…</div>
-      </div>
+      </section>
     );
   }
   return (
-    <div className="panel-section">
+    <section className="panel-section">
       {/* SEO: Use sequential heading tags (H2) to follow document outline initiated by H1 */}
       <h2>Results <span className="badge">{result.computeTimeMs.toFixed(0)} ms</span></h2>
       <div className="stat">
@@ -51,7 +51,7 @@ export function StatsReadout() {
         <strong>Note:</strong> Termination reduces reflections along the antenna wire.
         It does not guarantee a 50 Ω feedpoint impedance.
       </div>
-    </div>
+    </section>
   );
 }
 


### PR DESCRIPTION
💡 **What**: Upgraded generic `<div className="panel-section">` wrappers across all panel components and charts to semantic `<section className="panel-section">` tags. Included an explanatory code comment on the SEO value of the semantic upgrade.

🎯 **Why**: Improves the semantic document outline for search engines and assistive technologies, making the page structure clearer without altering visual behavior or styling. This is a very clean, low-risk way to give structure, particularly because these components all immediately host `<h2>` heading elements. 

📊 **Value**: Enhances on-page discoverability and structural parsing by crawlers. Better accessibility tree. 

🔬 **Measurement**: Verify by inspecting the DOM in the developer tools in any of the side-panel controls. The tag wrapper will show as `<section>` rather than `<div>`.

---
*PR created automatically by Jules for task [4576195350311866423](https://jules.google.com/task/4576195350311866423) started by @2fst4u*