### PR TITLE
feat: implement Option A NT-across-tips termination for V antennas

### DIFF
--- a/src/store/antennaStore.ts
+++ b/src/store/antennaStore.ts
@@ -17,6 +17,7 @@ import type {
   Wire,
   TransmissionLine,
   SegmentLoad,
+  NetworkLoad,
   AntennaType,
 } from '../physics/types';
 import {
@@ -110,6 +111,13 @@ export interface AntennaState {
    */
   legSlope: number;
 
+  /**
+   * For sloping-V and V-beam: far-end terminating resistor across the two tips.
+   * 0 = unterminated. Any positive value inserts one NEC NT card representing
+   * the total across-tip resistance (not per-leg-to-ground).
+   */
+  terminatingResistor: number;
+
   // Environment
   groundId: string;
   groundSigma: number;
@@ -159,6 +167,7 @@ export interface AntennaState {
   setOrientation(o: Orientation): void;
   setVAngle(deg: number): void;
   setLegSlope(deg: number): void;
+  setTerminatingResistor(ohms: number): void;
   setWireRadius(meters: number): void;
   setSegments(n: number): void;
   setGround(id: string): void;
@@ -214,6 +223,7 @@ export const useAntennaStore = create<AntennaState>()(
       segments: 21,
       vAngle: 180,
       legSlope: 0,
+      terminatingResistor: 0,
 
       groundId: DEFAULT_GROUND_ID,
       groundSigma: findGroundPreset(DEFAULT_GROUND_ID).sigma,
@@ -316,6 +326,10 @@ export const useAntennaStore = create<AntennaState>()(
       setLegSlope: (deg) => set((s) => {
         if (!Number.isFinite(deg)) return;
         s.legSlope = Math.max(0, Math.min(90, deg));
+      }),
+      setTerminatingResistor: (ohms) => set((s) => {
+        if (!Number.isFinite(ohms)) return;
+        s.terminatingResistor = Math.max(0, ohms);
       }),
       setWireRadius: (r) => set((s) => {
         if (!Number.isFinite(r)) return;
@@ -707,6 +721,22 @@ export function selectSimulationInput(state: AntennaState): SimulationInput {
     }
   }
 
+  const networks: NetworkLoad[] = [];
+  const isVTopology = state.antennaType === 'sloping-v' || state.antennaType === 'v-beam';
+  if (isVTopology && state.terminatingResistor > 0) {
+    const R = state.terminatingResistor;
+    const rightWire = wires.find((w) => w.tag === DIPOLE_RIGHT_TAG)!;
+    networks.push({
+      fromTag: DIPOLE_LEFT_TAG,
+      fromSegment: 1,
+      toTag: DIPOLE_RIGHT_TAG,
+      toSegment: rightWire.segments,
+      y11Real: 1 / R,
+      y12Real: -1 / R,
+      y22Real: 1 / R,
+    });
+  }
+
   return {
     wires,
     frequencyMHz: state.frequency,
@@ -718,6 +748,7 @@ export function selectSimulationInput(state: AntennaState): SimulationInput {
     },
     transmissionLines: transmissionLines.length > 0 ? transmissionLines : undefined,
     loads: loads.length > 0 ? loads : undefined,
+    networks: networks.length > 0 ? networks : undefined,
   };
 }
 

--- a/tests/necInspect.ts
+++ b/tests/necInspect.ts
@@ -69,6 +69,29 @@ export function parseTlLine(line: string) {
 }
 
 /**
+ * Parses an NT (Two-port Network) card line.
+ * Format: NT tag1 seg1 tag2 seg2 Y11r Y11i Y12r Y12i Y22r Y22i
+ */
+export function parseNtLine(line: string) {
+  const parts = line.trim().split(/\s+/);
+  if (parts[0] !== 'NT') {
+    throw new Error(`Not an NT line: ${line}`);
+  }
+  return {
+    tag1: parseInt(parts[1], 10),
+    seg1: parseInt(parts[2], 10),
+    tag2: parseInt(parts[3], 10),
+    seg2: parseInt(parts[4], 10),
+    y11Real: parseFloat(parts[5]),
+    y11Imag: parseFloat(parts[6]),
+    y12Real: parseFloat(parts[7]),
+    y12Imag: parseFloat(parts[8]),
+    y22Real: parseFloat(parts[9]),
+    y22Imag: parseFloat(parts[10]),
+  };
+}
+
+/**
  * Asserts that no wires in the deck have endpoints at or below z=0.
  * Useful for verifying height regressions.
  */

--- a/tests/vBeamTermination.test.ts
+++ b/tests/vBeamTermination.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useAntennaStore, selectSimulationInput } from '../src/store/antennaStore';
+import { buildNecCards } from '../src/physics/necCard';
+import {
+  getNecLines,
+  parseNtLine,
+  expectNoGroundTouchingWires,
+  expectExcitation,
+} from './necInspect';
+import { DIPOLE_LEFT_TAG, DIPOLE_RIGHT_TAG, FEED_BRIDGE_TAG } from '../src/physics/constants';
+
+function setupVBeam(terminatingResistor?: number) {
+  const store = useAntennaStore.getState();
+  store.setAntennaType('v-beam');
+  store.setFrequency(7.1);
+  store.setLength(84);
+  store.setHeight(15);
+  store.setVAngle(90);
+  if (terminatingResistor !== undefined) {
+    store.setTerminatingResistor(terminatingResistor);
+  }
+}
+
+function setupSlopingV(terminatingResistor?: number) {
+  const store = useAntennaStore.getState();
+  store.setAntennaType('sloping-v');
+  store.setFrequency(7.1);
+  store.setLength(84);
+  store.setHeight(15);
+  store.setVAngle(90);
+  store.setLegSlope(15);
+  if (terminatingResistor !== undefined) {
+    store.setTerminatingResistor(terminatingResistor);
+  }
+}
+
+describe('V-antenna termination topology (Option A: NT across tips)', () => {
+  beforeEach(() => {
+    useAntennaStore.getState().setTerminatingResistor(0);
+  });
+
+  it('v-beam: no NT card when unterminated (terminatingResistor=0)', () => {
+    setupVBeam(0);
+    const input = selectSimulationInput(useAntennaStore.getState());
+    const deck = buildNecCards(input);
+    expect(getNecLines(deck, 'NT')).toHaveLength(0);
+    expect(input.networks).toBeUndefined();
+  });
+
+  it('sloping-v: no NT card when unterminated (terminatingResistor=0)', () => {
+    setupSlopingV(0);
+    const input = selectSimulationInput(useAntennaStore.getState());
+    const deck = buildNecCards(input);
+    expect(getNecLines(deck, 'NT')).toHaveLength(0);
+    expect(input.networks).toBeUndefined();
+  });
+
+  it('v-beam: exactly one NT card when terminatingResistor > 0', () => {
+    setupVBeam(800);
+    const input = selectSimulationInput(useAntennaStore.getState());
+    const deck = buildNecCards(input);
+    expect(getNecLines(deck, 'NT')).toHaveLength(1);
+    expect(input.networks).toHaveLength(1);
+  });
+
+  it('sloping-v: exactly one NT card when terminatingResistor > 0', () => {
+    setupSlopingV(800);
+    const input = selectSimulationInput(useAntennaStore.getState());
+    const deck = buildNecCards(input);
+    expect(getNecLines(deck, 'NT')).toHaveLength(1);
+    expect(input.networks).toHaveLength(1);
+  });
+
+  it('v-beam: NT card connects left far tip (tag 1, seg 1) to right far tip (tag 2, seg N)', () => {
+    setupVBeam(800);
+    const input = selectSimulationInput(useAntennaStore.getState());
+    const deck = buildNecCards(input);
+    const nt = parseNtLine(getNecLines(deck, 'NT')[0]);
+    const rightWire = input.wires.find((w) => w.tag === DIPOLE_RIGHT_TAG)!;
+    expect(nt.tag1).toBe(DIPOLE_LEFT_TAG);
+    expect(nt.seg1).toBe(1);
+    expect(nt.tag2).toBe(DIPOLE_RIGHT_TAG);
+    expect(nt.seg2).toBe(rightWire.segments);
+  });
+
+  it('sloping-v: NT card connects left far tip to right far tip', () => {
+    setupSlopingV(800);
+    const input = selectSimulationInput(useAntennaStore.getState());
+    const deck = buildNecCards(input);
+    const nt = parseNtLine(getNecLines(deck, 'NT')[0]);
+    const rightWire = input.wires.find((w) => w.tag === DIPOLE_RIGHT_TAG)!;
+    expect(nt.tag1).toBe(DIPOLE_LEFT_TAG);
+    expect(nt.seg1).toBe(1);
+    expect(nt.tag2).toBe(DIPOLE_RIGHT_TAG);
+    expect(nt.seg2).toBe(rightWire.segments);
+  });
+
+  it('v-beam: NT Y-params are correct for R=800 (G=1/R, all imaginary parts zero)', () => {
+    const R = 800;
+    setupVBeam(R);
+    const input = selectSimulationInput(useAntennaStore.getState());
+    const deck = buildNecCards(input);
+    const nt = parseNtLine(getNecLines(deck, 'NT')[0]);
+    expect(nt.y11Real).toBeCloseTo(1 / R, 9);
+    expect(nt.y11Imag).toBeCloseTo(0, 9);
+    expect(nt.y12Real).toBeCloseTo(-1 / R, 9);
+    expect(nt.y12Imag).toBeCloseTo(0, 9);
+    expect(nt.y22Real).toBeCloseTo(1 / R, 9);
+    expect(nt.y22Imag).toBeCloseTo(0, 9);
+  });
+
+  it('sloping-v: NT Y-params are correct for R=500', () => {
+    const R = 500;
+    setupSlopingV(R);
+    const input = selectSimulationInput(useAntennaStore.getState());
+    const deck = buildNecCards(input);
+    const nt = parseNtLine(getNecLines(deck, 'NT')[0]);
+    expect(nt.y11Real).toBeCloseTo(1 / R, 9);
+    expect(nt.y12Real).toBeCloseTo(-1 / R, 9);
+    expect(nt.y22Real).toBeCloseTo(1 / R, 9);
+  });
+
+  it('v-beam: halving terminatingResistor doubles the conductance G', () => {
+    setupVBeam(1000);
+    const input1 = selectSimulationInput(useAntennaStore.getState());
+    const nt1 = parseNtLine(getNecLines(buildNecCards(input1), 'NT')[0]);
+
+    useAntennaStore.getState().setTerminatingResistor(500);
+    const input2 = selectSimulationInput(useAntennaStore.getState());
+    const nt2 = parseNtLine(getNecLines(buildNecCards(input2), 'NT')[0]);
+
+    expect(nt2.y11Real).toBeCloseTo(nt1.y11Real * 2, 9);
+  });
+
+  it('v-beam terminated: no wires touch ground', () => {
+    setupVBeam(800);
+    const input = selectSimulationInput(useAntennaStore.getState());
+    expectNoGroundTouchingWires(buildNecCards(input));
+  });
+
+  it('sloping-v terminated: no wires touch ground', () => {
+    setupSlopingV(800);
+    const input = selectSimulationInput(useAntennaStore.getState());
+    expectNoGroundTouchingWires(buildNecCards(input));
+  });
+
+  it('v-beam terminated: excitation remains on apex bridge (tag 3, seg 1)', () => {
+    setupVBeam(800);
+    const input = selectSimulationInput(useAntennaStore.getState());
+    expectExcitation(buildNecCards(input), FEED_BRIDGE_TAG, 1);
+  });
+
+  it('sloping-v terminated: excitation remains on apex bridge (tag 3, seg 1)', () => {
+    setupSlopingV(800);
+    const input = selectSimulationInput(useAntennaStore.getState());
+    expectExcitation(buildNecCards(input), FEED_BRIDGE_TAG, 1);
+  });
+
+  it('dipole: terminatingResistor has no effect (no NT card emitted)', () => {
+    const store = useAntennaStore.getState();
+    store.setAntennaType('dipole');
+    store.setTerminatingResistor(800);
+    const input = selectSimulationInput(useAntennaStore.getState());
+    expect(getNecLines(buildNecCards(input), 'NT')).toHaveLength(0);
+    expect(input.networks).toBeUndefined();
+  });
+
+  it('inverted-v: terminatingResistor has no effect (no NT card emitted)', () => {
+    const store = useAntennaStore.getState();
+    store.setAntennaType('inverted-v');
+    store.setTerminatingResistor(800);
+    const input = selectSimulationInput(useAntennaStore.getState());
+    expect(getNecLines(buildNecCards(input), 'NT')).toHaveLength(0);
+    expect(input.networks).toBeUndefined();
+  });
+
+  it('delta-loop: terminatingResistor has no effect (no NT card emitted)', () => {
+    const store = useAntennaStore.getState();
+    store.setAntennaType('delta-loop');
+    store.setTerminatingResistor(800);
+    const input = selectSimulationInput(useAntennaStore.getState());
+    expect(getNecLines(buildNecCards(input), 'NT')).toHaveLength(0);
+    expect(input.networks).toBeUndefined();
+  });
+
+  it('setTerminatingResistor clamps negative values to 0 (unterminated)', () => {
+    setupVBeam();
+    useAntennaStore.getState().setTerminatingResistor(-100);
+    expect(useAntennaStore.getState().terminatingResistor).toBe(0);
+    const input = selectSimulationInput(useAntennaStore.getState());
+    expect(input.networks).toBeUndefined();
+  });
+
+  it('terminatingResistor is documented as total across-tip resistance (not per-leg)', () => {
+    // R=400 total → G = 1/400. A per-leg model would give G = 1/200.
+    const R = 400;
+    setupVBeam(R);
+    const input = selectSimulationInput(useAntennaStore.getState());
+    expect(input.networks).toHaveLength(1);
+    expect(input.networks![0].y11Real).toBeCloseTo(1 / R, 9);
+    expect(input.networks![0].y12Real).toBeCloseTo(-1 / R, 9);
+  });
+});


### PR DESCRIPTION
Closes #143

Implements one mathematically consistent termination topology for V-shaped travelling-wave antennas:

**Option A — single NT card across far tips**
`left far tip ── Rterm ── right far tip`

- `terminatingResistor` is the total across-tip resistance (not per-leg-to-ground).
- Default 0 = unterminated; any positive value inserts one NT card.
- No new wires added → no ground-touching wire risk.
- 16 new tests in `vBeamTermination.test.ts` assert the exact NEC cards generated.

Generated with [Claude Code](https://claude.ai/code)