### PR TITLE
fix: grant Claude Code write permissions in GitHub Actions workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,9 +19,9 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:


### PR DESCRIPTION
## Summary

- `contents`, `pull-requests`, and `issues` were all set to `read` in the Claude Code workflow
- This silently prevented Claude from pushing commits or creating PRs after implementing an issue (the action job itself would still exit 0, making it look like it succeeded)
- Changed all three to `write` so Claude can actually commit code and open PRs

## Test plan

- [ ] Merge this PR
- [ ] Re-trigger issue #144 with another `@claude` comment
- [ ] Confirm Claude creates a branch and opens a PR this time

https://claude.ai/code/session_01BPyf4VUJuYDYJjxf2MuikN

---
_Generated by [Claude Code](https://claude.ai/code/session_01BPyf4VUJuYDYJjxf2MuikN)_