### PR TITLE
fix: tell Claude to comment when it cannot implement an issue

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,9 +19,9 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,9 +19,9 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
-      issues: write
+      contents: read
+      pull-requests: read
+      issues: read
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -41,7 +41,7 @@ jobs:
             actions: read
 
           # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
-          prompt: "Implement the issue and open a pull request when done."
+          prompt: "Implement the issue and open a pull request when done. If you cannot proceed (e.g. prerequisites are not yet complete, or the scope is unclear), post a comment on the issue explaining what is blocking you."
 
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md


### PR DESCRIPTION
## Problem

When Claude can't proceed with an issue (e.g. prerequisites not met, scope unclear), it silently exits the session. The GitHub Actions job still shows as green, but nothing happens on the issue or in PRs — making it look like a ghost run.

This is what happened with issue #144: the custom prompt only said "implement and open a PR when done", with no fallback instruction, so Claude had no direction to explain itself when it hit a blocker.

## Fix

Extend the prompt to explicitly tell Claude to post a comment on the issue if it cannot proceed:

```
If you cannot proceed (e.g. prerequisites are not yet complete, or the scope is unclear), post a comment on the issue explaining what is blocking you.
```

## After merging

Re-trigger issue #144 with another `@claude` comment — Claude should now either implement it or leave a comment explaining what's blocking it.

https://claude.ai/code/session_01BPyf4VUJuYDYJjxf2MuikN

---
_Generated by [Claude Code](https://claude.ai/code/session_01BPyf4VUJuYDYJjxf2MuikN)_