### PR TITLE
Fix claude-code-review workflow not posting comments

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 


### PR DESCRIPTION
## Summary

- The `claude-review` job was running successfully but posting no comments
- Root cause: `pull-requests: read` in the workflow permissions — the GitHub token couldn't write reviews
- Fix: change `pull-requests: read` → `pull-requests: write`

## Test plan

- [ ] Merge this PR
- [ ] Open or re-open a PR and confirm the `claude-review` job now posts review comments

https://claude.ai/code/session_01LXxUyB3GPcRc81e7MgrNiQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01LXxUyB3GPcRc81e7MgrNiQ)_