### PR TITLE
feat: add optional ideal transformer post-processing display (#147)

### DIFF
--- a/src/components/Charts/SWRChart.tsx
+++ b/src/components/Charts/SWRChart.tsx
@@ -17,6 +17,7 @@ import {
 } from 'chart.js';
 import annotationPlugin from 'chartjs-plugin-annotation';
 import { useAntennaStore } from '../../store/antennaStore';
+import { swr as computeSwr, transformImpedance } from '../../physics/impedance';
 import type { AnnotationOptions } from 'chartjs-plugin-annotation';
 import { useMemo } from 'react';
 
@@ -37,6 +38,9 @@ export function SWRChart() {
   const theme = useAntennaStore((s) => s.theme);
   const mode = useAntennaStore((s) => s.mode);
   const reference = useAntennaStore((s) => s.comparisonReference);
+
+  const transformerEnabled = useAntennaStore((s) => s.transformerEnabled);
+  const transformerRatio = useAntennaStore((s) => s.transformerRatio);
 
   const chartText = getCssVar('--chart-text') || '#aaa';
   const chartGrid = getCssVar('--chart-grid') || 'rgba(255,255,255,0.1)';
@@ -74,8 +78,16 @@ export function SWRChart() {
       });
     }
 
+    const rawLabel = comparisonActive && transformerEnabled
+      ? 'Current (raw)'
+      : comparisonActive
+        ? 'Current'
+        : transformerEnabled
+          ? 'Raw (vs 50 Ω)'
+          : 'SWR (vs 50 Ω)';
+
     datasets.push({
-      label: comparisonActive ? 'Current' : 'SWR (vs 50 Ω)',
+      label: rawLabel,
       data: sweep.map((point) => ({ x: point.frequencyMHz, y: point.swr })),
       borderColor: accent,
       backgroundColor: currentFill,
@@ -86,8 +98,26 @@ export function SWRChart() {
       pointBackgroundColor: accent,
     });
 
+    if (transformerEnabled && transformerRatio > 0) {
+      datasets.push({
+        label: `After ${transformerRatio}:1 xfmr`,
+        data: sweep.map((point) => ({
+          x: point.frequencyMHz,
+          y: computeSwr(transformImpedance({ R: point.R, X: point.X }, transformerRatio)),
+        })),
+        borderColor: 'rgba(80, 200, 120, 0.9)',
+        backgroundColor: 'rgba(80, 200, 120, 0.1)',
+        fill: false,
+        tension: 0.18,
+        pointRadius: 0,
+        pointHoverRadius: 3,
+        pointBackgroundColor: '#50c878',
+        borderDash: [6, 3],
+      });
+    }
+
     return { datasets };
-  }, [accent, comparisonActive, currentFill, reference, referenceFill, sweep]);
+  }, [accent, comparisonActive, currentFill, reference, referenceFill, sweep, transformerEnabled, transformerRatio]);
 
   const xBounds = useMemo(() => {
     const allFrequencies = [
@@ -140,6 +170,9 @@ export function SWRChart() {
     const values = [
       ...sweep.map((point) => point.swr),
       ...(comparisonActive && reference ? reference.sweep.map((point) => point.swr) : []),
+      ...(transformerEnabled && transformerRatio > 0
+        ? sweep.map((point) => computeSwr(transformImpedance({ R: point.R, X: point.X }, transformerRatio)))
+        : []),
     ];
     if (values.length === 0) return 5;
 
@@ -154,7 +187,7 @@ export function SWRChart() {
 
     // If we have some points below 2:1, we want to see the 2:1 crossing context.
     return Math.min(999, Math.max(5, Math.ceil(maxVal * 1.1)));
-  }, [comparisonActive, reference, sweep]);
+  }, [comparisonActive, reference, sweep, transformerEnabled, transformerRatio]);
 
   const options = useMemo<ChartOptions<'line'>>(() => {
     const annotations: Record<string, AnnotationOptions> = {
@@ -234,7 +267,7 @@ export function SWRChart() {
       },
       plugins: {
         legend: {
-          display: comparisonActive,
+          display: comparisonActive || transformerEnabled,
           labels: { color: chartText },
         },
         annotation: {
@@ -242,7 +275,7 @@ export function SWRChart() {
         },
       },
     };
-  }, [accent, chartGrid, chartText, comparisonActive, frequency, xBounds.max, xBounds.min, yMax, stats]);
+  }, [accent, chartGrid, chartText, comparisonActive, transformerEnabled, frequency, xBounds.max, xBounds.min, yMax, stats]);
 
   if (!result || sweep.length === 0) {
     return (

--- a/src/components/Panel/ControlPanel.tsx
+++ b/src/components/Panel/ControlPanel.tsx
@@ -11,6 +11,7 @@ import { PolarPlots } from '../Charts/PolarPlots';
 import { ThemeToggle } from '../UI/ThemeToggle';
 import { UnitToggle } from './UnitToggle';
 import { ComparisonControl } from './ComparisonControl';
+import { TransformerControl } from './TransformerControl';
 
 export function ControlPanel() {
   return (
@@ -43,6 +44,7 @@ export function ControlPanel() {
       <GroundControl />
       <FeedlineControl />
       <StatsReadout />
+      <TransformerControl />
       <SWRChart />
       <PolarPlots />
       <PropagationControl />

--- a/src/components/Panel/TransformerControl.tsx
+++ b/src/components/Panel/TransformerControl.tsx
@@ -1,0 +1,117 @@
+import { useAntennaStore } from '../../store/antennaStore';
+import { swr, transformImpedance } from '../../physics/impedance';
+
+export function TransformerControl() {
+  const result = useAntennaStore((s) => s.result);
+  const transformerEnabled = useAntennaStore((s) => s.transformerEnabled);
+  const transformerRatio = useAntennaStore((s) => s.transformerRatio);
+  const setTransformerEnabled = useAntennaStore((s) => s.setTransformerEnabled);
+  const setTransformerRatio = useAntennaStore((s) => s.setTransformerRatio);
+
+  const transformedZ = result && transformerEnabled
+    ? transformImpedance(result.impedance, transformerRatio)
+    : null;
+  const transformedSwr = transformedZ !== null ? swr(transformedZ) : null;
+
+  return (
+    <section className="panel-section">
+      {/* SEO: Use sequential heading tags (H2) to follow document outline initiated by H1 */}
+      <h2>Ideal transformer</h2>
+      <label
+        htmlFor="transformer-enable"
+        style={{ display: 'flex', alignItems: 'center', gap: 6, textTransform: 'none', letterSpacing: 0, margin: 0, fontSize: 12 }}
+      >
+        <input
+          id="transformer-enable"
+          type="checkbox"
+          checked={transformerEnabled}
+          onChange={(e) => setTransformerEnabled(e.target.checked)}
+        />
+        Show post-processing view
+      </label>
+
+      {transformerEnabled && (
+        <>
+          <label htmlFor="transformer-ratio" style={{ marginTop: 10 }}>
+            Impedance ratio (n²)
+          </label>
+          <input
+            id="transformer-ratio"
+            type="number"
+            min={1}
+            max={10000}
+            step={1}
+            value={transformerRatio}
+            onChange={(e) => {
+              const v = parseFloat(e.target.value);
+              if (Number.isFinite(v) && v >= 1) setTransformerRatio(v);
+            }}
+            style={{ width: '100%', marginTop: 4 }}
+          />
+          <div style={{ fontSize: 10, color: 'var(--text-muted)', marginTop: 4 }}>
+            Z_transformed = Z_feedpoint / ratio (ideal, lossless)
+          </div>
+
+          {result && transformedZ !== null && transformedSwr !== null && (
+            <>
+              <div style={{ marginTop: 10, fontSize: 11, color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: 4 }}>
+                After {transformerRatio}:1 transformer
+              </div>
+              <div className="stat">
+                <span
+                  className="stat-label"
+                  title="Raw feedpoint impedance from NEC — unchanged by transformer setting."
+                >Feedpoint (raw R + jX)</span>
+                <span className="stat-value">
+                  {result.impedance.R.toFixed(1)} {result.impedance.X >= 0 ? '+' : '−'}j{Math.abs(result.impedance.X).toFixed(1)} Ω
+                </span>
+              </div>
+              <div className="stat">
+                <span
+                  className="stat-label"
+                  title="Raw SWR vs 50 Ω at the feedpoint — unchanged by transformer setting."
+                >Raw SWR (vs 50 Ω)</span>
+                <span
+                  className="stat-value"
+                  style={{
+                    color: result.swr > 2 ? 'var(--danger)' : result.swr > 1.5 ? 'var(--warning)' : 'var(--success)',
+                  }}
+                >
+                  {result.swr.toFixed(2)}:1
+                </span>
+              </div>
+              <div className="stat">
+                <span
+                  className="stat-label"
+                  title="Transformed impedance = feedpoint impedance ÷ ratio. Post-processing only."
+                >Transformed (R + jX)</span>
+                <span className="stat-value">
+                  {transformedZ.R.toFixed(1)} {transformedZ.X >= 0 ? '+' : '−'}j{Math.abs(transformedZ.X).toFixed(1)} Ω
+                </span>
+              </div>
+              <div className="stat">
+                <span
+                  className="stat-label"
+                  title="SWR vs 50 Ω after ideal transformer. Post-processing only."
+                >Transformed SWR (vs 50 Ω)</span>
+                <span
+                  className="stat-value"
+                  style={{
+                    color: transformedSwr > 2 ? 'var(--danger)' : transformedSwr > 1.5 ? 'var(--warning)' : 'var(--success)',
+                  }}
+                >
+                  {transformedSwr.toFixed(2)}:1
+                </span>
+              </div>
+              <div style={{ marginTop: 10, fontSize: 11, color: 'var(--text-muted)', lineHeight: 1.4 }}>
+                <strong>Note:</strong> Transformer values are ideal post-processing calculations.
+                Actual transformer losses, bandwidth limits, and physical effects are not modelled
+                unless explicitly added to the NEC geometry.
+              </div>
+            </>
+          )}
+        </>
+      )}
+    </section>
+  );
+}

--- a/src/physics/impedance.ts
+++ b/src/physics/impedance.ts
@@ -43,3 +43,14 @@ export function mismatchLossFactor(z: ImpedanceResult, z0: number = Z0_SYSTEM): 
   const gamma = reflectionCoefficientMag(z, z0);
   return 1 - gamma * gamma;
 }
+
+/**
+ * Apply an ideal impedance transformer: Z_transformed = Z_raw / ratio.
+ * Divides both R and X by the impedance ratio (n²). Post-processing display
+ * only — does not affect radiation pattern, currents, or NEC simulation.
+ * Returns the original z unchanged for invalid ratios (≤ 0 or non-finite).
+ */
+export function transformImpedance(z: ImpedanceResult, ratio: number): ImpedanceResult {
+  if (!Number.isFinite(ratio) || ratio <= 0) return z;
+  return { R: z.R / ratio, X: z.X / ratio };
+}

--- a/src/store/antennaStore.ts
+++ b/src/store/antennaStore.ts
@@ -142,6 +142,11 @@ export interface AntennaState {
   showAxes: boolean;
   showPolarCuts: boolean;
 
+  // Ideal transformer post-processing display (does not affect NEC simulation)
+  transformerEnabled: boolean;
+  /** Impedance transformation ratio n² (e.g. 9 for a 3:1 turns-ratio transformer). */
+  transformerRatio: number;
+
   // Propagation
   tIndex: number;
   latitudeDeg: number | null;
@@ -188,6 +193,8 @@ export interface AntennaState {
   setShowGrid(v: boolean): void;
   setShowAxes(v: boolean): void;
   setShowPolarCuts(v: boolean): void;
+  setTransformerEnabled(enabled: boolean): void;
+  setTransformerRatio(ratio: number): void;
   captureComparisonReference(): void;
   clearComparisonReference(): void;
 
@@ -244,6 +251,8 @@ export const useAntennaStore = create<AntennaState>()(
       showGrid: true,
       showAxes: true,
       showPolarCuts: true,
+      transformerEnabled: false,
+      transformerRatio: 9,
 
       tIndex: 30,
       latitudeDeg: null,
@@ -381,6 +390,11 @@ export const useAntennaStore = create<AntennaState>()(
       setShowGrid: (v) => set((s) => { s.showGrid = v; }),
       setShowAxes: (v) => set((s) => { s.showAxes = v; }),
       setShowPolarCuts: (v) => set((s) => { s.showPolarCuts = v; }),
+      setTransformerEnabled: (enabled) => set((s) => { s.transformerEnabled = !!enabled; }),
+      setTransformerRatio: (ratio) => set((s) => {
+        if (!Number.isFinite(ratio) || ratio <= 0) return;
+        s.transformerRatio = Math.max(1, ratio);
+      }),
       captureComparisonReference: () => set((s) => {
         s.comparisonReference = createComparisonSnapshot(s);
       }),

--- a/tests/TransformerControl.test.tsx
+++ b/tests/TransformerControl.test.tsx
@@ -1,0 +1,119 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { fireEvent } from '@testing-library/dom';
+import { TransformerControl } from '../src/components/Panel/TransformerControl';
+import { useAntennaStore } from '../src/store/antennaStore';
+
+describe('TransformerControl', () => {
+  beforeEach(() => {
+    cleanup();
+    useAntennaStore.setState({
+      transformerEnabled: false,
+      transformerRatio: 9,
+      result: null,
+    });
+  });
+
+  it('renders the section heading', () => {
+    const { getByText } = render(<TransformerControl />);
+    expect(getByText('Ideal transformer')).not.toBeNull();
+  });
+
+  it('shows the enable checkbox unchecked by default', () => {
+    const { getByRole } = render(<TransformerControl />);
+    const checkbox = getByRole('checkbox') as HTMLInputElement;
+    expect(checkbox.checked).toBe(false);
+  });
+
+  it('does not show ratio input when disabled', () => {
+    const { queryByLabelText } = render(<TransformerControl />);
+    expect(queryByLabelText(/Impedance ratio/i)).toBeNull();
+  });
+
+  it('shows ratio input and note when enabled', () => {
+    useAntennaStore.setState({ transformerEnabled: true });
+    const { getByLabelText, container } = render(<TransformerControl />);
+    expect(getByLabelText(/Impedance ratio/i)).not.toBeNull();
+    expect(container.textContent).toContain('Z_transformed = Z_feedpoint / ratio');
+  });
+
+  it('enables transformer when checkbox is clicked', () => {
+    const { getByRole } = render(<TransformerControl />);
+    const checkbox = getByRole('checkbox') as HTMLInputElement;
+    fireEvent.click(checkbox);
+    expect(useAntennaStore.getState().transformerEnabled).toBe(true);
+  });
+
+  it('shows transformed values when enabled and result is present', () => {
+    useAntennaStore.setState({
+      transformerEnabled: true,
+      transformerRatio: 9,
+      result: {
+        computeTimeMs: 10,
+        maxGainDbi: 7,
+        takeoffElevationDeg: 15,
+        takeoffAzimuthDeg: 0,
+        impedance: { R: 450, X: 0 },
+        swr: 9.0,
+        pattern: { data: new Float32Array([1]), phiSteps: 1, thetaSteps: 1 },
+      } as unknown as import('../src/physics/types').SimulationResult,
+    });
+
+    const { container } = render(<TransformerControl />);
+
+    // Raw values visible
+    expect(container.textContent).toContain('Feedpoint (raw R + jX)');
+    expect(container.textContent).toContain('Raw SWR (vs 50 Ω)');
+    // Transformed values visible: 450/9 = 50, SWR ≈ 1.00:1
+    expect(container.textContent).toContain('Transformed (R + jX)');
+    expect(container.textContent).toContain('50.0');
+    expect(container.textContent).toContain('Transformed SWR (vs 50 Ω)');
+    expect(container.textContent).toContain('1.00:1');
+  });
+
+  it('does not show transformed values when disabled even if result is present', () => {
+    useAntennaStore.setState({
+      transformerEnabled: false,
+      result: {
+        computeTimeMs: 10,
+        maxGainDbi: 7,
+        takeoffElevationDeg: 15,
+        takeoffAzimuthDeg: 0,
+        impedance: { R: 450, X: 0 },
+        swr: 9.0,
+        pattern: { data: new Float32Array([1]), phiSteps: 1, thetaSteps: 1 },
+      } as unknown as import('../src/physics/types').SimulationResult,
+    });
+
+    const { container } = render(<TransformerControl />);
+    expect(container.textContent).not.toContain('Transformed SWR');
+    expect(container.textContent).not.toContain('Raw SWR');
+  });
+
+  it('updates ratio when input changes', () => {
+    useAntennaStore.setState({ transformerEnabled: true });
+    const { getByLabelText } = render(<TransformerControl />);
+    const input = getByLabelText(/Impedance ratio/i) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '4' } });
+    expect(useAntennaStore.getState().transformerRatio).toBe(4);
+  });
+
+  it('shows disclaimer note when enabled and result is present', () => {
+    useAntennaStore.setState({
+      transformerEnabled: true,
+      transformerRatio: 9,
+      result: {
+        computeTimeMs: 10,
+        maxGainDbi: 2,
+        takeoffElevationDeg: 15,
+        takeoffAzimuthDeg: 0,
+        impedance: { R: 450, X: 0 },
+        swr: 9.0,
+        pattern: { data: new Float32Array([1]), phiSteps: 1, thetaSteps: 1 },
+      } as unknown as import('../src/physics/types').SimulationResult,
+    });
+
+    const { container } = render(<TransformerControl />);
+    expect(container.textContent).toContain('ideal post-processing calculations');
+  });
+});

--- a/tests/impedance.test.ts
+++ b/tests/impedance.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { swr, mismatchLossFactor } from '../src/physics/impedance';
+import { swr, mismatchLossFactor, transformImpedance } from '../src/physics/impedance';
 
 describe('reflection coefficient and SWR', () => {
   it('perfect match => |Γ|=0, SWR=1', () => {
@@ -64,5 +64,53 @@ describe('mismatchLossFactor', () => {
     const mlf = mismatchLossFactor({ R: 50, X: 50 });
     expect(mlf).toBeGreaterThan(0);
     expect(mlf).toBeLessThan(1);
+  });
+});
+
+describe('transformImpedance', () => {
+  it('450+j0 with ratio 9 gives 50+j0 and SWR ~1:1', () => {
+    const z = transformImpedance({ R: 450, X: 0 }, 9);
+    expect(z.R).toBeCloseTo(50, 6);
+    expect(z.X).toBeCloseTo(0, 6);
+    expect(swr(z)).toBeCloseTo(1, 5);
+  });
+
+  it('ratio 1 leaves impedance unchanged', () => {
+    const z = transformImpedance({ R: 73, X: 42 }, 1);
+    expect(z.R).toBeCloseTo(73, 6);
+    expect(z.X).toBeCloseTo(42, 6);
+  });
+
+  it('transforms both R and X', () => {
+    const z = transformImpedance({ R: 400, X: 200 }, 4);
+    expect(z.R).toBeCloseTo(100, 6);
+    expect(z.X).toBeCloseTo(50, 6);
+  });
+
+  it('raw SWR is unaffected by calling transformImpedance', () => {
+    const original = { R: 450, X: 0 };
+    const rawSwr = swr(original);
+    transformImpedance(original, 9);
+    // Ensure the original object is not mutated
+    expect(swr(original)).toBe(rawSwr);
+    expect(original.R).toBe(450);
+  });
+
+  it('invalid ratio (0) returns original impedance unchanged', () => {
+    const original = { R: 100, X: 50 };
+    const result = transformImpedance(original, 0);
+    expect(result).toBe(original);
+  });
+
+  it('invalid ratio (negative) returns original impedance unchanged', () => {
+    const original = { R: 100, X: 50 };
+    const result = transformImpedance(original, -1);
+    expect(result).toBe(original);
+  });
+
+  it('invalid ratio (NaN) returns original impedance unchanged', () => {
+    const original = { R: 100, X: 50 };
+    const result = transformImpedance(original, NaN);
+    expect(result).toBe(original);
   });
 });


### PR DESCRIPTION
Implements issue #147: adds an optional ideal impedance-transformer post-processing view.

Raw feedpoint R+jX and SWR remain always visible and primary. The "Ideal transformer" section is off by default and shows transformed values only when the user enables it. The SWR sweep chart gains a dashed green trace for the transformed sweep.

Generates with [Claude Code](https://claude.ai/code)