### PR TITLE
feat: Delta Loop isosceles geometry, apex feed, DELTA_BASE_TAG

### DIFF
--- a/src/components/Scene/DipoleWire.tsx
+++ b/src/components/Scene/DipoleWire.tsx
@@ -117,18 +117,15 @@ export function DipoleWire({
   // Locate elements we want to decorate.
   const bridge = rendered.find((s) => s.isBridge);
   const dipoleSingle = rendered.find((s) => s.tag === DIPOLE_TAG && !bridge);
-  const deltaLoopBottom = rendered.find((s) => type === 'delta-loop' && s.tag === DIPOLE_RIGHT_TAG);
   const shield = rendered.find((s) => s.isShield);
 
-  // V-Beam: left leg runs tip→apex (sceneEnd = apex). DIPOLE_TAG === DIPOLE_LEFT_TAG,
-  // so dipoleSingle would match the left leg and place the marker at its midpoint;
-  // use sceneEnd (the apex) instead.
+  // V-Beam and Delta Loop: left leg runs tip→apex; sceneEnd is the apex point.
   const vBeamLeft = type === 'v-beam' ? (rendered.find((s) => s.tag === DIPOLE_LEFT_TAG) ?? null) : null;
+  const deltaLoopLeft = type === 'delta-loop' ? (rendered.find((s) => s.tag === DIPOLE_LEFT_TAG) ?? null) : null;
 
-  // The feedpoint is at the bridge midpoint when split, else at the dipole
-  // wire's midpoint (legacy single-wire layout).
-  // For Delta Loop, it's at the center of the bottom wire.
-  const feedpoint = bridge?.feedMid ?? deltaLoopBottom?.feedMid ?? vBeamLeft?.sceneEnd ?? dipoleSingle?.feedMid ?? null;
+  // Feedpoint: bridge midpoint (split-fed) > delta loop apex > v-beam apex >
+  // dipole wire midpoint (single-wire legacy).
+  const feedpoint = bridge?.feedMid ?? deltaLoopLeft?.sceneEnd ?? vBeamLeft?.sceneEnd ?? dipoleSingle?.feedMid ?? null;
 
   return (
     <group>

--- a/src/physics/constants.ts
+++ b/src/physics/constants.ts
@@ -66,7 +66,8 @@ export const DIPOLE_LEFT_TAG = 1; // left half of split dipole
 export const DIPOLE_RIGHT_TAG = 2; // right half of split dipole
 export const FEED_BRIDGE_TAG = 3; // 1-segment source bridge
 export const FEEDLINE_SHIELD_TAG = 4; // coax shield (radiating outer surface)
-export const DELTA_LOOP_RIGHT_LEG_TAG = 5; // right leg of delta loop (apex to right corner)
+export const DELTA_LOOP_RIGHT_LEG_TAG = 5; // right leg of delta loop (apex to right corner) — superseded by DIPOLE_RIGHT_TAG; kept for compatibility
+export const DELTA_BASE_TAG = 6; // base wire of delta loop (left corner to right corner)
 
 /**
  * Length of the source bridge segment for apex-fed or split-fed antennas (metres).

--- a/src/store/antennaGeometry.ts
+++ b/src/store/antennaGeometry.ts
@@ -5,7 +5,7 @@ import {
   DIPOLE_RIGHT_TAG,
   FEED_BRIDGE_TAG,
   FEED_BRIDGE_LENGTH_M,
-  DELTA_LOOP_RIGHT_LEG_TAG,
+  DELTA_BASE_TAG,
 } from '../physics/constants';
 import type { Wire } from '../physics/types';
 
@@ -296,68 +296,79 @@ export interface DeltaLoopWiresParams {
 }
 
 /**
- * Builds the wires for a Delta Loop antenna (Apex-up equilateral).
- * Tag 1: Left leg
- * Tag 2: Bottom wire (fed at center)
- * Tag 5: Right leg
+ * Builds the wires for a Delta Loop antenna (apex-up, apex-fed).
+ *
+ * Produces an isosceles triangle whose perimeter always equals params.length.
+ * When the equilateral triangle height fits within the mast height, the result
+ * is equilateral. When the mast is too short the triangle is flattened while
+ * preserving the full perimeter.
+ *
+ * Tags:
+ *   DIPOLE_LEFT_TAG  (1) — left leg:  leftCorner → apex
+ *   DIPOLE_RIGHT_TAG (2) — right leg: apex → rightCorner
+ *   DELTA_BASE_TAG   (6) — base wire: leftCorner → rightCorner
+ *
+ * Excitation is placed on the last segment of DIPOLE_LEFT_TAG (the apex end).
  */
 export function buildDeltaLoopWires(params: DeltaLoopWiresParams): Wire[] {
   const perimeter = params.length;
-  const sideLen = perimeter / 3;
   const h = params.height;
   const [dx, dy] = orientationVector(params.orientation);
 
-  // Apex at (0,0,h). Equilateral triangle in the plane defined by orientation.
-  // Height of equilateral triangle = sideLen * sqrt(3)/2.
-  let triHeight = (sideLen * Math.sqrt(3)) / 2;
+  // Maximum available triangle height given the mast height.
+  const equilateralHeight = (perimeter * Math.sqrt(3)) / 6;
+  const maxAvailable = Math.max(0, h - SLOPING_V_MIN_TIP_Z_M);
+  const triHeight = Math.min(equilateralHeight, maxAvailable);
 
-  // Clamp height to avoid wires touching ground.
-  if (triHeight > h - SLOPING_V_MIN_TIP_Z_M) {
-    triHeight = Math.max(0, h - SLOPING_V_MIN_TIP_Z_M);
-  }
   const bottomZ = h - triHeight;
 
+  // Isosceles triangle with fixed perimeter P and height t:
+  //   leg  = t²/P + P/4
+  //   base = P − 2·leg  →  halfBase = P/4 − t²/P
+  const legLength = (triHeight * triHeight) / perimeter + perimeter / 4;
+  const halfBase = perimeter / 4 - (triHeight * triHeight) / perimeter;
+
   const apex: [number, number, number] = [0, 0, h];
-  const leftCorner: [number, number, number] = [
-    -(sideLen / 2) * dx,
-    -(sideLen / 2) * dy,
-    bottomZ,
-  ];
-  const rightCorner: [number, number, number] = [
-    (sideLen / 2) * dx,
-    (sideLen / 2) * dy,
-    bottomZ,
-  ];
+  const leftCorner: [number, number, number] = [-halfBase * dx, -halfBase * dy, bottomZ];
+  const rightCorner: [number, number, number] = [halfBase * dx, halfBase * dy, bottomZ];
 
   const lambda = wavelengthMeters(params.frequency);
-  const minSegPerSide = Math.ceil((SEGS_PER_WAVELENGTH * sideLen) / lambda);
-  const segmentsPerSide = Math.min(
+
+  const minLegSegs = Math.ceil((SEGS_PER_WAVELENGTH * legLength) / lambda);
+  const segmentsPerLeg = Math.min(
     MAX_SEGS_PER_LEG,
-    Math.max(MIN_SEGS_PER_LEG, minSegPerSide, Math.round(params.segments / 3)),
+    Math.max(MIN_SEGS_PER_LEG, minLegSegs, Math.round(params.segments / 3)),
   );
-  const bottomSegments = segmentsPerSide % 2 === 0 ? segmentsPerSide + 1 : segmentsPerSide;
+
+  const baseLength = halfBase * 2;
+  const minBaseSegs = Math.ceil((SEGS_PER_WAVELENGTH * baseLength) / lambda);
+  const rawBaseSegs = Math.min(
+    MAX_SEGS_PER_LEG,
+    Math.max(MIN_SEGS_PER_LEG, minBaseSegs, Math.round(params.segments / 3)),
+  );
+  const baseSegments = rawBaseSegs % 2 === 0 ? rawBaseSegs + 1 : rawBaseSegs;
 
   return [
     {
       start: leftCorner,
       end: apex,
       radius: params.wireRadius,
-      segments: segmentsPerSide,
+      segments: segmentsPerLeg,
       tag: DIPOLE_LEFT_TAG,
     },
     {
       start: apex,
       end: rightCorner,
       radius: params.wireRadius,
-      segments: segmentsPerSide,
-      tag: DELTA_LOOP_RIGHT_LEG_TAG,
+      segments: segmentsPerLeg,
+      tag: DIPOLE_RIGHT_TAG,
     },
     {
       start: leftCorner,
       end: rightCorner,
       radius: params.wireRadius,
-      segments: bottomSegments,
-      tag: DIPOLE_RIGHT_TAG, // Tag 2
+      segments: baseSegments,
+      tag: DELTA_BASE_TAG,
     },
   ];
 }

--- a/src/store/antennaStore.ts
+++ b/src/store/antennaStore.ts
@@ -37,6 +37,7 @@ import {
   FEED_BRIDGE_TAG,
   FEEDLINE_SHIELD_TAG,
   FEED_BRIDGE_LENGTH_M,
+  DELTA_BASE_TAG,
 } from '../physics/constants';
 
 // Re-export geometry tags for UI and tests.
@@ -47,6 +48,7 @@ export {
   FEED_BRIDGE_TAG,
   FEEDLINE_SHIELD_TAG,
   FEED_BRIDGE_LENGTH_M,
+  DELTA_BASE_TAG,
 };
 import type { UnitSystem } from '../physics/units';
 import {
@@ -704,8 +706,8 @@ export function selectSimulationInput(state: AntennaState): SimulationInput {
     const leftWire = wires.find((w) => w.tag === DIPOLE_LEFT_TAG)!;
     excitation = { wireTag: DIPOLE_LEFT_TAG, segment: leftWire.segments };
   } else if (state.antennaType === 'delta-loop') {
-    const bottomWire = wires.find((w) => w.tag === DIPOLE_RIGHT_TAG)!;
-    excitation = { wireTag: DIPOLE_RIGHT_TAG, segment: Math.ceil(bottomWire.segments / 2) };
+    const leftLeg = wires.find((w) => w.tag === DIPOLE_LEFT_TAG)!;
+    excitation = { wireTag: DIPOLE_LEFT_TAG, segment: leftLeg.segments };
   } else {
     const dipoleCentreSeg = Math.ceil(state.segments / 2);
     excitation = { wireTag: DIPOLE_TAG, segment: dipoleCentreSeg };

--- a/tests/antennaStore.test.ts
+++ b/tests/antennaStore.test.ts
@@ -6,6 +6,7 @@ import {
   computeEffectiveSlope,
   DIPOLE_LEFT_TAG,
   DIPOLE_RIGHT_TAG,
+  DELTA_BASE_TAG,
   type AntennaState,
 } from '../src/store/antennaStore';
 import { FEED_BRIDGE_TAG } from '../src/physics/constants';
@@ -874,6 +875,112 @@ describe('antennaStore actions', () => {
 
     it('emits no transmission lines or loads for Inverted V', () => {
       const state = { ...useAntennaStore.getState(), ...commonState, antennaType: 'inverted-v' };
+      const input = selectSimulationInput(state as AntennaState);
+      expect(input.transmissionLines).toBeUndefined();
+      expect(input.loads).toBeUndefined();
+    });
+  });
+
+  describe('Delta Loop Geometry', () => {
+    // λ at 7.1 MHz ≈ 42.224 m; default delta loop perimeter = 1λ
+    const lambda = 299.792458 / 7.1;
+
+    const baseState = {
+      antennaType: 'delta-loop' as const,
+      length: lambda,         // perimeter = 1λ
+      height: 15,
+      orientation: 'EW' as const,
+      wireRadius: 0.001,
+      segments: 21,
+      frequency: 7.1,
+      vAngle: 180,
+      legSlope: 0,
+    };
+
+    it('produces exactly 3 wires with distinct tags', () => {
+      const wires = buildWires(baseState);
+      expect(wires).toHaveLength(3);
+      const tags = wires.map((w) => w.tag).sort((a, b) => a - b);
+      expect(tags).toEqual([DIPOLE_LEFT_TAG, DIPOLE_RIGHT_TAG, DELTA_BASE_TAG]);
+    });
+
+    it('apex is at full mast height on all leg endpoints', () => {
+      const wires = buildWires(baseState);
+      const leftLeg = wires.find((w) => w.tag === DIPOLE_LEFT_TAG)!;
+      const rightLeg = wires.find((w) => w.tag === DIPOLE_RIGHT_TAG)!;
+      // Left leg: start = leftCorner, end = apex
+      expect(leftLeg.end[2]).toBeCloseTo(baseState.height);
+      // Right leg: start = apex, end = rightCorner
+      expect(rightLeg.start[2]).toBeCloseTo(baseState.height);
+      // Apex coordinates agree between the two legs
+      expect(leftLeg.end[0]).toBeCloseTo(rightLeg.start[0]);
+      expect(leftLeg.end[1]).toBeCloseTo(rightLeg.start[1]);
+      expect(leftLeg.end[2]).toBeCloseTo(rightLeg.start[2]);
+    });
+
+    it('equilateral triangle when mast height allows it (7.1 MHz, 15 m)', () => {
+      // P = λ ≈ 42.224 m. Equilateral height = P * sqrt(3) / 6 ≈ 12.18 m.
+      // 15 m - 0.5 m = 14.5 m available, so equilateral fits.
+      const wires = buildWires(baseState);
+      const equilateralHeight = (lambda * Math.sqrt(3)) / 6;
+      const sideLen = lambda / 3;
+
+      const leftLeg = wires.find((w) => w.tag === DIPOLE_LEFT_TAG)!;
+      const base = wires.find((w) => w.tag === DELTA_BASE_TAG)!;
+
+      // Base width = side length (equilateral)
+      const baseWidth = Math.sqrt(
+        (base.start[0] - base.end[0]) ** 2 + (base.start[1] - base.end[1]) ** 2,
+      );
+      expect(baseWidth).toBeCloseTo(sideLen, 2);
+
+      // Triangle height: apex z - base z
+      const triHeight = leftLeg.end[2] - leftLeg.start[2];
+      expect(triHeight).toBeCloseTo(equilateralHeight, 2);
+    });
+
+    it('preserves full perimeter when height forces isosceles shape', () => {
+      // Mast height 5 m: equilateral height ≈ 12.18 m, but available is 4.5 m.
+      const shortState = { ...baseState, height: 5 };
+      const wires = buildWires(shortState);
+
+      const leftLeg = wires.find((w) => w.tag === DIPOLE_LEFT_TAG)!;
+      const rightLeg = wires.find((w) => w.tag === DIPOLE_RIGHT_TAG)!;
+      const base = wires.find((w) => w.tag === DELTA_BASE_TAG)!;
+
+      const dist3d = (
+        a: readonly [number, number, number],
+        b: readonly [number, number, number],
+      ) => Math.sqrt((a[0] - b[0]) ** 2 + (a[1] - b[1]) ** 2 + (a[2] - b[2]) ** 2);
+
+      const leftLen = dist3d(leftLeg.start, leftLeg.end);
+      const rightLen = dist3d(rightLeg.start, rightLeg.end);
+      const baseLen = dist3d(base.start, base.end);
+      const actualPerimeter = leftLen + rightLen + baseLen;
+
+      expect(actualPerimeter).toBeCloseTo(lambda, 1);
+    });
+
+    it('base corners stay above minimum height (SLOPING_V_MIN_TIP_Z_M = 0.5 m)', () => {
+      // Very short mast — base must not go below 0.5 m.
+      const shortState = { ...baseState, height: 2 };
+      const wires = buildWires(shortState);
+      const base = wires.find((w) => w.tag === DELTA_BASE_TAG)!;
+      expect(base.start[2]).toBeGreaterThanOrEqual(0.49);
+      expect(base.end[2]).toBeGreaterThanOrEqual(0.49);
+    });
+
+    it('excitation lands on the left leg at its last (apex) segment', () => {
+      const state = { ...useAntennaStore.getState(), ...baseState };
+      const input = selectSimulationInput(state as AntennaState);
+
+      const leftLeg = input.wires.find((w) => w.tag === DIPOLE_LEFT_TAG)!;
+      expect(input.excitation.wireTag).toBe(DIPOLE_LEFT_TAG);
+      expect(input.excitation.segment).toBe(leftLeg.segments);
+    });
+
+    it('emits no transmission lines or loads', () => {
+      const state = { ...useAntennaStore.getState(), ...baseState };
       const input = selectSimulationInput(state as AntennaState);
       expect(input.transmissionLines).toBeUndefined();
       expect(input.loads).toBeUndefined();

--- a/tests/apexFeed.test.ts
+++ b/tests/apexFeed.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { useAntennaStore, selectSimulationInput } from '../src/store/antennaStore';
 import { buildNecCards } from '../src/physics/necCard';
 import { parseGwLine, getNecLines, expectExcitation } from './necInspect';
-import { FEED_BRIDGE_TAG, DIPOLE_RIGHT_TAG } from '../src/physics/constants';
+import { FEED_BRIDGE_TAG, DIPOLE_LEFT_TAG, DELTA_BASE_TAG } from '../src/physics/constants';
 
 describe('Apex Feed and Geometry', () => {
   it('should generate a balanced bridge for Inverted V', () => {
@@ -74,7 +74,7 @@ describe('Apex Feed and Geometry', () => {
     expectExcitation(deck, FEED_BRIDGE_TAG, 1);
   });
 
-  it('should feed the center of the bottom wire for Delta Loop', () => {
+  it('should feed the apex (last segment of left leg) for Delta Loop', () => {
     const store = useAntennaStore.getState();
     store.setAntennaType('delta-loop');
     store.setFrequency(7.1);
@@ -85,11 +85,16 @@ describe('Apex Feed and Geometry', () => {
     const deck = buildNecCards(input);
 
     const gwLines = getNecLines(deck, 'GW');
-    const bottomWireLine = gwLines.find(l => parseGwLine(l).tag === DIPOLE_RIGHT_TAG); // Tag 2
-    expect(bottomWireLine).toBeDefined();
-    const bottomWire = parseGwLine(bottomWireLine!);
 
-    const expectedSegment = Math.ceil(bottomWire.segments / 2);
-    expectExcitation(deck, DIPOLE_RIGHT_TAG, expectedSegment);
+    // Left leg (tag 1) ends at the apex — excitation must land on its last segment.
+    const leftLegLine = gwLines.find(l => parseGwLine(l).tag === DIPOLE_LEFT_TAG);
+    expect(leftLegLine).toBeDefined();
+    const leftLeg = parseGwLine(leftLegLine!);
+
+    expectExcitation(deck, DIPOLE_LEFT_TAG, leftLeg.segments);
+
+    // Base wire must use DELTA_BASE_TAG (tag 6), not DIPOLE_RIGHT_TAG (tag 2).
+    const baseLine = gwLines.find(l => parseGwLine(l).tag === DELTA_BASE_TAG);
+    expect(baseLine).toBeDefined();
   });
 });


### PR DESCRIPTION
Closes #149 with the refinement from the issue comment: an isosceles triangle constrained by mast height that always preserves the full perimeter.

## Changes

- Isosceles triangle formula: leg = t²/P + P/4, halfBase = P/4 − t²/P
- New `DELTA_BASE_TAG = 6` constant (fixes tag-reuse bug from PR #101)
- Excitation at apex (last segment of DIPOLE_LEFT_TAG, not base center)
- 3D feedpoint marker moved to apex
- 6 new tests covering tags, geometry, perimeter preservation, height clamping, and excitation

Closes #149

Generated with [Claude Code](https://claude.ai/code)