### PR TITLE
feat: implement Delta Loop termination at base centre

### DIFF
--- a/src/store/antennaStore.ts
+++ b/src/store/antennaStore.ts
@@ -114,9 +114,12 @@ export interface AntennaState {
   legSlope: number;
 
   /**
-   * For sloping-V and V-beam: far-end terminating resistor across the two tips.
-   * 0 = unterminated. Any positive value inserts one NEC NT card representing
-   * the total across-tip resistance (not per-leg-to-ground).
+   * Far-end terminating resistor (ohms).
+   * 0 = unterminated.
+   *
+   * - sloping-V / v-beam: inserts one NEC NT card representing the total
+   *   across-tip resistance (not per-leg-to-ground).
+   * - delta-loop: inserts one NEC LD 4 card at the centre of the base wire.
    */
   terminatingResistor: number;
 
@@ -738,6 +741,19 @@ export function selectSimulationInput(state: AntennaState): SimulationInput {
         param2: 0,
       });
     }
+  }
+
+  if (state.antennaType === 'delta-loop' && state.terminatingResistor > 0) {
+    const baseWire = wires.find((w) => w.tag === DELTA_BASE_TAG)!;
+    const centerSeg = Math.ceil(baseWire.segments / 2);
+    loads.push({
+      type: 4,
+      wireTag: DELTA_BASE_TAG,
+      segmentStart: centerSeg,
+      segmentEnd: centerSeg,
+      param1: state.terminatingResistor,
+      param2: 0,
+    });
   }
 
   const networks: NetworkLoad[] = [];

--- a/tests/deltaLoopTermination.test.ts
+++ b/tests/deltaLoopTermination.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useAntennaStore, selectSimulationInput } from '../src/store/antennaStore';
+import { buildNecCards } from '../src/physics/necCard';
+import { getNecLines, parseLdLine, expectExcitation } from './necInspect';
+import { DELTA_BASE_TAG, DIPOLE_LEFT_TAG } from '../src/physics/constants';
+
+function setupDeltaLoop(terminatingResistor?: number) {
+  const store = useAntennaStore.getState();
+  store.setAntennaType('delta-loop');
+  store.setFrequency(7.1);
+  store.setLength(42);
+  store.setHeight(15);
+  if (terminatingResistor !== undefined) {
+    store.setTerminatingResistor(terminatingResistor);
+  }
+}
+
+describe('Delta Loop termination (LD 4 at base centre)', () => {
+  beforeEach(() => {
+    useAntennaStore.getState().setTerminatingResistor(0);
+  });
+
+  it('no LD card when unterminated (terminatingResistor=0)', () => {
+    setupDeltaLoop(0);
+    const input = selectSimulationInput(useAntennaStore.getState());
+    const deck = buildNecCards(input);
+    expect(getNecLines(deck, 'LD')).toHaveLength(0);
+    expect(input.loads).toBeUndefined();
+  });
+
+  it('exactly one LD card when terminatingResistor > 0', () => {
+    setupDeltaLoop(600);
+    const input = selectSimulationInput(useAntennaStore.getState());
+    const deck = buildNecCards(input);
+    expect(getNecLines(deck, 'LD')).toHaveLength(1);
+    expect(input.loads).toHaveLength(1);
+  });
+
+  it('LD card is type 4', () => {
+    setupDeltaLoop(600);
+    const input = selectSimulationInput(useAntennaStore.getState());
+    const deck = buildNecCards(input);
+    const ld = parseLdLine(getNecLines(deck, 'LD')[0]);
+    expect(ld.type).toBe(4);
+  });
+
+  it('LD card targets DELTA_BASE_TAG', () => {
+    setupDeltaLoop(600);
+    const input = selectSimulationInput(useAntennaStore.getState());
+    const deck = buildNecCards(input);
+    const ld = parseLdLine(getNecLines(deck, 'LD')[0]);
+    expect(ld.tag).toBe(DELTA_BASE_TAG);
+  });
+
+  it('LD card targets the centre segment of the base wire', () => {
+    setupDeltaLoop(600);
+    const input = selectSimulationInput(useAntennaStore.getState());
+    const baseWire = input.wires.find((w) => w.tag === DELTA_BASE_TAG)!;
+    const expectedCenter = Math.ceil(baseWire.segments / 2);
+    const deck = buildNecCards(input);
+    const ld = parseLdLine(getNecLines(deck, 'LD')[0]);
+    expect(ld.segmentStart).toBe(expectedCenter);
+    expect(ld.segmentEnd).toBe(expectedCenter);
+  });
+
+  it('LD resistance equals terminatingResistor directly (not halved)', () => {
+    const R = 600;
+    setupDeltaLoop(R);
+    const input = selectSimulationInput(useAntennaStore.getState());
+    const deck = buildNecCards(input);
+    const ld = parseLdLine(getNecLines(deck, 'LD')[0]);
+    expect(ld.p1).toBeCloseTo(R, 9);
+    expect(ld.p2).toBeCloseTo(0, 9);
+  });
+
+  it('LD resistance scales with terminatingResistor', () => {
+    setupDeltaLoop(1200);
+    const input1 = selectSimulationInput(useAntennaStore.getState());
+    const ld1 = parseLdLine(getNecLines(buildNecCards(input1), 'LD')[0]);
+
+    useAntennaStore.getState().setTerminatingResistor(600);
+    const input2 = selectSimulationInput(useAntennaStore.getState());
+    const ld2 = parseLdLine(getNecLines(buildNecCards(input2), 'LD')[0]);
+
+    expect(ld2.p1).toBeCloseTo(ld1.p1 / 2, 9);
+  });
+
+  it('excitation remains on left leg (DIPOLE_LEFT_TAG) last segment', () => {
+    setupDeltaLoop(600);
+    const input = selectSimulationInput(useAntennaStore.getState());
+    const leftLeg = input.wires.find((w) => w.tag === DIPOLE_LEFT_TAG)!;
+    expectExcitation(buildNecCards(input), DIPOLE_LEFT_TAG, leftLeg.segments);
+  });
+
+  it('no NT card emitted for delta-loop termination', () => {
+    setupDeltaLoop(600);
+    const input = selectSimulationInput(useAntennaStore.getState());
+    const deck = buildNecCards(input);
+    expect(getNecLines(deck, 'NT')).toHaveLength(0);
+    expect(input.networks).toBeUndefined();
+  });
+
+  it('v-beam: delta-loop termination does not add LD card', () => {
+    const store = useAntennaStore.getState();
+    store.setAntennaType('v-beam');
+    store.setFrequency(7.1);
+    store.setLength(84);
+    store.setHeight(15);
+    store.setVAngle(90);
+    store.setTerminatingResistor(600);
+    const input = selectSimulationInput(useAntennaStore.getState());
+    expect(getNecLines(buildNecCards(input), 'LD')).toHaveLength(0);
+    expect(input.loads).toBeUndefined();
+  });
+
+  it('dipole: terminatingResistor has no effect on LD cards', () => {
+    const store = useAntennaStore.getState();
+    store.setAntennaType('dipole');
+    store.setTerminatingResistor(600);
+    const input = selectSimulationInput(useAntennaStore.getState());
+    expect(getNecLines(buildNecCards(input), 'LD')).toHaveLength(0);
+    expect(input.loads).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Implement termination for the Delta Loop antenna at the base centre (opposite the feedpoint).

When `terminatingResistor > 0` and `antennaType === 'delta-loop'`, a single NEC LD 4 card is inserted at the centre segment of `DELTA_BASE_TAG`. The UI value is mapped directly (not halved). V-beam and dipole termination paths are unchanged.

Closes #160

Generated with [Claude Code](https://claude.ai/code)