### PR TITLE
fix(necParser): remove spurious lower-lobe on ground-plane patterns

### DIFF
--- a/src/physics/necParser.ts
+++ b/src/physics/necParser.ts
@@ -115,7 +115,7 @@ function parsePattern(text: string, thetaSteps: number, phiSteps: number): GainP
   const rowRe = /^\s+(-?\d+\.\d+)\s+(-?\d+\.\d+)\s+(-?\d+\.\d+)\s+(-?\d+\.\d+)\s+(-?\d+\.\d+)/;
 
   const expected = thetaSteps * phiSteps;
-  const data = new Float32Array(expected);
+  const data = new Float32Array(expected).fill(-100);
   let count = 0;
 
   // Track the order we see (theta, phi) so we can verify NEC emitted in the


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- NEC with a ground plane (`GE 1`) does not emit radiation-pattern rows for theta > 90° — there is physically no far-field radiation below the ground.
- `parsePattern` allocated the data array with `new Float32Array(expected)`, which zero-fills. Unpopulated below-ground slots therefore read as **0 dBi** and rendered as a visible lower-hemisphere lobe in the 3D pattern viewer.
- Fix: initialise the array with `.fill(-100)` — the same sentinel used for NEC's own `-999.99` "unmeasured" values — so those slots correctly represent the absence of below-ground radiation and collapse to an imperceptible radius in the renderer.
- Free-space patterns are unaffected: NEC fills every theta slot (0°–180°) there, so the initial value is overwritten for all entries.

## Test plan

- [ ] Non-free-space patterns (real ground, perfect ground) no longer show a lower lobe below the ground plane
- [ ] Free-space patterns are visually unchanged (symmetric upper and lower lobes still present)
- [ ] All 356 tests pass (`npx vitest run`)

https://claude.ai/code/session_01JyU1Rn8sXvbywfb145BY8k
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JyU1Rn8sXvbywfb145BY8k)_