### PR TITLE
🛡️ Sentinel: [HIGH] Add WASM Cross-Origin Isolation Headers

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -13,3 +13,7 @@
   Content-Security-Policy: default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; worker-src 'self' blob:; object-src 'none';
   # Isolate the browsing context to same-origin to prevent cross-origin info leaks
   Cross-Origin-Opener-Policy: same-origin
+  # Prevent cross-origin resource embedding for WASM isolation
+  Cross-Origin-Embedder-Policy: require-corp
+  # Prevent other origins from reading the application's resources
+  Cross-Origin-Resource-Policy: same-origin


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Add WASM Cross-Origin Isolation Headers

🚨 Severity: HIGH
💡 Vulnerability: Missing `Cross-Origin-Embedder-Policy` and `Cross-Origin-Resource-Policy` in the HTTP response headers. Without full cross-origin isolation, WebAssembly execution environments (especially those that may utilize SharedArrayBuffer for multithreading) are potentially exposed to cross-origin information leaks (such as Spectre attacks).
🎯 Impact: Attackers could theoretically perform timing attacks or read sensitive data from the WASM memory space if malicious cross-origin documents were able to embed the application without restriction.
🔧 Fix: Appended `Cross-Origin-Embedder-Policy: require-corp` and `Cross-Origin-Resource-Policy: same-origin` to `public/_headers`, completing the cross-origin isolation triad alongside the existing `Cross-Origin-Opener-Policy`.
✅ Verification: `npm run test` and `npm run lint` passed successfully. Changes can be verified by checking the deployed site's response headers.

---
*PR created automatically by Jules for task [1616304093890185788](https://jules.google.com/task/1616304093890185788) started by @2fst4u*