### PR TITLE
🎨 Palette: Minor UX accessibility enhancements

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -38,3 +38,7 @@
 ## 2024-05-26 - Exposing Keyboard Shortcuts
 **Learning:** Hidden keyboard shortcuts are great for power users, but they lack discoverability. Additionally, screen readers are not aware of custom JavaScript-based keybindings unless explicitly told.
 **Action:** When adding global keyboard shortcuts (like `T` for theme toggle, `U` for unit toggle, or `M`/`N`/`C` for mode switching), always append the shortcut to the visual `title` tooltip (e.g. `(T)`) and add the `aria-keyshortcuts` attribute to the corresponding interactive element.
+
+## 2024-05-27 - Inline Constraint Warnings (Geometry Status)
+**Learning:** Found that when a user's requested numeric input (e.g., Sloping V angle) is silently clamped by the system to satisfy physical constraints (e.g., minimum tip height), visual warnings alone are insufficient for accessibility. Without proper ARIA announcements, screen reader users miss the fact that their requested input was overridden by the system, leading to confusion about the actual state of the simulation.
+**Action:** When creating inline warning components that display dynamic constraint violations or system overrides (like `GeometryStatus`), always wrap the notification in a container with `role="status"` and `aria-live="polite"` so screen readers are audibly notified of the clamp.

--- a/src/components/Panel/DipoleControl.tsx
+++ b/src/components/Panel/DipoleControl.tsx
@@ -252,14 +252,18 @@ function GeometryStatus() {
   const unit = displayLengthUnit(units);
 
   return (
-    <div style={{
-      marginTop: 12,
-      padding: '8px 10px',
-      fontSize: 12,
-      borderRadius: 4,
-      background: isClamped ? 'rgba(255, 107, 107, 0.1)' : 'var(--bg-accent)',
-      border: `1px solid ${isClamped ? '#ff6b6b' : 'var(--border)'}`,
-    }}>
+    <div
+      role="status"
+      aria-live="polite"
+      style={{
+        marginTop: 12,
+        padding: '8px 10px',
+        fontSize: 12,
+        borderRadius: 4,
+        background: isClamped ? 'rgba(255, 107, 107, 0.1)' : 'var(--bg-accent)',
+        border: `1px solid ${isClamped ? '#ff6b6b' : 'var(--border)'}`,
+      }}
+    >
       <div style={{ fontWeight: 600, marginBottom: 4, color: isClamped ? '#ff6b6b' : 'inherit' }}>
         {isClamped ? '⚠️ Geometry Clamped' : 'Geometry Status'}
       </div>

--- a/src/components/Panel/TransformerControl.tsx
+++ b/src/components/Panel/TransformerControl.tsx
@@ -42,13 +42,14 @@ export function TransformerControl() {
             max={10000}
             step={1}
             value={transformerRatio}
+            aria-describedby="transformer-hint"
             onChange={(e) => {
               const v = parseFloat(e.target.value);
               if (Number.isFinite(v) && v >= 1) setTransformerRatio(v);
             }}
             style={{ width: '100%', marginTop: 4 }}
           />
-          <div style={{ fontSize: 10, color: 'var(--text-muted)', marginTop: 4 }}>
+          <div id="transformer-hint" style={{ fontSize: 10, color: 'var(--text-muted)', marginTop: 4 }}>
             Z_transformed = Z_feedpoint / ratio (ideal, lossless)
           </div>
 


### PR DESCRIPTION
- Added `role="status"` and `aria-live="polite"` to the `GeometryStatus` warning panel to ensure screen readers announce when numeric constraints are enforced by the system.
- Fixed an accessibility issue in `TransformerControl.tsx` by linking the impedance ratio input field to its descriptive hint text via `aria-describedby`.
- Maintained a footprint under 50 lines without affecting backend logic.
- Recorded the learnings in the `.jules/palette.md` journal.

---
*PR created automatically by Jules for task [2065748188441635091](https://jules.google.com/task/2065748188441635091) started by @2fst4u*