### PR TITLE
🧪 Spec: Add tests for ComparisonControl

### DIFF
--- a/.jules/spec.md
+++ b/.jules/spec.md
@@ -5,3 +5,6 @@
 ## 2024-05-15 - Bumping coverage threshold for PolarPlots
 **Learning:** React Component Unit Tests for complex charts. When testing ChartJS components that use callbacks in deep properties (like `options.scales.r.ticks.callback`), simulating those specific nested functions in the mocked component allows testing internal branch logic safely without rendering real canvases.
 **Action:** Mock `react-chartjs-2` specifically testing the callbacks if necessary, rather than trying to load the full canvas.
+## 2026-05-18 - Explicit typing in mocked selectors
+**Learning:** The project's ESLint configuration strictly enforces `@typescript-eslint/no-explicit-any`. When writing tests or mocking functions (such as Zustand selectors), use `unknown` or precise typing instead of `any` to prevent linting failures.
+**Action:** Use `unknown` instead of `any` when mocking Zustand selectors in unit tests.

--- a/tests/ComparisonControl.test.tsx
+++ b/tests/ComparisonControl.test.tsx
@@ -1,0 +1,154 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { ComparisonControl } from '../src/components/Panel/ComparisonControl';
+import { useAntennaStore } from '../src/store/antennaStore';
+
+// Mock the store
+vi.mock('../src/store/antennaStore', async () => {
+  const actual = await vi.importActual('../src/store/antennaStore');
+  return {
+    ...actual,
+    useAntennaStore: vi.fn(),
+  };
+});
+
+describe('ComparisonControl', () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('renders nothing when mode is not comparison', () => {
+    vi.mocked(useAntennaStore).mockImplementation((selector: (s: unknown) => unknown) => {
+      const state = {
+        mode: 'standard',
+        units: 'metric',
+        result: null,
+        sweep: [],
+        comparisonReference: null,
+        captureComparisonReference: vi.fn(),
+        clearComparisonReference: vi.fn(),
+      };
+      return selector(state);
+    });
+
+    const { container } = render(<ComparisonControl />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders buttons but disabled when no result available', () => {
+    vi.mocked(useAntennaStore).mockImplementation((selector: (s: unknown) => unknown) => {
+      const state = {
+        mode: 'comparison',
+        units: 'metric',
+        result: null,
+        sweep: [],
+        comparisonReference: null,
+        captureComparisonReference: vi.fn(),
+        clearComparisonReference: vi.fn(),
+      };
+      return selector(state);
+    });
+
+    render(<ComparisonControl />);
+
+    expect(screen.getByRole('heading', { name: 'Comparison' })).toBeTruthy();
+
+    const captureButton = screen.getByRole('button', { name: 'Use current as reference' });
+    const clearButton = screen.getByRole('button', { name: 'Clear reference' });
+
+    expect(captureButton.hasAttribute('disabled')).toBe(true);
+    expect(clearButton.hasAttribute('disabled')).toBe(true);
+
+    expect(screen.getByText('Capture a solved configuration to enable side-by-side comparison.')).toBeTruthy();
+  });
+
+  it('enables capture button when result is available', () => {
+    const captureComparisonReference = vi.fn();
+    vi.mocked(useAntennaStore).mockImplementation((selector: (s: unknown) => unknown) => {
+      const state = {
+        mode: 'comparison',
+        units: 'metric',
+        result: { maxGainDbi: 2.15, swr: 1.5 },
+        sweep: [ { frequency: 14.1, swr: 1.5, impedance: { real: 50, imag: 0 } } ],
+        comparisonReference: null,
+        captureComparisonReference,
+        clearComparisonReference: vi.fn(),
+      };
+      return selector(state);
+    });
+
+    render(<ComparisonControl />);
+
+    const captureButton = screen.getByRole('button', { name: 'Use current as reference' });
+    expect(captureButton.hasAttribute('disabled')).toBe(false);
+
+    fireEvent.click(captureButton);
+    expect(captureComparisonReference).toHaveBeenCalledOnce();
+  });
+
+  it('displays reference and enables clear button when reference is captured', () => {
+    const clearComparisonReference = vi.fn();
+    vi.mocked(useAntennaStore).mockImplementation((selector: (s: unknown) => unknown) => {
+      const state = {
+        mode: 'comparison',
+        units: 'metric',
+        result: { maxGainDbi: 2.15, swr: 1.5 },
+        sweep: [ { frequency: 14.1, swr: 1.5, impedance: { real: 50, imag: 0 } } ],
+        comparisonReference: {
+          capturedAt: 1680000000000,
+          frequency: 14.1,
+          length: 10,
+          height: 5,
+          orientation: 'NS',
+          groundId: 'pastoral',
+          result: { maxGainDbi: 2.15, swr: 1.5 },
+        },
+        captureComparisonReference: vi.fn(),
+        clearComparisonReference,
+      };
+      return selector(state);
+    });
+
+    render(<ComparisonControl />);
+
+    const clearButton = screen.getByRole('button', { name: 'Clear reference' });
+    expect(clearButton.hasAttribute('disabled')).toBe(false);
+
+    // Check some rendered reference data
+    expect(screen.getByText('14.100 MHz')).toBeTruthy();
+    expect(screen.getByText('Pastoral (avg)')).toBeTruthy();
+    expect(screen.getByText('2.15 dBi')).toBeTruthy();
+    expect(screen.getByText('1.50:1')).toBeTruthy();
+
+    fireEvent.click(clearButton);
+    expect(clearComparisonReference).toHaveBeenCalledOnce();
+  });
+
+  it('displays custom ground correctly', () => {
+    vi.mocked(useAntennaStore).mockImplementation((selector: (s: unknown) => unknown) => {
+      const state = {
+        mode: 'comparison',
+        units: 'metric',
+        result: null,
+        sweep: [],
+        comparisonReference: {
+          capturedAt: 1680000000000,
+          frequency: 14.1,
+          length: 10,
+          height: 5,
+          orientation: 45,
+          groundId: 'custom',
+          result: { maxGainDbi: 2.15, swr: 1.5 },
+        },
+        captureComparisonReference: vi.fn(),
+        clearComparisonReference: vi.fn(),
+      };
+      return selector(state);
+    });
+
+    render(<ComparisonControl />);
+    expect(screen.getByText('Custom')).toBeTruthy();
+    expect(screen.getByText('45°')).toBeTruthy();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,10 +9,10 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       thresholds: {
-        statements: 60,
-        branches: 48,
-        functions: 65,
-        lines: 80,
+        statements: 61,
+        branches: 49,
+        functions: 66,
+        lines: 81,
       }
     }
   },


### PR DESCRIPTION
💡 What: The exact change made to the test suite: Added unit tests for `ComparisonControl.tsx` to verify its behaviors properly, and fixed an issue where `any` was breaking the typescript strict linting by replacing it with `unknown`.
🎯 Why: `ComparisonControl.tsx` lacked tests entirely. This newly added test makes the component secure against future regressions.
📈 Maturity Impact: Bumped coverage threshold from 60% statements to 61% statements, branches from 48% to 49%, functions from 65% to 66% and lines from 80% to 81% to lock in progress toward business standards.

---
*PR created automatically by Jules for task [12946302383615822090](https://jules.google.com/task/12946302383615822090) started by @2fst4u*