### PR TITLE
📚 Archivist: Clarify feedline support in antenna-spec.md

### DIFF
--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -1,12 +1,24 @@
 ## 2024-05-03 - Package Manager Drift
+
 **Learning:** The documentation originally instructed users to use `pnpm`, but the repository strictly uses `npm` (as evidenced by `package-lock.json`, `.npmrc` with `legacy-peer-deps=true`, and the GitHub Actions test workflow which runs `npm ci`). The `README.md` likely drifted from the actual toolchain over time or inherited an old template.
 **Action:** The `README.md` was updated to accurately reflect `npm` commands to prevent setup failures and confusion.
+
 ## 2025-02-12 - Phantom UI Test Command
+
 **Learning:** `package.json` included a phantom command `"test:ui": "vitest --ui"` which fails out-of-the-box because `@vitest/ui` is deliberately excluded from `devDependencies`. Adding dependencies to fix phantom commands violates strict boundaries on modifying project architecture/configs unnecessarily.
 **Action:** When finding phantom scripts in `package.json`, carefully remove the script to align with the actual project state rather than artificially installing dependencies to "make the documentation work".
+
 ## 2025-05-10 - Canonical Domain URL Drift
+
 **Learning:** The documentation and agent guidelines referenced the root domain `https://gain.observer` as the hosted URL, but the site's metadata (`index.html` canonical/og links) strictly enforces the `www` subdomain (`https://www.gain.observer/`). Inconsistent domain documentation can cause SEO confusion and duplicate indexing.
 **Action:** Ensure all documentation links pointing to the production application match the exact `rel="canonical"` URL defined in the application's main HTML entry point.
+
 ## 2024-05-17 - README Scope Drift
+
 **Learning:** The `README.md` file listed only "horizontal dipoles" under its current scope, while the application actually supports multiple other topologies (e.g., inverted-v, sloping-v, delta-loop), leading to an inaccurate representation of the tool's capabilities.
 **Action:** Regularly audit the capabilities listed in the README against the actual codebase features to prevent scope drift and ensure the documented features accurately reflect the product's true capabilities.
+
+## 2025-05-18 - Feedline Support Drift
+
+**Learning:** `docs/antenna-spec.md` originally stated that both Inverted-V and Delta Loop topologies supported feedlines. However, reviewing the actual code in `src/store/antennaStore.ts` showed that `selectSimulationInput` correctly restricts feedline generation only to horizontal dipoles.
+**Action:** The documentation was updated to reflect reality: feedlines are only supported for the dipole antenna type, while other types like inverted-v and delta-loop use direct feeds.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,29 +1,45 @@
 ## 2024-05-18 - Expensive 3D computations in tight loops
+
 **Learning:** In Three.js geometry generation, recalculating vertex angles (spherical coordinates from Cartesian) for `thetaDeg` and `phiDeg` on every frame or state change can be significantly expensive and redundant, especially when LOD details stay the same. Caching these arrays separately from visual attributes drastically improves performance.
 **Action:** When mapping scalar data to 3D meshes (like antenna radiation patterns), cache structural calculations (like vertex spherical angles) separately from dynamic visual state (like colors or scale) using separate `useMemo` hooks.
+
 ## 2025-02-18 - Pre-allocate Arrays in Polar Plot Generation
+
 **Performance Issue:** Dynamic array resizing via `out.push(...)` in `cutAzimuth` and `cutElevation` inside `src/components/Charts/PolarPlots.tsx` caused significant memory overhead and slowdowns when called frequently during polar chart rendering.
 **Optimization:** Replaced `[]` and `push` with `new Array(size)` and populated elements using a standard `for` loop and index assignments. This eliminates reallocation and pushes array creation performance from ~361ms down to ~138ms in synthetic benchmarking.
 **Action:** Always pre-allocate arrays when the exact final size is known upfront, especially in chart generation or rendering loops.
 
 ## 2024-05-18 - Optimized Zenith Gain Fetch
+
 **Learning:** In spherical coordinates used by the NEC-2 engine (theta=0 at zenith), the direction vector is straight up regardless of the azimuth (phi) step.
 **Action:** Replace $O(N)$ averaging loops over `phi` at zenith with a direct $O(1)$ sample from `data[0]` to fetch the gain faster, avoiding redundant memory reads in the JS engine.
+
 ## 2025-02-18 - [Batching WebAssembly Engine Execution]
+
 **Learning:** Instantiating the Emscripten WASM module and interacting with its virtual filesystem repeatedly inside a `for` loop (as seen in sequential sweeps) is a major performance bottleneck due to the engine's internal concurrency lock and initialization overhead.
 **Action:** Always batch related simulations at the lowest possible layer. For the NEC-2 engine, this means generating a single input deck using the `FR` card's linear sweep capability (`FR 0 nfreq ...`) and parsing the multiple concatenated outputs in a single execution context.
+
 ## 2025-03-02 - Hot Loop Math and Inlining Optimization in 3D Rendering
+
 **Learning:** In hot loops such as 3D geometry and color computation (like `RadiationPattern.tsx`), function calls and certain math functions incur high overhead when invoked millions of times per frame. `Math.pow(10, x)` is measurably slower than calculating the precomputed natural exponential `Math.exp(x * (Math.LN10 / 20))`. Additionally, inlining simple linear interpolation or condition checks inside hot loops avoids function stack overhead, yielding up to a 20-25% performance improvement in heavy 3D visualizations.
 **Action:** Always precompute invariant scaling factors outside of hot loops and prefer `Math.exp()` with an `LN10` scale over `Math.pow(10, ...)` for power calculations. Inline simple value clamping and mapping logic rather than calling utility functions during inner rendering loops.
+
 ## 2025-05-05 - Avoid Math.hypot in bounded rendering loops
+
 **Learning:** `Math.hypot` is significantly slower than doing a manual sum of squares and `Math.sqrt`, especially in V8 and other modern JS engines. The overhead of handling an arbitrary number of arguments and ensuring protection against overflow/underflow makes `Math.hypot` roughly 10-12x slower than standard `Math.sqrt(x*x + y*y + z*z)` when iterating over thousands of vertices.
 **Action:** Always prefer `Math.sqrt` with manual squaring for simple 2D or 3D distance calculations in tight rendering or geometry loops where numbers are bounded (e.g. unit sphere coordinates). Avoid this optimization for unbounded numeric domains like complex magnitude or impedance calculations, where `Math.hypot`'s overflow/underflow protections are necessary.
+
 ## 2025-05-18 - Precompute Elevation-Dependent Math Outside Hot Loops
-**Learning:** In the propagation physics engine (`predictPropagation`), estimating MUF and calculating hop range involves expensive operations like `Math.asin`, `Math.cos`, and custom scaling. Calculating this for every combination of azimuth (`phi`) and elevation (`theta`) (i.e. $O(P \times T)$) is highly redundant because these geometric constraints depend *only* on the elevation angle.
+
+**Learning:** In the propagation physics engine (`predictPropagation`), estimating MUF and calculating hop range involves expensive operations like `Math.asin`, `Math.cos`, and custom scaling. Calculating this for every combination of azimuth (`phi`) and elevation (`theta`) (i.e. $O(P \times T)$) is highly redundant because these geometric constraints depend _only_ on the elevation angle.
 **Action:** Precompute these elevation-dependent metrics (MUF, range, path status) into a 1D array (`baseRays[theta]`) first. Inside the $O(P \times T)$ loop, simply combine the precomputed ray with the direction-specific gain. This optimization changes expensive math from $O(P \times T)$ to $O(T)$ plus simple assignments, significantly improving rendering and sweep speed.
+
 ## 2025-05-18 - Maintainability in Inner Loops
+
 **Learning:** Reconstructing complex state strings (like `LinkQuality`) from integer rank metrics (like `0`/`1`/`2`) inside an inner loop using ternary operators is brittle and presents a maintainability hazard. If rank values or the states they represent ever evolve, the hardcoded ternary mappings become bugs.
 **Action:** Instead of dynamically reconstructing states from arbitrary integer ranks, simply maintain explicit variables representing the best actual states found along with the rank used for comparison (e.g. `let bestLinkQuality: LinkQuality = 'unusable'`). This completely eliminates brittle conversions and avoids logic duplication later when producing output.
+
 ## 2024-05-17 - Optimize multiple Zustand selectors with useShallow
+
 **Learning:** Selecting multiple separate fields from a Zustand store using separate `useStore(s => s.field)` calls incurs significant React hook overhead in highly-re-rendering components.
 **Action:** When a component needs to select many fields from the store (e.g. 18 separate values), group them into a single object returned from a single hook call wrapped in `useShallow` from `zustand/react/shallow`. This cuts down overhead and batches state checks efficiently.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,44 +1,59 @@
 ## 2024-05-03 - Missing Button Group Roles and Form Associations in Sidebar Panels
+
 **Learning:** Found a recurring pattern in the sidebar panels where `div`s with `className="button-group"` lacked the explicit `role="group"` and `aria-label`/`aria-labelledby` attributes, meaning screen readers wouldn't announce the options as part of a coherent group. Additionally, several inputs and dropdowns lacked proper implicit or explicit labels (`aria-label`, `htmlFor`).
 **Action:** Always ensure that visually grouped toggle buttons have a `role="group"` and `aria-pressed` states. Ensure standalone inputs without text labels have `aria-label`s, and ensure label tags properly associate with their inputs via `htmlFor` and `id`.
 
 ## 2024-05-03 - Always Append to Journals
+
 **Learning:** Found that when writing to journal files like `.jules/palette.md` using shell commands (e.g., `cat << 'EOF' > ...`), it is crucial to use the append operator (`>>`) instead of the overwrite operator (`>`). Overwriting destroys historical context and previous critical learnings.
 **Action:** Always verify the existence of a journal file and explicitly use the append redirection operator (`>>`) when adding new entries to preserve history.
 
 ## 2024-05-04 - Keyboard Navigation Focus Indicators
+
 **Learning:** Found that keyboard navigation was lacking explicit visual feedback (`:focus-visible`) across the UI, particularly for interactive elements like buttons, inputs, and selects. Adding global `:focus-visible` styles with a high-contrast accent color greatly improves keyboard accessibility without negatively impacting mouse users.
 **Action:** Always verify keyboard accessibility and add clear `:focus-visible` styles to interactive elements when building out new UIs or auditing existing ones.
 
 ## 2024-05-05 - Propagation Control ARIA Additions
+
 **Learning:** In complex control panels, async UI state (like geolocation requesting) requires explicit `aria-live` and `aria-busy` announcements so screen readers know a background action is pending and eventually completed. Furthermore, supplementary help text near inputs must be explicitly linked via `aria-describedby` so it isn't skipped when users tab directly to the input field.
 **Action:** Always verify `aria-busy` and `aria-live` are present for async button interactions, and link form hints to their associated inputs using matching `id` and `aria-describedby` attributes.
+
 ## 2024-05-06 - Dynamic Form Hints and ARIA describedby
+
 **Learning:** Adding dynamic, contextual helper text below form controls (like `<select>` dropdowns or `<input>` ranges) is a common pattern in the side panels. However, without an explicit `aria-describedby` mapping, screen reader users miss this critical context when they navigate directly to the input via keyboard tabbing.
 **Action:** Always wrap supplementary helper text in a `div` or `span` with a unique `id`, and link it to the associated interactive control using the `aria-describedby` attribute. This ensures screen readers announce the helper text alongside the input label.
+
 ## 2024-05-08 - Dynamic Tooltips for Disabled States
+
 **Learning:** In dense control panels (like this app), disabling utility buttons without explanation causes user friction. Users often cannot tell why an action (like "Capture Reference" or "Centre Feedline") is unavailable. Providing dynamic tooltips on disabled buttons significantly improves discoverability and clarifies system state.
 **Action:** Always add dynamic `title` or `aria-label` properties that change when a button is `disabled`, clearly explaining the constraint.
 
 ## 2024-05-18 - Missing Button Group Roles
+
 **Learning:** The `ComparisonControl.tsx` had a `.button-group` component lacking the `role="group"` and `aria-label` attribute, which prevented screen readers from correctly announcing the options as part of a coherent group.
 **Action:** Always ensure `.button-group` elements have the required ARIA grouping attributes.
 
 ## 2024-05-24 - Resolving WCAG 2.5.3 Label in Name Violations
+
 **Learning:** Using an `aria-label` that completely overrides the visible text of a button (like `aria-label="Meters"` for a button showing "m") violates WCAG 2.5.3 (Label in Name). Speech recognition users might say "Click m" which won't work if the accessible name doesn't contain "m".
 **Action:** Always ensure the visible text is included within the `aria-label` (e.g., `aria-label="m (Meters)"`), and use the `title` attribute to provide the expanded tooltip for mouse users.
 
 ## 2024-05-25 - ARIA Roles for Loading and Error Overlays
+
 **Learning:** Global application states like "Loading WebAssembly" or solver errors use custom overlay divs (`.loading-overlay`, `.error-banner`). Without explicit ARIA roles and live regions, screen readers are unaware when the application transitions between these states. This leads to a confusing experience where the UI appears frozen to assistive technologies.
 **Action:** Always add `role="status"` and `aria-live="polite"` to loading overlays, and add `role="alert"` and `aria-live="assertive"` to error banners. Additionally, mark purely decorative animation elements like spinners with `aria-hidden="true"`.
+
 ## 2026-05-13 - Loading Spinner Alignment
+
 **Learning:** Adding a spinner to a button with text requires adjusting the display properties to `flex` and aligning items to the center, along with a gap, to prevent the spinner from sitting awkwardly above or below the text.
 **Action:** When adding inline spinners to buttons, ensure the button has `display: 'flex', alignItems: 'center', gap: '6px'` to maintain visual balance and layout.
 
 ## 2024-05-26 - Exposing Keyboard Shortcuts
+
 **Learning:** Hidden keyboard shortcuts are great for power users, but they lack discoverability. Additionally, screen readers are not aware of custom JavaScript-based keybindings unless explicitly told.
 **Action:** When adding global keyboard shortcuts (like `T` for theme toggle, `U` for unit toggle, or `M`/`N`/`C` for mode switching), always append the shortcut to the visual `title` tooltip (e.g. `(T)`) and add the `aria-keyshortcuts` attribute to the corresponding interactive element.
 
 ## 2024-05-27 - Inline Constraint Warnings (Geometry Status)
+
 **Learning:** Found that when a user's requested numeric input (e.g., Sloping V angle) is silently clamped by the system to satisfy physical constraints (e.g., minimum tip height), visual warnings alone are insufficient for accessibility. Without proper ARIA announcements, screen reader users miss the fact that their requested input was overridden by the system, leading to confusion about the actual state of the simulation.
 **Action:** When creating inline warning components that display dynamic constraint violations or system overrides (like `GeometryStatus`), always wrap the notification in a container with `role="status"` and `aria-live="polite"` so screen readers are audibly notified of the clamp.

--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -1,6 +1,9 @@
 ## 2025-05-11 - [Inline Styles for SEO Semantics Overriding CSS]
+
 **Learning:** When upgrading a generic `<div>` to a semantic `<h2>` tag, attempting to fully clear browser default styles using inline styles (e.g. `style={{ fontSize: 'inherit' }}`) can inadvertently create a CSS specificity issue where the inline style aggressively overrides the component's actual target CSS class rules.
 **Action:** Only use inline styles to reset properties you know aren't governed by a local CSS class (e.g. `margin: 0`), and leave properties like `fontSize` alone so the `.class` rules can apply normally.
+
 ## 2025-05-13 - [Semantic HTML Structure]
+
 **Learning:** Upgrading generic `<div>` wrappers to `<section>` tags provides excellent semantic document outlining without requiring changes to CSS styles (assuming classes are applied correctly on the new tags), making it a highly effective and safe SEO boost.
 **Action:** Always verify with `git diff` that the correct opening and closing tags were updated and no CSS classes were lost during the replacement.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,20 +1,29 @@
 ## 2025-02-20 - [Security Headers via Cloudflare Pages _headers File]
+
 **Vulnerability:** Missing fundamental HTTP security headers (e.g., HSTS, X-Frame-Options, X-Content-Type-Options) in the production deployment.
 **Learning:** For Cloudflare Pages deployments built with Vite, security headers must be defined in `public/_headers` so they are copied to `dist/_headers` and served by Cloudflare.
 **Prevention:** Ensure any new security headers are appended to the `public/_headers` file.
+
 ## 2025-02-21 - [NPM Audit Vulnerabilities Resolution]
+
 **Vulnerability:** Found 3 high-severity vulnerabilities in a transitive development dependency (`serialize-javascript` via `vite-plugin-pwa`).
 **Learning:** `npm audit fix` successfully resolves transitively vulnerable packages without requiring overrides, by correctly bumping the lockfile entries for the dependents (`@rollup/plugin-terser` -> `workbox-build`). This emphasizes that build-time dependencies should also be kept secure to maintain a healthy project state.
 **Prevention:** Regularly run `npm audit` and use `npm audit fix` to maintain lockfile security, confirming success via tests before submission.
+
 ## 2026-05-06 - Enhance Permissions-Policy and add Cross-Origin-Opener-Policy
-**Vulnerability:** Weak default Permissions-Policy and missing Cross-Origin-Opener-Policy in public/_headers
+
+**Vulnerability:** Weak default Permissions-Policy and missing Cross-Origin-Opener-Policy in public/\_headers
 **Learning:** Adding a more comprehensive Permissions-Policy restricting sensitive APIs (camera, microphone, payment) and ensuring geolocation is restricted to (self), as well as adding Cross-Origin-Opener-Policy, creates strong defense-in-depth against unauthorized API access and side-channel attacks for WASM apps.
 **Prevention:** Always verify if new device APIs need explicit opt-out in Permissions-Policy, especially for applications dealing with WASM execution, and ensure strong process isolation.
+
 ## 2026-05-07 - Add Input Validation to LocalStorage Writes
+
 **Vulnerability:** Unvalidated state was being written to `localStorage` via `window.localStorage.setItem` using the Zustand store state. If an attacker managed to poison the store state, they could write excessively large payloads or malicious strings into `localStorage`.
 **Learning:** React hooks orchestrating persistence (`useTheme.ts`, `useUnits.ts`) validated data read from `localStorage`, but trusted internal state blindly when writing. This breaks the defense-in-depth security principle that all input boundaries, including internal ones persisting state, should be validated.
 **Prevention:** Always validate all data being serialized to `localStorage` even if it originates from an internal store. Enforce exact type or allowed-value checks before calling `setItem`.
+
 ## 2026-05-13 - Defensive Programming: Explicit Radix in `parseInt`
+
 **Vulnerability:** Unspecified radix in `parseInt` calls processing UI string inputs can lead to unexpected numeric evaluation (e.g. interpreting leading zeros as octal in legacy or non-strict environments).
 **Learning:** Relying on implicit base-10 parsing is a classic defensive programming weakness. Specifying radix 10 explicitly guarantees correct parsing behavior and satisfies SAST tools and strict linters, reinforcing input handling correctness.
 **Prevention:** Always provide the radix argument explicitly when using `parseInt`, e.g., `parseInt(value, 10)`.

--- a/.jules/spec.md
+++ b/.jules/spec.md
@@ -1,10 +1,14 @@
 ## 2024-05-10 - Bumping coverage threshold
+
 **Learning:** Adding new test files can alter the total codebase line count, which may cause a slight reduction in overall `lines` percentage (e.g., from 59% to 58%) even when `branches` or `functions` coverage increases.
 **Action:** Always verify final thresholds using `npm run test -- --coverage` and manually update vitest configuration thresholds (e.g. `lines` coverage from `69` to `70`) rather than chasing individual coverage numbers blindly.
 
 ## 2024-05-15 - Bumping coverage threshold for PolarPlots
+
 **Learning:** React Component Unit Tests for complex charts. When testing ChartJS components that use callbacks in deep properties (like `options.scales.r.ticks.callback`), simulating those specific nested functions in the mocked component allows testing internal branch logic safely without rendering real canvases.
 **Action:** Mock `react-chartjs-2` specifically testing the callbacks if necessary, rather than trying to load the full canvas.
+
 ## 2026-05-18 - Explicit typing in mocked selectors
+
 **Learning:** The project's ESLint configuration strictly enforces `@typescript-eslint/no-explicit-any`. When writing tests or mocking functions (such as Zustand selectors), use `unknown` or precise typing instead of `any` to prevent linting failures.
 **Action:** Use `unknown` instead of `any` when mocking Zustand selectors in unit tests.

--- a/.jules/sweep.md
+++ b/.jules/sweep.md
@@ -1,3 +1,4 @@
 ## 2024-05-13 - Knip Unused Export Removal
-**Learning:** `knip` correctly identifies types that are unused outside of the file they are defined in, but removing the `export` keyword can break TypeScript builds if the types are referenced internally by other *exported* interfaces in the same file. I need to be careful when removing `export` from types and verify that they aren't part of an exported interface's signature.
+
+**Learning:** `knip` correctly identifies types that are unused outside of the file they are defined in, but removing the `export` keyword can break TypeScript builds if the types are referenced internally by other _exported_ interfaces in the same file. I need to be careful when removing `export` from types and verify that they aren't part of an exported interface's signature.
 **Action:** Always check internal usages of a type within the file, especially if it's used in the signature of other exported entities, before deciding to drop the `export` keyword. Run `npm run build` to guarantee safety.

--- a/docs/antenna-model-spec.md
+++ b/docs/antenna-model-spec.md
@@ -5,18 +5,22 @@ This document defines the stable reference for antenna geometry, coordinate syst
 ## 1. Coordinate Conventions
 
 ### 1.1 NEC Coordinate Axes
+
 We use the standard NEC-2 Cartesian coordinate system:
+
 - **Z-Axis**: Vertical axis. Positive Z is "up" (toward the zenith).
 - **XY-Plane**: The horizontal ground plane.
 - **Origin (0,0,0)**: Located at ground level directly under the antenna's geometric center (for symmetric antennas) or the primary feedpoint.
 
 ### 1.2 Ground Plane Convention
+
 - **Free Space**: No ground plane. Calculations are performed in an infinite vacuum.
 - **Perfect Ground**: An infinite, perfectly conducting plane at $Z = 0$.
 - **Real Ground**: An infinite lossy dielectric plane at $Z = 0$, characterized by conductivity ($\sigma$ in S/m) and relative permittivity ($\epsilon_r$).
 - **Grounded Wires**: Wires must not end exactly at $Z = 0$ unless they are part of a deliberate grounded structure (e.g., a monopole or a terminated leg). NEC-2 requires special care for wires touching ground.
 
 ### 1.3 Orientation and Angles
+
 - **Compass Heading**: $0^\circ$ is North ($+Y$ axis), $90^\circ$ is East ($+X$ axis).
 - **Internal Mapping**: To convert a compass heading $\alpha$ to a standard unit circle angle $\theta$ (where $0^\circ$ is $+X$): $\theta = 90^\circ - \alpha$.
 - **Elevation**: $0^\circ$ is the horizon (XY plane), $90^\circ$ is the zenith ($+Z$ axis).
@@ -26,6 +30,7 @@ We use the standard NEC-2 Cartesian coordinate system:
 ## 2. Antenna Type Definitions
 
 ### 2.1 Dipole
+
 - **Structure**: A single straight horizontal wire or two collinear wires.
 - **Length**: The total end-to-end physical length.
 - **Height**: The Z-coordinate of the wire(s).
@@ -33,6 +38,7 @@ We use the standard NEC-2 Cartesian coordinate system:
 - **Balanced**: Yes.
 
 ### 2.2 Inverted V
+
 - **Structure**: Two wires sloping down from a common central apex.
 - **Apex Height**: The height parameter refers to the apex (highest point).
 - **Length**: The total wire length (sum of both legs).
@@ -41,6 +47,7 @@ We use the standard NEC-2 Cartesian coordinate system:
 - **Balanced**: Yes.
 
 ### 2.3 Sloping V (Terminated or Unterminated)
+
 - **Structure**: Two wires forming a V-shape, typically sloping from a high feedpoint toward the ground or lower supports.
 - **Length**: Refers to the length of a **single leg**.
 - **Height**: Refers to the height of the feedpoint (apex).
@@ -49,6 +56,7 @@ We use the standard NEC-2 Cartesian coordinate system:
 - **Termination Support**: Supports termination at the far ends of the legs.
 
 ### 2.4 Delta Loop
+
 - **Structure**: A triangular loop of wire.
 - **Length**: The total perimeter of the loop.
 - **Configuration**: Apex-up or Apex-down.
@@ -61,14 +69,17 @@ We use the standard NEC-2 Cartesian coordinate system:
 ## 3. "Terminated" Antennas
 
 ### 3.1 Physical Meaning
+
 A **terminated** antenna is a travelling-wave antenna where the end of the radiating element is connected to a non-inductive resistive load (terminator). This load absorbs the remaining energy of the forward wave, preventing reflections that would otherwise create a standing wave.
 
 ### 3.2 Termination Implementation
+
 - **Sloping V**: Termination consists of a resistor connected from the end of each leg to ground via a short stub wire.
 - **Default Value**: Typically $300\text{--}600\,\Omega$ depending on the characteristic impedance of the wire over ground.
 - **Effect**: It converts the antenna from a resonant (standing-wave) bi-directional radiator into a broadband, uni-directional travelling-wave radiator.
 
 ### 3.3 Termination vs. Matching
+
 - **Crucial Distinction**: A "correctly terminated" antenna **does not** imply a $50\,\Omega$ feedpoint SWR.
 - The termination resistor is chosen to match the **antenna wire's characteristic impedance** to ground to prevent reflections on the wire itself.
 - The resulting feedpoint impedance may still be high (e.g., $400\text{--}800\,\Omega$) and will likely require a transformer (Balun/Unun) to match to $50\,\Omega$ coax.
@@ -78,14 +89,17 @@ A **terminated** antenna is a travelling-wave antenna where the end of the radia
 ## 4. SWR and Impedance Definitions
 
 ### 4.1 Raw Feedpoint Impedance
+
 The complex impedance $Z = R + jX$ calculated by NEC at the excitation segment.
 
 ### 4.2 Raw SWR (vs 50 Ω)
+
 SWR calculated directly from the raw feedpoint impedance relative to a $50\,\Omega$ system:
 $$\Gamma = \frac{Z - 50}{Z + 50}$$
 $$\text{SWR} = \frac{1 + |\Gamma|}{1 - |\Gamma|}$$
 
 ### 4.3 Reflection Distinction
+
 - **Wire Reflection**: Reflection at the end of the antenna wire (controlled by termination).
 - **Source SWR**: Mismatch between the transmission line (or generator) and the antenna feedpoint.
 - **Note**: A travelling-wave antenna (terminated) can have an excellent (low) wire reflection but a high source SWR if not transformed.

--- a/docs/antenna-spec.md
+++ b/docs/antenna-spec.md
@@ -7,6 +7,7 @@ This document defines the physical and mathematical model for all antenna types 
 ## 1. Center-Fed Dipole
 
 ### 1.1 Geometry Definition
+
 - **Apex Location:** Geometric center of the wire at $(0, 0, \text{height})$.
 - **Leg Count & Length:** 1 wire, total length $L$.
 - **Reference Length:** $0.475\lambda$ (Resonance).
@@ -15,24 +16,29 @@ This document defines the physical and mathematical model for all antenna types 
 - **Min Height:** All points must satisfy $z \ge 0.1$ m to avoid NEC-2 `GE 1` instability.
 
 ### 1.2 Feedpoint Definition
+
 - **NEC Excitation:** Single-segment voltage source (`EX`) on Tag 1.
 - **Segment:** Center segment of the wire.
 - **Feed Type:** Single-segment voltage source.
 - **Feedline Support:** Supported (Radiating shield + NEC `TL` card).
 
 ### 1.3 Termination Definition
+
 - **Model:** None. Dipoles are resonant, non-terminated antennas.
 
 ### 1.4 SWR Convention
+
 - **Reference:** 50.0 Ω.
 - **Metric:** Raw feedpoint SWR (Mismatch to 50 Ω).
 
 ### 1.5 Segmentation Rules
+
 - **Density:** 20 segments per $\lambda$ minimum.
 - **Minimum:** 9 segments total.
 - **Alignment:** Must use an **odd** number of segments to ensure a precise center feedpoint.
 
 ### 1.6 Glossary
+
 - **Directivity ($D$):** $D = \frac{4\pi U_{max}}{P_{rad}}$.
 - **Gain ($G$):** $10 \log_{10}(\eta \cdot D)$ dBi.
 - **Realized Gain:** $G(dBi) + 10 \log_{10}(1 - |\Gamma|^2)$.
@@ -45,6 +51,7 @@ This document defines the physical and mathematical model for all antenna types 
 ## 2. Inverted-V
 
 ### 2.1 Geometry Definition
+
 - **Apex Location:** Highest point at $(0, 0, \text{height})$.
 - **Leg Count & Length:** 2 legs, total radiating length $L$ (sum of both legs).
 - **Reference Length:** $0.485\lambda$ (Resonance).
@@ -53,24 +60,29 @@ This document defines the physical and mathematical model for all antenna types 
 - **Min Height:** Tip height must be $\ge 0.1$ m.
 
 ### 2.2 Feedpoint Definition
+
 - **NEC Excitation:** 1-segment "source bridge" (Tag 3) at apex.
 - **Segment:** Segment 1 of Tag 3.
 - **Feed Type:** Balanced bridge segment.
-- **Feedline Support:** Supported.
+- **Feedline Support:** Not supported (Direct feed only).
 
 ### 2.3 Termination Definition
+
 - **Model:** None.
 
 ### 2.4 SWR Convention
+
 - **Reference:** 50.0 Ω.
 - **Metric:** Raw feedpoint SWR.
 
 ### 2.5 Segmentation Rules
+
 - **Density:** 20 segments per $\lambda$ minimum.
 - **Minimum:** 9 segments per radiating leg.
 - **Alignment:** Legs should have equal segments. Bridge is exactly 1 segment.
 
 ### 2.6 Glossary
+
 - Same as Section 1.6.
 
 ---
@@ -78,6 +90,7 @@ This document defines the physical and mathematical model for all antenna types 
 ## 3. Sloping V (Terminated)
 
 ### 3.1 Geometry Definition
+
 - **Apex Location:** Highest point at $(0, 0, \text{height})$.
 - **Leg Count & Length:** 2 legs, length $L$ **per leg** (Total radiating wire $2L$).
 - **Reference Length:** $2.0\lambda$ per leg (Traveling wave directivity).
@@ -86,12 +99,14 @@ This document defines the physical and mathematical model for all antenna types 
 - **Min Height:** Tip height must be $\ge 0.1$ m.
 
 ### 3.2 Feedpoint Definition
+
 - **NEC Excitation:** 1-segment source bridge at apex.
 - **Segment:** Segment 1 of bridge.
 - **Feed Type:** Balanced bridge segment.
 - **Feedline Support:** Not supported (Direct feed only).
 
 ### 3.3 Termination Definition
+
 - **Topology:** Differential resistor between the two leg tips.
 - **Diagram:**
   ```
@@ -106,14 +121,17 @@ This document defines the physical and mathematical model for all antenna types 
 - **Return Path:** No return to ground. Explicitly rejects vertical drop wires or independent ground terminations.
 
 ### 3.4 SWR Convention
+
 - **Reference:** 50.0 Ω.
 - **Statement:** Traveling wave antennas often have high raw SWR (e.g., 600 Ω feed). Raw SWR graph reflects this mismatch, not termination quality.
 
 ### 3.5 Segmentation Rules
+
 - **Density:** 20 segments per $\lambda$ minimum.
 - **Minimum:** 9 segments per radiating leg.
 
 ### 3.6 Glossary
+
 - Same as Section 1.6.
 
 ---
@@ -121,6 +139,7 @@ This document defines the physical and mathematical model for all antenna types 
 ## 4. Delta Loop
 
 ### 4.1 Geometry Definition
+
 - **Apex Location:** Highest point at $(0, 0, \text{height})$.
 - **Leg Count & Length:** 3 wires forming a triangle, total perimeter $L$.
 - **Reference Length:** $1.03\lambda$ (Resonance).
@@ -129,22 +148,27 @@ This document defines the physical and mathematical model for all antenna types 
 - **Min Height:** Bottom wire must be $\ge 0.1$ m above ground.
 
 ### 4.2 Feedpoint Definition
+
 - **NEC Excitation:** Center of the bottom horizontal wire (Tag 2).
 - **Segment:** Center segment of Tag 2.
 - **Feed Type:** Single-segment voltage source.
-- **Feedline Support:** Supported.
+- **Feedline Support:** Not supported (Direct feed only).
 
 ### 4.3 Termination Definition
+
 - **Model:** None.
 
 ### 4.4 SWR Convention
+
 - **Reference:** 50.0 Ω.
 - **Metric:** Raw feedpoint SWR.
 
 ### 4.5 Segmentation Rules
+
 - **Density:** 20 segments per $\lambda$.
 - **Minimum:** 9 segments per side.
 - **Alignment:** Bottom wire should have an **odd** number of segments for center feed.
 
 ### 4.6 Glossary
+
 - Same as Section 1.6.


### PR DESCRIPTION
- **Problem:** `docs/antenna-spec.md` falsely claimed that Inverted-V and Delta Loop topologies supported feedlines, causing ambiguity for users reading the specifications.
- **Fix:** Updated the Inverted-V and Delta Loop sections to accurately state that feedlines are "Not supported (Direct feed only)". Appended a critical learning entry to `.jules/archivist.md` detailing the documentation drift.
- **Verification:** Read `src/store/antennaStore.ts` and confirmed that the `computeFeedlineLayout` function explicitly restricts feedlines via `antennaType === 'dipole'`.
- **Scope:** This PR contains strictly markdown documentation updates and formatting changes.

---
*PR created automatically by Jules for task [10895709253999328987](https://jules.google.com/task/10895709253999328987) started by @2fst4u*