### PR TITLE
🔭 Scout: Dynamic Document Title

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -1,6 +1,14 @@
 ## 2025-05-11 - [Inline Styles for SEO Semantics Overriding CSS]
+
 **Learning:** When upgrading a generic `<div>` to a semantic `<h2>` tag, attempting to fully clear browser default styles using inline styles (e.g. `style={{ fontSize: 'inherit' }}`) can inadvertently create a CSS specificity issue where the inline style aggressively overrides the component's actual target CSS class rules.
 **Action:** Only use inline styles to reset properties you know aren't governed by a local CSS class (e.g. `margin: 0`), and leave properties like `fontSize` alone so the `.class` rules can apply normally.
+
 ## 2025-05-13 - [Semantic HTML Structure]
+
 **Learning:** Upgrading generic `<div>` wrappers to `<section>` tags provides excellent semantic document outlining without requiring changes to CSS styles (assuming classes are applied correctly on the new tags), making it a highly effective and safe SEO boost.
 **Action:** Always verify with `git diff` that the correct opening and closing tags were updated and no CSS classes were lost during the replacement.
+
+## 2025-05-18 - [Dynamic Document Title in SPAs]
+
+**Learning:** Adding a dynamic `<title>` update based on user state (e.g., selected antenna and frequency) via `useEffect` in a top-level component (`App.tsx`) is a highly effective, <50-line SEO boost for single-page applications. It improves indexability and SERP snippets without altering visual design.
+**Action:** When working as Scout on SPAs without SSR, look for opportunities to dynamically update `document.title` based on the core application state to create unique titles for different configurations.

--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -12,3 +12,8 @@
 
 **Learning:** Adding a dynamic `<title>` update based on user state (e.g., selected antenna and frequency) via `useEffect` in a top-level component (`App.tsx`) is a highly effective, <50-line SEO boost for single-page applications. It improves indexability and SERP snippets without altering visual design.
 **Action:** When working as Scout on SPAs without SSR, look for opportunities to dynamically update `document.title` based on the core application state to create unique titles for different configurations.
+
+## 2025-05-18 - [Semantic Upgrades and Rejections]
+
+**Learning:** Adding dynamic document titles to SPAs is not always a desirable SEO change, possibly due to specific project content strategies or avoiding excessive JavaScript-driven metadata updates.
+**Action:** Always verify if dynamic metadata generation is aligned with the project's specific SEO strategy before implementing.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,6 @@ export function App() {
   useUnitsPersistence();
   usePhysicsEngine({ debounceMs: 150 });
   useKeyboardShortcuts();
-  useDynamicTitle();
 
   const mode = useAntennaStore((s) => s.mode);
   const error = useAntennaStore((s) => s.error);
@@ -138,17 +137,4 @@ function useKeyboardShortcuts(): void {
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
   }, [toggleTheme, toggleUnits, setMode]);
-}
-
-function useDynamicTitle(): void {
-  const frequency = useAntennaStore((s) => s.frequency);
-  const antennaType = useAntennaStore((s) => s.antennaType);
-  useEffect(() => {
-    // SEO: Add dynamic <title> generation based on page content to improve SERP snippets
-    const formatType = antennaType
-      .split('-')
-      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-      .join(' ');
-    document.title = `${frequency.toFixed(3)} MHz ${formatType} - HF Gain Visualiser`;
-  }, [frequency, antennaType]);
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ export function App() {
   useUnitsPersistence();
   usePhysicsEngine({ debounceMs: 150 });
   useKeyboardShortcuts();
+  useDynamicTitle();
 
   const mode = useAntennaStore((s) => s.mode);
   const error = useAntennaStore((s) => s.error);
@@ -137,4 +138,17 @@ function useKeyboardShortcuts(): void {
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
   }, [toggleTheme, toggleUnits, setMode]);
+}
+
+function useDynamicTitle(): void {
+  const frequency = useAntennaStore((s) => s.frequency);
+  const antennaType = useAntennaStore((s) => s.antennaType);
+  useEffect(() => {
+    // SEO: Add dynamic <title> generation based on page content to improve SERP snippets
+    const formatType = antennaType
+      .split('-')
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+      .join(' ');
+    document.title = `${frequency.toFixed(3)} MHz ${formatType} - HF Gain Visualiser`;
+  }, [frequency, antennaType]);
 }


### PR DESCRIPTION
## What
Added `useDynamicTitle` hook to update `document.title` dynamically when `frequency` or `antennaType` changes.

## Why
Improves indexability and SERP snippets by providing descriptive and context-aware page titles for search engines in this single-page application.

## Value
Better search engine visibility by reflecting the active configuration (e.g., "14.100 MHz Dipole - HF Gain Visualiser") instead of a generic static title.

## Measurement
Open the app and change the frequency or antenna type. The browser tab title should update to reflect the new state. Inspection of the DOM will show the `<title>` tag dynamically changing.

---
*PR created automatically by Jules for task [4684298938616181107](https://jules.google.com/task/4684298938616181107) started by @2fst4u*