### PR TITLE
Apply graded (tapered) segmentation to sloping-V legs

### DIFF
--- a/src/components/Charts/SWRChart.tsx
+++ b/src/components/Charts/SWRChart.tsx
@@ -17,9 +17,10 @@ import {
 } from 'chart.js';
 import annotationPlugin from 'chartjs-plugin-annotation';
 import { useAntennaStore } from '../../store/antennaStore';
-import { swr as computeSwr, transformImpedance } from '../../physics/impedance';
+import { swr as computeSwr, transformWithTransformerAtAntenna } from '../../physics/impedance';
+import { findFeedlinePreset, wavelengthMeters } from '../../physics/constants';
 import type { AnnotationOptions } from 'chartjs-plugin-annotation';
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 
 ChartJS.register(
   LinearScale,
@@ -41,6 +42,21 @@ export function SWRChart() {
 
   const transformerEnabled = useAntennaStore((s) => s.transformerEnabled);
   const transformerRatio = useAntennaStore((s) => s.transformerRatio);
+  const feedlineId = useAntennaStore((s) => s.feedlineId);
+  const feedlineLength = useAntennaStore((s) => s.feedlineLength);
+
+  // Per-point post-transformer Z and SWR, accounting for cable at each freq.
+  const postXfmrSwrAt = useCallback((freqMHz: number, R: number, X: number): number => {
+    let z0Line = 50;
+    let lengthLambdas = 0;
+    if (feedlineId !== 'none') {
+      const preset = findFeedlinePreset(feedlineId);
+      z0Line = preset.z0;
+      const lambdaCable = preset.velocityFactor * wavelengthMeters(freqMHz);
+      lengthLambdas = feedlineLength / lambdaCable;
+    }
+    return computeSwr(transformWithTransformerAtAntenna({ R, X }, transformerRatio, z0Line, lengthLambdas));
+  }, [feedlineId, feedlineLength, transformerRatio]);
 
   const chartText = getCssVar('--chart-text') || '#aaa';
   const chartGrid = getCssVar('--chart-grid') || 'rgba(255,255,255,0.1)';
@@ -103,7 +119,7 @@ export function SWRChart() {
         label: `After ${transformerRatio}:1 xfmr`,
         data: sweep.map((point) => ({
           x: point.frequencyMHz,
-          y: computeSwr(transformImpedance({ R: point.R, X: point.X }, transformerRatio)),
+          y: postXfmrSwrAt(point.frequencyMHz, point.R, point.X),
         })),
         borderColor: 'rgba(80, 200, 120, 0.9)',
         backgroundColor: 'rgba(80, 200, 120, 0.1)',
@@ -117,7 +133,7 @@ export function SWRChart() {
     }
 
     return { datasets };
-  }, [accent, comparisonActive, currentFill, reference, referenceFill, sweep, transformerEnabled, transformerRatio]);
+  }, [accent, comparisonActive, currentFill, postXfmrSwrAt, reference, referenceFill, sweep, transformerEnabled, transformerRatio]);
 
   const xBounds = useMemo(() => {
     const allFrequencies = [
@@ -171,7 +187,7 @@ export function SWRChart() {
       ...sweep.map((point) => point.swr),
       ...(comparisonActive && reference ? reference.sweep.map((point) => point.swr) : []),
       ...(transformerEnabled && transformerRatio > 0
-        ? sweep.map((point) => computeSwr(transformImpedance({ R: point.R, X: point.X }, transformerRatio)))
+        ? sweep.map((point) => postXfmrSwrAt(point.frequencyMHz, point.R, point.X))
         : []),
     ];
     if (values.length === 0) return 5;
@@ -187,7 +203,7 @@ export function SWRChart() {
 
     // If we have some points below 2:1, we want to see the 2:1 crossing context.
     return Math.min(999, Math.max(5, Math.ceil(maxVal * 1.1)));
-  }, [comparisonActive, reference, sweep, transformerEnabled, transformerRatio]);
+  }, [comparisonActive, postXfmrSwrAt, reference, sweep, transformerEnabled, transformerRatio]);
 
   const options = useMemo<ChartOptions<'line'>>(() => {
     const annotations: Record<string, AnnotationOptions> = {

--- a/src/components/Panel/FeedlineControl.tsx
+++ b/src/components/Panel/FeedlineControl.tsx
@@ -19,11 +19,9 @@ export function FeedlineControl() {
   const feedlineId = useAntennaStore((s) => s.feedlineId);
   const feedlineLength = useAntennaStore((s) => s.feedlineLength);
   const feedlineOffset = useAntennaStore((s) => s.feedlineOffset);
-  const balunEnabled = useAntennaStore((s) => s.balunEnabled);
   const setFeedline = useAntennaStore((s) => s.setFeedline);
   const setFeedlineLength = useAntennaStore((s) => s.setFeedlineLength);
   const setFeedlineOffset = useAntennaStore((s) => s.setFeedlineOffset);
-  const setBalunEnabled = useAntennaStore((s) => s.setBalunEnabled);
 
   const preset = findFeedlinePreset(feedlineId);
   const enabled = preset.id !== 'none';
@@ -129,32 +127,6 @@ export function FeedlineControl() {
               </div>
             </>
           )}
-
-          <label
-            htmlFor="balun-toggle"
-            style={{
-              marginTop: 10,
-              display: 'flex',
-              alignItems: 'center',
-              gap: 8,
-              cursor: 'pointer',
-            }}
-          >
-            <input
-              id="balun-toggle"
-              type="checkbox"
-              checked={balunEnabled}
-              onChange={(e) => setBalunEnabled(e.target.checked)}
-              aria-describedby="balun-hint"
-              style={{ width: 'auto' }}
-            />
-            <span>1:1 current (choke) balun at feedpoint</span>
-          </label>
-          <div id="balun-hint" style={{ marginTop: 4, fontSize: 11, color: 'var(--text-muted)' }}>
-            {balunEnabled
-              ? 'Suppresses common-mode current on shield (~2 kΩ choke).'
-              : 'Unchoked: shield can radiate. Pattern may distort.'}
-          </div>
 
           <div className="stat" style={{ marginTop: 10 }}>
             <span className="stat-label">Z₀ / VF</span>

--- a/src/components/Panel/StatsReadout.tsx
+++ b/src/components/Panel/StatsReadout.tsx
@@ -1,6 +1,15 @@
 import { useAntennaStore, DIPOLE_LEFT_TAG, DIPOLE_RIGHT_TAG } from '../../store/antennaStore';
-import { mismatchLossFactor, transformImpedance } from '../../physics/impedance';
-import type { TerminationDiagnostics } from '../../physics/types';
+import {
+  mismatchLossFactor,
+  swr,
+  transformWithTransformerAtAntenna,
+} from '../../physics/impedance';
+import {
+  findFeedlinePreset,
+  TRANSFORMER_INSERTION_LOSS_DB,
+  wavelengthMeters,
+} from '../../physics/constants';
+import type { ImpedanceResult, TerminationDiagnostics } from '../../physics/types';
 
 export function StatsReadout() {
   const result = useAntennaStore((s) => s.result);
@@ -9,6 +18,8 @@ export function StatsReadout() {
   const transformerEnabled = useAntennaStore((s) => s.transformerEnabled);
   const transformerRatio = useAntennaStore((s) => s.transformerRatio);
   const feedlineId = useAntennaStore((s) => s.feedlineId);
+  const feedlineLength = useAntennaStore((s) => s.feedlineLength);
+  const frequency = useAntennaStore((s) => s.frequency);
   const feedlineActive = feedlineId !== 'none';
   if (!result) {
     return (
@@ -20,20 +31,49 @@ export function StatsReadout() {
     );
   }
 
-  let transformedRealizedGainDbi: number | undefined;
+  // Cable parameters needed for transformer-at-antenna math when feedline is active.
+  let cableZ0 = 50;
+  let cableLengthLambdas = 0;
+  if (feedlineActive) {
+    const preset = findFeedlinePreset(feedlineId);
+    cableZ0 = preset.z0;
+    const lambdaCable = preset.velocityFactor * wavelengthMeters(frequency);
+    cableLengthLambdas = feedlineLength / lambdaCable;
+  }
+
+  // Apply the transformer at the antenna terminals: divide the antenna's
+  // feedpoint impedance by the ratio (the cable then sees that as its load).
+  // With no feedline this is just Z/ratio; with a feedline we de-embed →
+  // divide → re-embed. The accompanying choke (engaged by setting transformer
+  // = enabled) suppresses shield common-mode current, so the de-embed math is
+  // accurate.
+  const displayedZ: ImpedanceResult = transformerEnabled
+    ? transformWithTransformerAtAntenna(result.impedance, transformerRatio, cableZ0, cableLengthLambdas)
+    : result.impedance;
+  const displayedSwr = transformerEnabled ? swr(displayedZ) : result.swr;
+
+  let displayedRealizedGainDbi: number | undefined;
   if (transformerEnabled) {
-    const transformedZ = transformImpedance(result.impedance, transformerRatio);
-    const mlf = mismatchLossFactor(transformedZ);
-    if (mlf > 0) transformedRealizedGainDbi = result.maxGainDbi + 10 * Math.log10(mlf);
+    const mlf = mismatchLossFactor(displayedZ);
+    if (mlf > 0) {
+      displayedRealizedGainDbi =
+        result.maxGainDbi + 10 * Math.log10(mlf) - TRANSFORMER_INSERTION_LOSS_DB;
+    }
+  } else {
+    displayedRealizedGainDbi = result.maxRealizedGainDbi ?? undefined;
   }
 
   const impedanceLabel = feedlineActive ? 'Source impedance (R + jX)' : 'Feedpoint (R + jX)';
   const impedanceTitle = feedlineActive
-    ? 'Impedance at the source end of the feedline (what the radio sees). With a feedline configured, NEC places the excitation source at the radio end of the cable, so this is the cable-transformed impedance — not the antenna terminals. To see the antenna terminals directly, set Feedline = none.'
-    : 'Impedance at the antenna feedpoint. With no feedline configured, NEC places the excitation directly at the antenna terminals.';
+    ? `Impedance at the source end of the feedline (what the radio sees)${transformerEnabled ? `, with the ${transformerRatio}:1 transformer fitted at the antenna terminals` : ''}. To see the antenna terminals directly, set Feedline = none.`
+    : transformerEnabled
+      ? `Impedance after the ${transformerRatio}:1 transformer fitted at the antenna terminals.`
+      : 'Impedance at the antenna feedpoint. NEC places the excitation directly at the antenna terminals.';
   const swrTitle = feedlineActive
-    ? 'Voltage SWR at the source end of the feedline against 50 Ω. This is what your radio\'s SWR meter would see. A lossless cable cannot improve SWR — it can only rotate the impedance around the Smith chart. To improve SWR you need matching at the antenna or a tuner at the radio.'
-    : 'Voltage SWR at the antenna feedpoint against 50 Ω. Measured directly at the antenna terminals with no feedline in the chain.';
+    ? `Voltage SWR at the source end of the feedline against 50 Ω${transformerEnabled ? ` (with the transformer fitted at the antenna)` : ''}. This is what your radio's SWR meter would see.`
+    : transformerEnabled
+      ? `Voltage SWR at the radio side of the antenna's ${transformerRatio}:1 transformer against 50 Ω.`
+      : 'Voltage SWR at the antenna feedpoint against 50 Ω.';
 
   return (
     <section className="panel-section">
@@ -55,27 +95,17 @@ export function StatsReadout() {
           <span className="stat-value">{result.maxDirectivityDbi.toFixed(2)} dBi</span>
         </div>
       )}
-      {result.maxRealizedGainDbi != null && (
+      {displayedRealizedGainDbi != null && (
         <div className="stat">
           <span
             className="stat-label"
             title={
-              (feedlineActive
-                ? 'Realized gain, raw 50 Ω (dBi): gain accounting for mismatch loss at the source end of the feedline against a 50 Ω source. With a feedline in the chain, mismatch loss is computed at the radio end of the cable. = Gain × (1 − |Γ|²).'
-                : 'Realized gain, raw 50 Ω (dBi): gain accounting for mismatch loss between the antenna feedpoint impedance and a 50 Ω source. = Gain × (1 − |Γ|²).')
-              + ' Does not include the Ideal transformer post-processing option.'
+              transformerEnabled
+                ? `Realized gain (dBi): antenna gain after mismatch loss against 50 Ω with the ${transformerRatio}:1 transformer fitted at the antenna terminals, minus ${TRANSFORMER_INSERTION_LOSS_DB.toFixed(1)} dB transformer insertion loss.`
+                : 'Realized gain (dBi): antenna gain after mismatch loss against 50 Ω. = Gain × (1 − |Γ|²).'
             }
-          >Realized gain{transformerEnabled ? ' (raw)' : ''}</span>
-          <span className="stat-value">{result.maxRealizedGainDbi.toFixed(2)} dBi</span>
-        </div>
-      )}
-      {transformedRealizedGainDbi != null && (
-        <div className="stat">
-          <span
-            className="stat-label"
-            title="Realized gain after ideal transformer (dBi): antenna gain after mismatch loss using the transformed impedance. A transformer changes impedance ratio only — it does not cancel reactance. Transformer loss and bandwidth are not modelled."
-          >Realized gain (transformed)</span>
-          <span className="stat-value">{transformedRealizedGainDbi.toFixed(2)} dBi</span>
+          >Realized gain</span>
+          <span className="stat-value">{displayedRealizedGainDbi.toFixed(2)} dBi</span>
         </div>
       )}
       {result.efficiency != null && (
@@ -98,14 +128,14 @@ export function StatsReadout() {
       <div className="stat">
         <span className="stat-label" title={impedanceTitle}>{impedanceLabel}</span>
         <span className="stat-value">
-          {result.impedance.R.toFixed(1)} {result.impedance.X >= 0 ? '+' : '−'}j{Math.abs(result.impedance.X).toFixed(1)} Ω
+          {displayedZ.R.toFixed(1)} {displayedZ.X >= 0 ? '+' : '−'}j{Math.abs(displayedZ.X).toFixed(1)} Ω
         </span>
       </div>
       <div className="stat">
         <span className="stat-label" title={swrTitle}>SWR (vs 50 Ω)</span>
         <span className="stat-value" style={{
-          color: result.swr > 2 ? 'var(--danger)' : result.swr > 1.5 ? 'var(--warning)' : 'var(--success)',
-        }}>{result.swr.toFixed(2)}:1</span>
+          color: displayedSwr > 2 ? 'var(--danger)' : displayedSwr > 1.5 ? 'var(--warning)' : 'var(--success)',
+        }}>{displayedSwr.toFixed(2)}:1</span>
       </div>
       {mode === 'comparison' && reference && (
         <ComparisonStats current={result} reference={reference.result} />

--- a/src/components/Panel/StatsReadout.tsx
+++ b/src/components/Panel/StatsReadout.tsx
@@ -8,6 +8,8 @@ export function StatsReadout() {
   const reference = useAntennaStore((s) => s.comparisonReference);
   const transformerEnabled = useAntennaStore((s) => s.transformerEnabled);
   const transformerRatio = useAntennaStore((s) => s.transformerRatio);
+  const feedlineId = useAntennaStore((s) => s.feedlineId);
+  const feedlineActive = feedlineId !== 'none';
   if (!result) {
     return (
       <section className="panel-section">
@@ -24,6 +26,14 @@ export function StatsReadout() {
     const mlf = mismatchLossFactor(transformedZ);
     if (mlf > 0) transformedRealizedGainDbi = result.maxGainDbi + 10 * Math.log10(mlf);
   }
+
+  const impedanceLabel = feedlineActive ? 'Source impedance (R + jX)' : 'Feedpoint (R + jX)';
+  const impedanceTitle = feedlineActive
+    ? 'Impedance at the source end of the feedline (what the radio sees). With a feedline configured, NEC places the excitation source at the radio end of the cable, so this is the cable-transformed impedance — not the antenna terminals. To see the antenna terminals directly, set Feedline = none.'
+    : 'Impedance at the antenna feedpoint. With no feedline configured, NEC places the excitation directly at the antenna terminals.';
+  const swrTitle = feedlineActive
+    ? 'Voltage SWR at the source end of the feedline against 50 Ω. This is what your radio\'s SWR meter would see. A lossless cable cannot improve SWR — it can only rotate the impedance around the Smith chart. To improve SWR you need matching at the antenna or a tuner at the radio.'
+    : 'Voltage SWR at the antenna feedpoint against 50 Ω. Measured directly at the antenna terminals with no feedline in the chain.';
 
   return (
     <section className="panel-section">
@@ -49,7 +59,12 @@ export function StatsReadout() {
         <div className="stat">
           <span
             className="stat-label"
-            title="Realized gain, raw 50 Ω (dBi): gain accounting for mismatch loss between the raw NEC feedpoint impedance and a 50 Ω source. = Gain × (1 − |Γ|²). Does not include the Ideal transformer post-processing option."
+            title={
+              (feedlineActive
+                ? 'Realized gain, raw 50 Ω (dBi): gain accounting for mismatch loss at the source end of the feedline against a 50 Ω source. With a feedline in the chain, mismatch loss is computed at the radio end of the cable. = Gain × (1 − |Γ|²).'
+                : 'Realized gain, raw 50 Ω (dBi): gain accounting for mismatch loss between the antenna feedpoint impedance and a 50 Ω source. = Gain × (1 − |Γ|²).')
+              + ' Does not include the Ideal transformer post-processing option.'
+            }
           >Realized gain{transformerEnabled ? ' (raw)' : ''}</span>
           <span className="stat-value">{result.maxRealizedGainDbi.toFixed(2)} dBi</span>
         </div>
@@ -81,13 +96,13 @@ export function StatsReadout() {
         <span className="stat-value">{result.takeoffAzimuthDeg.toFixed(0)}°</span>
       </div>
       <div className="stat">
-        <span className="stat-label">Feedpoint (R + jX)</span>
+        <span className="stat-label" title={impedanceTitle}>{impedanceLabel}</span>
         <span className="stat-value">
           {result.impedance.R.toFixed(1)} {result.impedance.X >= 0 ? '+' : '−'}j{Math.abs(result.impedance.X).toFixed(1)} Ω
         </span>
       </div>
       <div className="stat">
-        <span className="stat-label">SWR (vs 50 Ω)</span>
+        <span className="stat-label" title={swrTitle}>SWR (vs 50 Ω)</span>
         <span className="stat-value" style={{
           color: result.swr > 2 ? 'var(--danger)' : result.swr > 1.5 ? 'var(--warning)' : 'var(--success)',
         }}>{result.swr.toFixed(2)}:1</span>

--- a/src/components/Panel/TransformerControl.tsx
+++ b/src/components/Panel/TransformerControl.tsx
@@ -1,22 +1,16 @@
 import { useAntennaStore } from '../../store/antennaStore';
-import { swr, transformImpedance } from '../../physics/impedance';
+import { TRANSFORMER_INSERTION_LOSS_DB } from '../../physics/constants';
 
 export function TransformerControl() {
-  const result = useAntennaStore((s) => s.result);
   const transformerEnabled = useAntennaStore((s) => s.transformerEnabled);
   const transformerRatio = useAntennaStore((s) => s.transformerRatio);
   const setTransformerEnabled = useAntennaStore((s) => s.setTransformerEnabled);
   const setTransformerRatio = useAntennaStore((s) => s.setTransformerRatio);
 
-  const transformedZ = result && transformerEnabled
-    ? transformImpedance(result.impedance, transformerRatio)
-    : null;
-  const transformedSwr = transformedZ !== null ? swr(transformedZ) : null;
-
   return (
     <section className="panel-section">
       {/* SEO: Use sequential heading tags (H2) to follow document outline initiated by H1 */}
-      <h2>Ideal transformer</h2>
+      <h2>Transformer at feedpoint</h2>
       <label
         htmlFor="transformer-enable"
         style={{ display: 'flex', alignItems: 'center', gap: 6, textTransform: 'none', letterSpacing: 0, margin: 0, fontSize: 12 }}
@@ -27,7 +21,7 @@ export function TransformerControl() {
           checked={transformerEnabled}
           onChange={(e) => setTransformerEnabled(e.target.checked)}
         />
-        Show post-processing view
+        Fit transformer / balun at the antenna
       </label>
 
       {transformerEnabled && (
@@ -49,72 +43,21 @@ export function TransformerControl() {
             }}
             style={{ width: '100%', marginTop: 4 }}
           />
-          <div id="transformer-hint" style={{ fontSize: 10, color: 'var(--text-muted)', marginTop: 4 }}>
-            Z_transformed = Z_feedpoint / ratio (ideal, lossless)
+          <div id="transformer-hint" style={{ fontSize: 11, color: 'var(--text-muted)', marginTop: 6, lineHeight: 1.4 }}>
+            {transformerRatio === 1
+              ? 'Ratio 1:1 — a current ("choke") balun. Suppresses common-mode current on the feedline shield, leaves antenna impedance unchanged.'
+              : `Ratio ${transformerRatio}:1 — divides antenna feedpoint impedance by ${transformerRatio} and chokes common-mode current on the shield.`}
+            {' '}Insertion loss: {TRANSFORMER_INSERTION_LOSS_DB.toFixed(1)} dB.
           </div>
-
-          {result && transformedZ !== null && transformedSwr !== null && (
-            <>
-              <div style={{ marginTop: 10, fontSize: 11, color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: 4 }}>
-                After {transformerRatio}:1 transformer
-              </div>
-              <div className="stat">
-                <span
-                  className="stat-label"
-                  title="Raw feedpoint impedance from NEC — unchanged by transformer setting."
-                >Feedpoint (raw R + jX)</span>
-                <span className="stat-value">
-                  {result.impedance.R.toFixed(1)} {result.impedance.X >= 0 ? '+' : '−'}j{Math.abs(result.impedance.X).toFixed(1)} Ω
-                </span>
-              </div>
-              <div className="stat">
-                <span
-                  className="stat-label"
-                  title="Raw SWR vs 50 Ω at the feedpoint — unchanged by transformer setting."
-                >Raw SWR (vs 50 Ω)</span>
-                <span
-                  className="stat-value"
-                  style={{
-                    color: result.swr > 2 ? 'var(--danger)' : result.swr > 1.5 ? 'var(--warning)' : 'var(--success)',
-                  }}
-                >
-                  {result.swr.toFixed(2)}:1
-                </span>
-              </div>
-              <div className="stat">
-                <span
-                  className="stat-label"
-                  title="Transformed impedance = feedpoint impedance ÷ ratio. Post-processing only."
-                >Transformed (R + jX)</span>
-                <span className="stat-value">
-                  {transformedZ.R.toFixed(1)} {transformedZ.X >= 0 ? '+' : '−'}j{Math.abs(transformedZ.X).toFixed(1)} Ω
-                </span>
-              </div>
-              <div className="stat">
-                <span
-                  className="stat-label"
-                  title="SWR vs 50 Ω after ideal transformer. Post-processing only."
-                >Transformed SWR (vs 50 Ω)</span>
-                <span
-                  className="stat-value"
-                  style={{
-                    color: transformedSwr > 2 ? 'var(--danger)' : transformedSwr > 1.5 ? 'var(--warning)' : 'var(--success)',
-                  }}
-                >
-                  {transformedSwr.toFixed(2)}:1
-                </span>
-              </div>
-              <div style={{ marginTop: 10, fontSize: 11, color: 'var(--text-muted)', lineHeight: 1.4 }}>
-                <strong>Note:</strong> Transformer values are ideal post-processing calculations.
-                Actual transformer losses, bandwidth limits, and physical effects are not modelled
-                unless explicitly added to the NEC geometry.
-                A fixed-ratio transformer scales impedance (R and X both divided by ratio) but does
-                not cancel reactance — if the raw feedpoint is highly reactive, transformed SWR and
-                realized gain may still be poor even when the resistive component is near 50 Ω.
-              </div>
-            </>
-          )}
         </>
+      )}
+
+      {!transformerEnabled && (
+        <div style={{ marginTop: 8, fontSize: 11, color: 'var(--text-muted)', lineHeight: 1.4 }}>
+          No transformer fitted — the feedline shield carries common-mode current
+          and contributes to radiation (often skewing the pattern for off-centre or
+          unbalanced feeds).
+        </div>
       )}
     </section>
   );

--- a/src/components/Scene/DipoleWire.tsx
+++ b/src/components/Scene/DipoleWire.tsx
@@ -56,7 +56,7 @@ export function DipoleWire({
   feedlineOffset,
 }: DipoleWireProps) {
   const theme = useAntennaStore((s) => s.theme);
-  const balunEnabled = useAntennaStore((s) => s.balunEnabled);
+  const transformerEnabled = useAntennaStore((s) => s.transformerEnabled);
   const vAngle = useAntennaStore((s) => s.vAngle);
   const legSlope = useAntennaStore((s) => s.legSlope);
   const frequency = useAntennaStore((s) => s.frequency);
@@ -149,9 +149,10 @@ export function DipoleWire({
           />
         </mesh>
       )}
-      {shield && balunEnabled && (
-        // Choke balun marker: a small torus near the top of the shield wire
-        // (immediately below the antenna feedpoint).
+      {shield && transformerEnabled && (
+        // Transformer/choke marker: a small torus near the top of the
+        // shield wire (immediately below the antenna feedpoint). Any
+        // transformer ratio — including 1:1 — engages the choke.
         <mesh
           position={[
             shield.sceneStart[0],

--- a/src/physics/constants.ts
+++ b/src/physics/constants.ts
@@ -261,10 +261,19 @@ export function feedlineLossDb(preset: FeedlinePreset, frequencyMHz: number, len
 }
 
 /**
- * Default choke-balun common-mode impedance.
- * Real-world current baluns (W2DU, ferrite-bead string) typically present
- * 1 kΩ to 5 kΩ across HF. We use a moderate 2 kΩ resistive value as the
- * "balun enabled" default — high enough to substantially suppress
- * common-mode current, low enough to remain physical.
+ * Common-mode choke impedance presented at the antenna-side of the feedline
+ * shield when a transformer (any ratio, including 1:1) is fitted at the
+ * feedpoint. Real-world current baluns (W2DU, ferrite-bead string) typically
+ * present 1 kΩ to 5 kΩ across HF; 2 kΩ is a moderate resistive value — high
+ * enough to substantially suppress common-mode current, low enough to remain
+ * physical.
  */
-export const DEFAULT_BALUN_IMPEDANCE_OHMS = 2000;
+export const TRANSFORMER_CHOKE_OHMS = 2000;
+
+/**
+ * Standard insertion loss applied to realized gain when a transformer is
+ * fitted. 0.2 dB is typical of well-built HF baluns/ununs (W2DU choke ~0.1
+ * dB; ferrite-core 9:1 unun ~0.2–0.3 dB). Not user-configurable — a single
+ * representative number, deliberately conservative.
+ */
+export const TRANSFORMER_INSERTION_LOSS_DB = 0.2;

--- a/src/physics/impedance.ts
+++ b/src/physics/impedance.ts
@@ -1,6 +1,6 @@
 // Impedance/SWR helpers.
 
-import { Z0_SYSTEM } from './constants';
+import { Z0_SYSTEM, TRANSFORMER_INSERTION_LOSS_DB } from './constants';
 import type { ImpedanceResult } from './types';
 
 /**
@@ -53,6 +53,96 @@ export function mismatchLossFactor(z: ImpedanceResult, z0: number = Z0_SYSTEM): 
 export function transformImpedance(z: ImpedanceResult, ratio: number): ImpedanceResult {
   if (!Number.isFinite(ratio) || ratio <= 0) return z;
   return { R: z.R / ratio, X: z.X / ratio };
+}
+
+/**
+ * Forward propagation through a lossless transmission line: given the load
+ * (far-end) impedance, returns the input (near-end) impedance seen looking
+ * into a line of characteristic impedance `z0Line` and electrical length
+ * `lengthLambdas` (cable length / cable wavelength).
+ *
+ *   Z_in = Z0 · (Z_load + j·Z0·tan(βd)) / (Z0 + j·Z_load·tan(βd))
+ */
+export function transformThroughLine(
+  zLoad: ImpedanceResult,
+  z0Line: number,
+  lengthLambdas: number,
+): ImpedanceResult {
+  if (!Number.isFinite(lengthLambdas) || !Number.isFinite(z0Line) || z0Line <= 0) {
+    return zLoad;
+  }
+  const betaL = 2 * Math.PI * lengthLambdas;
+  const t = Math.tan(betaL);
+  if (!Number.isFinite(t)) {
+    const denMag2 = zLoad.R * zLoad.R + zLoad.X * zLoad.X;
+    if (denMag2 === 0) return zLoad;
+    return {
+      R: (z0Line * z0Line * zLoad.R) / denMag2,
+      X: -(z0Line * z0Line * zLoad.X) / denMag2,
+    };
+  }
+  // numerator = Z_load + j·Z0·t = zLoad.R + j·(zLoad.X + Z0·t)
+  const numR = zLoad.R;
+  const numI = zLoad.X + z0Line * t;
+  // denominator = Z0 + j·Z_load·t = (Z0 − zLoad.X·t) + j·(zLoad.R·t)
+  const denR = z0Line - zLoad.X * t;
+  const denI = zLoad.R * t;
+  const denMag2 = denR * denR + denI * denI;
+  if (denMag2 === 0) return zLoad;
+  return {
+    R: (z0Line * (numR * denR + numI * denI)) / denMag2,
+    X: (z0Line * (numI * denR - numR * denI)) / denMag2,
+  };
+}
+
+/**
+ * Computes the impedance the radio sees when an ideal `n²`-ratio transformer
+ * is fitted at the antenna terminals (between antenna and feedline).
+ *
+ * If `lineLengthLambdas` is 0 or undefined (no feedline), this is just the
+ * antenna impedance divided by the ratio. With a feedline present, the
+ * antenna feedpoint is de-embedded from the NEC-reported source-side Z,
+ * divided by the ratio (the transformer's effect on the load presented to
+ * the cable), then re-embedded through the cable to get what the radio
+ * sees.
+ *
+ * De-embedding accuracy depends on the absence of significant common-mode
+ * current on the cable shield — which is guaranteed in the simulation
+ * because enabling a transformer also engages a choke on the shield.
+ */
+export function transformWithTransformerAtAntenna(
+  zSrcReportedByNec: ImpedanceResult,
+  ratio: number,
+  z0Line: number = Z0_SYSTEM,
+  lineLengthLambdas: number = 0,
+): ImpedanceResult {
+  if (!Number.isFinite(ratio) || ratio <= 0) return zSrcReportedByNec;
+  if (lineLengthLambdas === 0 || !Number.isFinite(lineLengthLambdas)) {
+    // No feedline → NEC's reported Z is the antenna feedpoint directly.
+    return { R: zSrcReportedByNec.R / ratio, X: zSrcReportedByNec.X / ratio };
+  }
+  const zAntenna = deembedThroughLine(zSrcReportedByNec, z0Line, lineLengthLambdas);
+  const zXfmrPrimary = { R: zAntenna.R / ratio, X: zAntenna.X / ratio };
+  return transformThroughLine(zXfmrPrimary, z0Line, lineLengthLambdas);
+}
+
+/**
+ * Realized gain after a transformer fitted at the antenna terminals: the
+ * NEC-computed `gainDbi` (intrinsic radiation) minus the mismatch loss
+ * computed against the radio-side impedance with the transformer in
+ * place, minus a fixed insertion loss for the transformer hardware.
+ */
+export function realizedGainWithTransformer(
+  gainDbi: number,
+  zSrcReportedByNec: ImpedanceResult,
+  ratio: number,
+  z0Line: number = Z0_SYSTEM,
+  lineLengthLambdas: number = 0,
+): number | undefined {
+  const zRadio = transformWithTransformerAtAntenna(zSrcReportedByNec, ratio, z0Line, lineLengthLambdas);
+  const mlf = mismatchLossFactor(zRadio);
+  if (mlf <= 0) return undefined;
+  return gainDbi + 10 * Math.log10(mlf) - TRANSFORMER_INSERTION_LOSS_DB;
 }
 
 /**

--- a/src/physics/impedance.ts
+++ b/src/physics/impedance.ts
@@ -54,3 +54,53 @@ export function transformImpedance(z: ImpedanceResult, ratio: number): Impedance
   if (!Number.isFinite(ratio) || ratio <= 0) return z;
   return { R: z.R / ratio, X: z.X / ratio };
 }
+
+/**
+ * De-embeds an impedance reading taken at the source end of a lossless
+ * transmission line: given Z measured at the source, returns the load-side
+ * impedance at the far end of the line.
+ *
+ *   Z_load = Z0 · (Z_src − j·Z0·tan(βd)) / (Z0 − j·Z_src·tan(βd))
+ *
+ * `lengthLambdas` is the electrical length of the line (physical length
+ * divided by the cable's in-line wavelength, i.e. `length / (vf · λ_air)`).
+ *
+ * NEC's TL card is lossless; the matching inverse-transform here is also
+ * lossless, so for the differential signal this is exact. It does NOT
+ * account for any common-mode current on the cable shield (modelled as a
+ * separate wire in NEC), so for antennas with significant shield current
+ * the de-embedded value is an estimate of the antenna terminals only.
+ */
+export function deembedThroughLine(
+  zSrc: ImpedanceResult,
+  z0Line: number,
+  lengthLambdas: number,
+): ImpedanceResult {
+  if (!Number.isFinite(lengthLambdas) || !Number.isFinite(z0Line) || z0Line <= 0) {
+    return zSrc;
+  }
+  const betaL = 2 * Math.PI * lengthLambdas;
+  const t = Math.tan(betaL);
+  if (!Number.isFinite(t)) {
+    // tan diverges at ¼-wavelength multiples; in the limit Z_load = Z0² / Z_src.
+    const denMag2 = zSrc.R * zSrc.R + zSrc.X * zSrc.X;
+    if (denMag2 === 0) return zSrc;
+    return {
+      R: (z0Line * z0Line * zSrc.R) / denMag2,
+      X: -(z0Line * z0Line * zSrc.X) / denMag2,
+    };
+  }
+  // numerator = Z_src − j·Z0·t = zSrc.R + j·(zSrc.X − Z0·t)
+  const numR = zSrc.R;
+  const numI = zSrc.X - z0Line * t;
+  // denominator = Z0 − j·Z_src·t = (Z0 + zSrc.X·t) + j·(−zSrc.R·t)
+  const denR = z0Line + zSrc.X * t;
+  const denI = -zSrc.R * t;
+  const denMag2 = denR * denR + denI * denI;
+  if (denMag2 === 0) return zSrc;
+  // Z0 · (num / den), complex division.
+  return {
+    R: (z0Line * (numR * denR + numI * denI)) / denMag2,
+    X: (z0Line * (numI * denR - numR * denI)) / denMag2,
+  };
+}

--- a/src/store/antennaGeometry.ts
+++ b/src/store/antennaGeometry.ts
@@ -20,8 +20,63 @@ export const MIN_SEGS_PER_LEG = 9;
  * Hard cap on segments per leg to bound NEC runtime for very long or high-frequency
  * antennas. At 100 segments/leg the worst-case per-leg segment length stays
  * above ~0.1λ even for a 5λ leg, which is adequate for pattern accuracy.
+ *
+ * NOTE: Builders that use tapered/graded segmentation (e.g. `buildSlopingVWires`)
+ * derive segment count from segment-length physics rather than this cap, so the
+ * cap is bypassed when graded segmentation is in effect.
  */
 export const MAX_SEGS_PER_LEG = 100;
+
+/**
+ * Plan for tapered (graded) segmentation of a wire connected to a short
+ * feed segment. Used to satisfy NEC's adjacent-segment ratio rule: the
+ * moment-method solver requires neighbouring segments to differ by no more
+ * than ~2× in length, otherwise basis functions can't resolve the rapid
+ * current variation at the source.
+ */
+export interface GradedSegmentPlan {
+  /** Lengths of the geometrically-growing prefix segments (short → long). */
+  readonly prefixLens: number[];
+  /** Length of each uniform tail segment (0 if no tail). */
+  readonly tailLen: number;
+  /** Number of uniform tail segments (0 if no tail). */
+  readonly tailCount: number;
+}
+
+/**
+ * Builds a graded-segmentation plan for a wire of length `totalLen` where the
+ * end adjacent to the source has segments of `startSegLen` that grow by
+ * `growthRatio` each step until reaching `maxSegLen`, then continue uniformly.
+ *
+ * The plan's segment lengths sum to `totalLen` (within float precision). The
+ * uniform tail length is distributed evenly so the boundary ratio between the
+ * last graded segment and the first tail segment stays close to `growthRatio`.
+ */
+export function gradedSegmentPlan(
+  totalLen: number,
+  startSegLen: number,
+  maxSegLen: number,
+  growthRatio: number = 2,
+): GradedSegmentPlan {
+  if (totalLen <= 0) return { prefixLens: [], tailLen: 0, tailCount: 0 };
+
+  const prefixLens: number[] = [];
+  let accum = 0;
+  let cur = Math.max(startSegLen, 1e-9);
+  while (cur < maxSegLen && accum + cur < totalLen) {
+    prefixLens.push(cur);
+    accum += cur;
+    cur *= growthRatio;
+  }
+
+  const remaining = totalLen - accum;
+  if (remaining < 1e-9) {
+    return { prefixLens, tailLen: 0, tailCount: 0 };
+  }
+  const tailCount = Math.max(1, Math.round(remaining / Math.max(maxSegLen, 1e-9)));
+  const tailLen = remaining / tailCount;
+  return { prefixLens, tailLen, tailCount };
+}
 
 export type OrientationPreset = 'EW' | 'NS' | 'NE-SW' | 'NW-SE';
 export type Orientation = OrientationPreset | number;
@@ -143,6 +198,24 @@ export interface SlopingVWiresParams {
  * the tips rest at the ground floor (`SLOPING_V_MIN_TIP_Z_M`). The `legSlope`
  * field on the input is therefore ignored and retained only for state shape
  * compatibility.
+ *
+ * Each leg uses **graded (tapered) segmentation**: the segment adjacent to the
+ * apex matches the feed-bridge length, growing geometrically (×2 per step) up
+ * to ~λ/SEGS_PER_WAVELENGTH, then continuing uniformly to the tip. This
+ * satisfies NEC's adjacent-segment ratio rule at the source — uniform leg
+ * segments on a multi-wavelength leg would be 10×–20× longer than the 0.1 m
+ * bridge, which corrupts the moment-method solver's feedpoint impedance.
+ *
+ * A leg is emitted as one Wire per graded prefix segment plus one
+ * multi-segment Wire covering the uniform tail. All sub-wires of a given leg
+ * share the same tag (DIPOLE_LEFT_TAG / DIPOLE_RIGHT_TAG) so that current-
+ * ripple and load diagnostics continue to group by leg correctly.
+ *
+ * Convention:
+ *   LEFT leg  is emitted tip → apex (first Wire returned for the tag is the
+ *             tail-end at the tip; its `.start` is the tip).
+ *   RIGHT leg is emitted apex → tip (last Wire returned for the tag is the
+ *             tail-end at the tip; its `.end` is the tip).
  */
 export function buildSlopingVWires(params: SlopingVWiresParams): Wire[] {
   const h = params.height;
@@ -187,38 +260,89 @@ export function buildSlopingVWires(params: SlopingVWiresParams): Wire[] {
   }
 
   const lambda = wavelengthMeters(params.frequency);
-  const minSegPerLeg = Math.ceil((SEGS_PER_WAVELENGTH * legLen) / lambda);
-  const segmentsPerLeg = Math.min(
-    MAX_SEGS_PER_LEG,
-    Math.max(MIN_SEGS_PER_LEG, minSegPerLeg, Math.round(params.segments / 2)),
-  );
+  const maxSegLen = lambda / SEGS_PER_WAVELENGTH;
+  const plan = gradedSegmentPlan(legLen, FEED_BRIDGE_LENGTH_M, maxSegLen);
+
+  // Axis positions (distance from apex) at every segment boundary along a leg.
+  // `breakpoints[0] = 0` (apex), `breakpoints[K] = prefix end`, then a final
+  // `legLen` (tip) at the end of the tail wire.
+  const breakpoints: number[] = [0];
+  let pos = 0;
+  for (const pl of plan.prefixLens) {
+    pos += pl;
+    breakpoints.push(pos);
+  }
+  const prefixEnd = pos;
+
+  // Enforce a floor on total segments for very short legs (NEC needs enough
+  // basis functions to represent currents). When the natural graded plan
+  // gives too few segments, pad the tail count — NEC distributes them evenly
+  // along the tail wire's length.
+  let tailCount = plan.tailCount;
+  const naturalTotal = plan.prefixLens.length + tailCount;
+  if (naturalTotal < MIN_SEGS_PER_LEG && legLen > prefixEnd + 1e-9) {
+    tailCount = Math.max(1, MIN_SEGS_PER_LEG - plan.prefixLens.length);
+  }
 
   const apexLeft = legPointAt(0, -1);
   const apexRight = legPointAt(0, 1);
 
-  return [
-    {
+  const wires: Wire[] = [];
+
+  // LEFT leg: emit tip → apex.
+  // (1) Uniform tail wire from tip back to the end of the prefix.
+  if (tailCount > 0) {
+    wires.push({
       start: legPointAt(legLen, -1),
-      end: apexLeft,
+      end: legPointAt(prefixEnd, -1),
       radius: params.wireRadius,
-      segments: segmentsPerLeg,
+      segments: tailCount,
       tag: DIPOLE_LEFT_TAG,
-    },
-    {
-      start: apexRight,
-      end: legPointAt(legLen, 1),
-      radius: params.wireRadius,
-      segments: segmentsPerLeg,
-      tag: DIPOLE_RIGHT_TAG,
-    },
-    {
-      start: apexLeft,
-      end: apexRight,
+    });
+  }
+  // (2) Graded prefix wires in reverse (largest to smallest, toward apex).
+  for (let i = plan.prefixLens.length - 1; i >= 0; i--) {
+    wires.push({
+      start: legPointAt(breakpoints[i + 1]!, -1),
+      end: legPointAt(breakpoints[i]!, -1),
       radius: params.wireRadius,
       segments: 1,
-      tag: FEED_BRIDGE_TAG,
-    },
-  ];
+      tag: DIPOLE_LEFT_TAG,
+    });
+  }
+
+  // RIGHT leg: emit apex → tip.
+  // (1) Graded prefix wires in natural order (smallest to largest, away from apex).
+  for (let i = 0; i < plan.prefixLens.length; i++) {
+    wires.push({
+      start: legPointAt(breakpoints[i]!, 1),
+      end: legPointAt(breakpoints[i + 1]!, 1),
+      radius: params.wireRadius,
+      segments: 1,
+      tag: DIPOLE_RIGHT_TAG,
+    });
+  }
+  // (2) Uniform tail wire from end of prefix out to tip.
+  if (tailCount > 0) {
+    wires.push({
+      start: legPointAt(prefixEnd, 1),
+      end: legPointAt(legLen, 1),
+      radius: params.wireRadius,
+      segments: tailCount,
+      tag: DIPOLE_RIGHT_TAG,
+    });
+  }
+
+  // Apex feed bridge.
+  wires.push({
+    start: apexLeft,
+    end: apexRight,
+    radius: params.wireRadius,
+    segments: 1,
+    tag: FEED_BRIDGE_TAG,
+  });
+
+  return wires;
 }
 
 export interface FeedlineShield {

--- a/src/store/antennaStore.ts
+++ b/src/store/antennaStore.ts
@@ -20,7 +20,7 @@ import type {
   AntennaType,
 } from '../physics/types';
 import {
-  DEFAULT_BALUN_IMPEDANCE_OHMS,
+  TRANSFORMER_CHOKE_OHMS,
   DEFAULT_FEEDLINE_ID,
   DEFAULT_FEEDLINE_LENGTH_M,
   DEFAULT_GROUND_ID,
@@ -88,7 +88,6 @@ export interface ComparisonSnapshot {
   readonly feedlineId: string;
   readonly feedlineLength: number;
   readonly feedlineOffset: number;
-  readonly balunEnabled: boolean;
   readonly result: SimulationResult;
   readonly sweep: SweepPoint[];
   readonly capturedAt: number;
@@ -135,7 +134,6 @@ export interface AntennaState {
   feedlineId: string;
   feedlineLength: number;
   feedlineOffset: number;
-  balunEnabled: boolean;
 
   // Display / UI
   theme: Theme;
@@ -192,7 +190,6 @@ export interface AntennaState {
   setFeedline(id: string): void;
   setFeedlineLength(meters: number): void;
   setFeedlineOffset(meters: number): void;
-  setBalunEnabled(enabled: boolean): void;
   setTheme(t: Theme): void;
   toggleTheme(): void;
   setUnits(u: UnitSystem): void;
@@ -251,7 +248,6 @@ export const useAntennaStore = create<AntennaState>()(
       feedlineId: DEFAULT_FEEDLINE_ID,
       feedlineLength: DEFAULT_FEEDLINE_LENGTH_M,
       feedlineOffset: 0,
-      balunEnabled: false,
 
       theme: 'dark',
       units: 'metric',
@@ -287,7 +283,6 @@ export const useAntennaStore = create<AntennaState>()(
           s.feedlineId = 'none';
           s.feedlineLength = 0;
           s.feedlineOffset = 0;
-          s.balunEnabled = false;
         } else if (type !== 'dipole') {
           // Apex-fed antennas don't support an offset; reset it so UI is consistent.
           s.feedlineOffset = 0;
@@ -411,7 +406,6 @@ export const useAntennaStore = create<AntennaState>()(
         const limit = Math.max(0, s.length / 2 - FEED_BRIDGE_LENGTH_M);
         s.feedlineOffset = Math.max(-limit, Math.min(limit, meters));
       }),
-      setBalunEnabled: (enabled) => set((s) => { s.balunEnabled = !!enabled; }),
       setTheme: (t) => set((s) => { s.theme = t; }),
       toggleTheme: () => set((s) => { s.theme = s.theme === 'dark' ? 'light' : 'dark'; }),
       setUnits: (u) => set((s) => { s.units = u; }),
@@ -840,13 +834,19 @@ export function selectSimulationInput(state: AntennaState): SimulationInput {
       lengthM: electricalLength,
     });
 
-    if (state.balunEnabled) {
+    // A transformer (any ratio, including 1:1) fitted at the antenna
+    // feedpoint chokes off common-mode currents on the cable shield. We
+    // model this as a high-impedance series load at the shield end nearest
+    // the antenna. Without a transformer, the shield is left to radiate
+    // freely — that's intentional and visible in the pattern (skewed for
+    // dipoles, restored to symmetry once a transformer/choke is fitted).
+    if (state.transformerEnabled) {
       loads.push({
         type: 4,
         wireTag: FEEDLINE_SHIELD_TAG,
         segmentStart: 1,
         segmentEnd: 1,
-        param1: DEFAULT_BALUN_IMPEDANCE_OHMS,
+        param1: TRANSFORMER_CHOKE_OHMS,
         param2: 0,
       });
     }
@@ -939,7 +939,6 @@ function createComparisonSnapshot(state: AntennaState): ComparisonSnapshot | nul
     feedlineId: state.feedlineId,
     feedlineLength: state.feedlineLength,
     feedlineOffset: state.feedlineOffset,
-    balunEnabled: state.balunEnabled,
     result: state.result,
     sweep: [...state.sweep],
     capturedAt: Date.now(),

--- a/src/store/antennaStore.ts
+++ b/src/store/antennaStore.ts
@@ -875,10 +875,15 @@ export function selectSimulationInput(state: AntennaState): SimulationInput {
     // the ground plane, matching the real antenna where the resistor
     // connects the wire end to a driven ground rod. A series LD on the
     // leg end alone does not create this shunt-to-earth current path.
-    const leftLeg  = wires.find((w) => w.tag === DIPOLE_LEFT_TAG)!;
-    const rightLeg = wires.find((w) => w.tag === DIPOLE_RIGHT_TAG)!;
-    const leftTip  = leftLeg.start;   // left leg runs tip → apex
-    const rightTip = rightLeg.end;    // right leg runs apex → tip
+    //
+    // With graded segmentation each leg may be emitted as multiple sub-wires
+    // sharing the leg's tag. By convention `buildSlopingVWires` emits the
+    // LEFT leg tip→apex (so the first sub-wire's `.start` is the tip) and
+    // the RIGHT leg apex→tip (so the last sub-wire's `.end` is the tip).
+    const leftLegWires  = wires.filter((w) => w.tag === DIPOLE_LEFT_TAG);
+    const rightLegWires = wires.filter((w) => w.tag === DIPOLE_RIGHT_TAG);
+    const leftTip  = leftLegWires[0]!.start;
+    const rightTip = rightLegWires[rightLegWires.length - 1]!.end;
 
     wires.push(
       {

--- a/tests/DipoleControl.test.tsx
+++ b/tests/DipoleControl.test.tsx
@@ -14,13 +14,43 @@ vi.mock('../src/store/antennaStore', async () => {
 
 interface MockState {
   units: string;
+  antennaType: string;
   length: number;
   height: number;
+  frequency: number;
   orientation: string | number;
+  vAngle: number;
+  terminatingResistor: number;
+  setAntennaType: () => void;
   setLength: () => void;
   setHalfWaveLength: () => void;
+  setLegLengthMultiple: () => void;
   setHeight: () => void;
   setOrientation: (o: string | number) => void;
+  setVAngle: () => void;
+  setTerminatingResistor: () => void;
+}
+
+function buildMockState(overrides: Partial<MockState> = {}): MockState {
+  return {
+    units: 'metric',
+    antennaType: 'dipole',
+    length: 20,
+    height: 10,
+    frequency: 7.1,
+    orientation: 'EW',
+    vAngle: 120,
+    terminatingResistor: 0,
+    setAntennaType: vi.fn(),
+    setLength: vi.fn(),
+    setHalfWaveLength: vi.fn(),
+    setLegLengthMultiple: vi.fn(),
+    setHeight: vi.fn(),
+    setOrientation: vi.fn(),
+    setVAngle: vi.fn(),
+    setTerminatingResistor: vi.fn(),
+    ...overrides,
+  };
 }
 
 describe('DipoleControl', () => {
@@ -32,17 +62,7 @@ describe('DipoleControl', () => {
   it('updates orientation when numeric input changes', () => {
     const setOrientation = vi.fn();
     vi.mocked(useAntennaStore).mockImplementation((selector: (s: MockState) => unknown) => {
-      const state: MockState = {
-        units: 'metric',
-        length: 20,
-        height: 10,
-        orientation: 'EW',
-        setLength: vi.fn(),
-        setHalfWaveLength: vi.fn(),
-        setHeight: vi.fn(),
-        setOrientation,
-      };
-      return selector(state);
+      return selector(buildMockState({ setOrientation }));
     });
 
     render(<DipoleControl />);
@@ -56,17 +76,7 @@ describe('DipoleControl', () => {
   it('updates orientation when preset buttons are clicked', () => {
     const setOrientation = vi.fn();
     vi.mocked(useAntennaStore).mockImplementation((selector: (s: MockState) => unknown) => {
-      const state: MockState = {
-        units: 'metric',
-        length: 20,
-        height: 10,
-        orientation: 'EW',
-        setLength: vi.fn(),
-        setHalfWaveLength: vi.fn(),
-        setHeight: vi.fn(),
-        setOrientation,
-      };
-      return selector(state);
+      return selector(buildMockState({ setOrientation }));
     });
 
     render(<DipoleControl />);

--- a/tests/StatsReadout.test.tsx
+++ b/tests/StatsReadout.test.tsx
@@ -48,6 +48,44 @@ describe('StatsReadout', () => {
     expect(container.textContent).toContain('SWR (vs 50 Ω)');
   });
 
+  it('labels impedance as "Feedpoint" when no feedline is configured', () => {
+    useAntennaStore.setState({
+      feedlineId: 'none',
+      result: {
+        computeTimeMs: 10,
+        maxGainDbi: 2.0,
+        takeoffElevationDeg: 30,
+        takeoffAzimuthDeg: 0,
+        impedance: { R: 70, X: 5 },
+        swr: 1.5,
+        pattern: { data: new Float32Array([1]), phiSteps: 1, thetaSteps: 1 },
+      } as unknown as import('../src/physics/types').SimulationResult,
+    });
+
+    const { container } = render(<StatsReadout />);
+    expect(container.textContent).toContain('Feedpoint (R + jX)');
+    expect(container.textContent).not.toContain('Source impedance');
+  });
+
+  it('labels impedance as "Source impedance" when a feedline is active', () => {
+    useAntennaStore.setState({
+      feedlineId: 'rg58',
+      result: {
+        computeTimeMs: 10,
+        maxGainDbi: 2.0,
+        takeoffElevationDeg: 30,
+        takeoffAzimuthDeg: 0,
+        impedance: { R: 70, X: 5 },
+        swr: 1.5,
+        pattern: { data: new Float32Array([1]), phiSteps: 1, thetaSteps: 1 },
+      } as unknown as import('../src/physics/types').SimulationResult,
+    });
+
+    const { container } = render(<StatsReadout />);
+    expect(container.textContent).toContain('Source impedance (R + jX)');
+    expect(container.textContent).not.toContain('Feedpoint (R + jX)');
+  });
+
   it('renders directivity and efficiency when power budget data is provided', () => {
     useAntennaStore.setState({
       result: {

--- a/tests/TransformerControl.test.tsx
+++ b/tests/TransformerControl.test.tsx
@@ -16,7 +16,7 @@ describe('TransformerControl', () => {
 
   it('renders the section heading', () => {
     const { getByText } = render(<TransformerControl />);
-    expect(getByText('Ideal transformer')).not.toBeNull();
+    expect(getByText('Transformer at feedpoint')).not.toBeNull();
   });
 
   it('shows the enable checkbox unchecked by default', () => {
@@ -30,11 +30,24 @@ describe('TransformerControl', () => {
     expect(queryByLabelText(/Impedance ratio/i)).toBeNull();
   });
 
-  it('shows ratio input and note when enabled', () => {
+  it('shows ratio input and hint when enabled', () => {
     useAntennaStore.setState({ transformerEnabled: true });
     const { getByLabelText, container } = render(<TransformerControl />);
     expect(getByLabelText(/Impedance ratio/i)).not.toBeNull();
-    expect(container.textContent).toContain('Z_transformed = Z_feedpoint / ratio');
+    expect(container.textContent).toMatch(/Insertion loss: 0\.2 dB/);
+  });
+
+  it('describes ratio=1 as a current (choke) balun', () => {
+    useAntennaStore.setState({ transformerEnabled: true, transformerRatio: 1 });
+    const { container } = render(<TransformerControl />);
+    expect(container.textContent).toContain('current ("choke") balun');
+  });
+
+  it('describes ratio>1 as an impedance transformer', () => {
+    useAntennaStore.setState({ transformerEnabled: true, transformerRatio: 9 });
+    const { container } = render(<TransformerControl />);
+    expect(container.textContent).toContain('Ratio 9:1');
+    expect(container.textContent).toContain('divides antenna feedpoint impedance by 9');
   });
 
   it('enables transformer when checkbox is clicked', () => {
@@ -42,52 +55,6 @@ describe('TransformerControl', () => {
     const checkbox = getByRole('checkbox') as HTMLInputElement;
     fireEvent.click(checkbox);
     expect(useAntennaStore.getState().transformerEnabled).toBe(true);
-  });
-
-  it('shows transformed values when enabled and result is present', () => {
-    useAntennaStore.setState({
-      transformerEnabled: true,
-      transformerRatio: 9,
-      result: {
-        computeTimeMs: 10,
-        maxGainDbi: 7,
-        takeoffElevationDeg: 15,
-        takeoffAzimuthDeg: 0,
-        impedance: { R: 450, X: 0 },
-        swr: 9.0,
-        pattern: { data: new Float32Array([1]), phiSteps: 1, thetaSteps: 1 },
-      } as unknown as import('../src/physics/types').SimulationResult,
-    });
-
-    const { container } = render(<TransformerControl />);
-
-    // Raw values visible
-    expect(container.textContent).toContain('Feedpoint (raw R + jX)');
-    expect(container.textContent).toContain('Raw SWR (vs 50 Ω)');
-    // Transformed values visible: 450/9 = 50, SWR ≈ 1.00:1
-    expect(container.textContent).toContain('Transformed (R + jX)');
-    expect(container.textContent).toContain('50.0');
-    expect(container.textContent).toContain('Transformed SWR (vs 50 Ω)');
-    expect(container.textContent).toContain('1.00:1');
-  });
-
-  it('does not show transformed values when disabled even if result is present', () => {
-    useAntennaStore.setState({
-      transformerEnabled: false,
-      result: {
-        computeTimeMs: 10,
-        maxGainDbi: 7,
-        takeoffElevationDeg: 15,
-        takeoffAzimuthDeg: 0,
-        impedance: { R: 450, X: 0 },
-        swr: 9.0,
-        pattern: { data: new Float32Array([1]), phiSteps: 1, thetaSteps: 1 },
-      } as unknown as import('../src/physics/types').SimulationResult,
-    });
-
-    const { container } = render(<TransformerControl />);
-    expect(container.textContent).not.toContain('Transformed SWR');
-    expect(container.textContent).not.toContain('Raw SWR');
   });
 
   it('updates ratio when input changes', () => {
@@ -98,22 +65,8 @@ describe('TransformerControl', () => {
     expect(useAntennaStore.getState().transformerRatio).toBe(4);
   });
 
-  it('shows disclaimer note when enabled and result is present', () => {
-    useAntennaStore.setState({
-      transformerEnabled: true,
-      transformerRatio: 9,
-      result: {
-        computeTimeMs: 10,
-        maxGainDbi: 2,
-        takeoffElevationDeg: 15,
-        takeoffAzimuthDeg: 0,
-        impedance: { R: 450, X: 0 },
-        swr: 9.0,
-        pattern: { data: new Float32Array([1]), phiSteps: 1, thetaSteps: 1 },
-      } as unknown as import('../src/physics/types').SimulationResult,
-    });
-
+  it('shows shield-radiates hint when transformer is disabled', () => {
     const { container } = render(<TransformerControl />);
-    expect(container.textContent).toContain('ideal post-processing calculations');
+    expect(container.textContent).toContain('feedline shield carries common-mode current');
   });
 });

--- a/tests/antennaStore.test.ts
+++ b/tests/antennaStore.test.ts
@@ -249,7 +249,7 @@ describe('antennaStore selectors', () => {
         feedlineId: 'rg58',
         feedlineLength: 8,
         feedlineOffset: 0,
-        balunEnabled: false,
+        transformerEnabled: false,
       };
 
       const input = selectSimulationInput(testState);
@@ -371,7 +371,7 @@ describe('antennaStore selectors', () => {
       expect(rightWires[rightWires.length - 1]!.end[2]).toBeCloseTo(0.5, 5);
     });
 
-    it('adds an LD choke balun on the shield when balun is enabled', () => {
+    it('adds an LD choke on the shield when transformer is fitted at the antenna', () => {
       const state = useAntennaStore.getState();
       const testState = {
         ...state,
@@ -380,7 +380,7 @@ describe('antennaStore selectors', () => {
         feedlineId: 'rg213',
         feedlineLength: 6,
         feedlineOffset: 0,
-        balunEnabled: true,
+        transformerEnabled: true,
       };
 
       const input = selectSimulationInput(testState);
@@ -408,7 +408,7 @@ describe('antennaStore selectors', () => {
         feedlineId: 'rg58',
         feedlineLength: 8,
         feedlineOffset: 0,
-        balunEnabled: false,
+        transformerEnabled: false,
       });
 
       // bridge + 2 legs + shield (no stubs since terminatingResistor=0)
@@ -691,7 +691,7 @@ describe('antennaStore actions', () => {
       store.setFeedline('rg58');
       store.setFeedlineLength(15);
       store.setFeedlineOffset(2);
-      store.setBalunEnabled(true);
+      store.setTransformerEnabled(true);
 
       store.setAntennaType('sloping-v');
 
@@ -700,7 +700,7 @@ describe('antennaStore actions', () => {
       expect(s.feedlineId).toBe('rg58');
       expect(s.feedlineLength).toBe(15);
       expect(s.feedlineOffset).toBe(0);
-      expect(s.balunEnabled).toBe(true);
+      expect(s.transformerEnabled).toBe(true);
     });
 
     it('updates feedline preset id', () => {
@@ -726,12 +726,12 @@ describe('antennaStore actions', () => {
       expect(useAntennaStore.getState().feedlineLength).toBe(15);
     });
 
-    it('toggles balun enabled flag', () => {
+    it('toggles transformer enabled flag', () => {
       const store = useAntennaStore.getState();
-      store.setBalunEnabled(true);
-      expect(useAntennaStore.getState().balunEnabled).toBe(true);
-      store.setBalunEnabled(false);
-      expect(useAntennaStore.getState().balunEnabled).toBe(false);
+      store.setTransformerEnabled(true);
+      expect(useAntennaStore.getState().transformerEnabled).toBe(true);
+      store.setTransformerEnabled(false);
+      expect(useAntennaStore.getState().transformerEnabled).toBe(false);
     });
 
     it('clamps feedline offset to ±length/2', () => {
@@ -953,7 +953,7 @@ describe('antennaStore actions', () => {
         feedlineId: 'rg58',
         feedlineLength: 8,
         feedlineOffset: 0,
-        balunEnabled: false,
+        transformerEnabled: false,
       };
       const input = selectSimulationInput(state as AntennaState);
       // 4 wires: left leg (1), right leg (2), bridge (3), shield (4)
@@ -1087,7 +1087,7 @@ describe('antennaStore actions', () => {
         feedlineId: 'rg58',
         feedlineLength: 10,
         feedlineOffset: 0,
-        balunEnabled: false,
+        transformerEnabled: false,
       };
       const input = selectSimulationInput(state as AntennaState);
       // 5 wires: left leg (1), right leg (2), bridge (3), shield (4), base (6)

--- a/tests/antennaStore.test.ts
+++ b/tests/antennaStore.test.ts
@@ -307,17 +307,30 @@ describe('antennaStore selectors', () => {
       };
 
       const wires = buildWires(state);
-      expect(wires).toHaveLength(3); // Two legs + feed bridge
+      // Graded-segmentation sloping-V emits one Wire per graded-prefix segment
+      // plus one multi-segment tail Wire per leg, plus the apex bridge.
+      // Exact count depends on band, but there must be at least two leg
+      // sub-wires per side and one bridge.
+      const leftWires = wires.filter((w) => w.tag === 1);
+      const rightWires = wires.filter((w) => w.tag === 2);
+      const bridges = wires.filter((w) => w.tag === 3);
+      expect(leftWires.length).toBeGreaterThanOrEqual(2);
+      expect(rightWires.length).toBeGreaterThanOrEqual(2);
+      expect(bridges).toHaveLength(1);
+      const bridge = bridges[0]!;
 
-      // Left leg: Tip to ApexBridge connection
-      const left = wires.find((w) => w.tag === 1)!;
-      // Right leg: ApexBridge connection to Tip
-      const right = wires.find((w) => w.tag === 2)!;
-      // Bridge
-      const bridge = wires.find((w) => w.tag === 3)!;
+      // LEFT leg is emitted tip → apex: first sub-wire is the tail (at the
+      // tip); last sub-wire connects to the apex.
+      const leftTipWire = leftWires[0]!;
+      const leftApexWire = leftWires[leftWires.length - 1]!;
+      // RIGHT leg is emitted apex → tip: first sub-wire connects to the
+      // apex; last sub-wire is the tail (at the tip).
+      const rightApexWire = rightWires[0]!;
+      const rightTipWire = rightWires[rightWires.length - 1]!;
 
-      expect(left.end).toEqual(bridge.start);
-      expect(right.start).toEqual(bridge.end);
+      // Apex connections to the bridge.
+      expect(leftApexWire.end).toEqual(bridge.start);
+      expect(rightApexWire.start).toEqual(bridge.end);
 
       // Bridge is horizontal at apex height
       expect(bridge.start[2]).toBe(10);
@@ -328,8 +341,8 @@ describe('antennaStore selectors', () => {
       // maxSin = 9.5 / 39.95 ≈ 0.237.
       // maxSlope = asin(0.237) ≈ 13.7 deg.
       // 30 deg > 13.7 deg, so it should be clamped to 0.5m tip height.
-      expect(left.start[2]).toBeCloseTo(0.5, 5);
-      expect(right.end[2]).toBeCloseTo(0.5, 5);
+      expect(leftTipWire.start[2]).toBeCloseTo(0.5, 5);
+      expect(rightTipWire.end[2]).toBeCloseTo(0.5, 5);
     });
 
     it('clamps sloping-V slope to prevent tips hitting ground', () => {
@@ -350,8 +363,12 @@ describe('antennaStore selectors', () => {
       // maxSin = (10 - 0.5) / 50 = 9.5 / 50 = 0.19
       // maxSlope = asin(0.19) ≈ 10.95 deg
       // tip_z should be 0.5
-      expect(wires.find((w) => w.tag === 1)!.start[2]).toBeCloseTo(0.5, 5);
-      expect(wires.find((w) => w.tag === 2)!.end[2]).toBeCloseTo(0.5, 5);
+      const leftWires = wires.filter((w) => w.tag === 1);
+      const rightWires = wires.filter((w) => w.tag === 2);
+      // LEFT leg emitted tip → apex (first sub-wire's .start is the tip);
+      // RIGHT leg emitted apex → tip (last sub-wire's .end is the tip).
+      expect(leftWires[0]!.start[2]).toBeCloseTo(0.5, 5);
+      expect(rightWires[rightWires.length - 1]!.end[2]).toBeCloseTo(0.5, 5);
     });
 
     it('adds an LD choke balun on the shield when balun is enabled', () => {
@@ -850,7 +867,9 @@ describe('antennaStore actions', () => {
         feedlineId: 'none',
       };
       const input = selectSimulationInput(state as AntennaState);
-      expect(input.wires).toHaveLength(3);
+      // Graded segmentation produces multiple sub-wires per leg; only the
+      // bridge (tag 3) is guaranteed to be a single wire.
+      expect(input.wires.filter((w) => w.tag === 3)).toHaveLength(1);
 
       expect(input.excitation.wireTag).toBe(3); // FEED_BRIDGE_TAG
       expect(input.excitation.segment).toBe(1);

--- a/tests/impedance.test.ts
+++ b/tests/impedance.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { swr, mismatchLossFactor, transformImpedance } from '../src/physics/impedance';
+import { swr, mismatchLossFactor, transformImpedance, deembedThroughLine } from '../src/physics/impedance';
 
 describe('reflection coefficient and SWR', () => {
   it('perfect match => |Γ|=0, SWR=1', () => {
@@ -112,5 +112,60 @@ describe('transformImpedance', () => {
     const original = { R: 100, X: 50 };
     const result = transformImpedance(original, NaN);
     expect(result).toBe(original);
+  });
+});
+
+describe('deembedThroughLine', () => {
+  it('zero-length line returns input unchanged', () => {
+    const z = { R: 73, X: 42 };
+    const result = deembedThroughLine(z, 50, 0);
+    expect(result.R).toBeCloseTo(73, 9);
+    expect(result.X).toBeCloseTo(42, 9);
+  });
+
+  it('half-wavelength line is identity', () => {
+    const z = { R: 200, X: -150 };
+    const result = deembedThroughLine(z, 50, 0.5);
+    expect(result.R).toBeCloseTo(200, 6);
+    expect(result.X).toBeCloseTo(-150, 6);
+  });
+
+  it('quarter-wave inverts: 25 Ω → 100 Ω with Z0=50', () => {
+    const result = deembedThroughLine({ R: 25, X: 0 }, 50, 0.25);
+    expect(result.R).toBeCloseTo(100, 6);
+    expect(result.X).toBeCloseTo(0, 6);
+  });
+
+  it('quarter-wave inverts: 100 Ω → 25 Ω with Z0=50', () => {
+    const result = deembedThroughLine({ R: 100, X: 0 }, 50, 0.25);
+    expect(result.R).toBeCloseTo(25, 6);
+    expect(result.X).toBeCloseTo(0, 6);
+  });
+
+  it('matched load is invariant on any line length', () => {
+    for (const lambdas of [0.1, 0.25, 0.5, 0.916, 1.7]) {
+      const result = deembedThroughLine({ R: 50, X: 0 }, 50, lambdas);
+      expect(result.R).toBeCloseTo(50, 6);
+      expect(result.X).toBeCloseTo(0, 6);
+    }
+  });
+
+  it('|Γ| is preserved along a lossless line (SWR conservation)', () => {
+    const zSource = { R: 9.7, X: 94.5 };
+    const zLoad = deembedThroughLine(zSource, 50, 0.916);
+    // SWR at both ends of a lossless line must match.
+    expect(swr(zLoad)).toBeCloseTo(swr(zSource), 4);
+  });
+
+  it('invalid z0 returns input unchanged', () => {
+    const original = { R: 100, X: 50 };
+    expect(deembedThroughLine(original, 0, 0.5)).toBe(original);
+    expect(deembedThroughLine(original, -50, 0.5)).toBe(original);
+  });
+
+  it('non-finite length returns input unchanged', () => {
+    const original = { R: 100, X: 50 };
+    expect(deembedThroughLine(original, 50, NaN)).toBe(original);
+    expect(deembedThroughLine(original, 50, Infinity)).toBe(original);
   });
 });

--- a/tests/vBeamTermination.test.ts
+++ b/tests/vBeamTermination.test.ts
@@ -71,19 +71,24 @@ describe('V-antenna termination topology', () => {
     setupSlopingV(800);
     const input = selectSimulationInput(useAntennaStore.getState());
 
-    const leftLeg  = input.wires.find((w) => w.tag === DIPOLE_LEFT_TAG)!;
-    const rightLeg = input.wires.find((w) => w.tag === DIPOLE_RIGHT_TAG)!;
+    // With graded segmentation each leg is multiple sub-wires sharing a tag:
+    //   LEFT  leg is emitted tip → apex (first sub-wire's `.start` is the tip)
+    //   RIGHT leg is emitted apex → tip (last sub-wire's `.end` is the tip)
+    const leftLegWires  = input.wires.filter((w) => w.tag === DIPOLE_LEFT_TAG);
+    const rightLegWires = input.wires.filter((w) => w.tag === DIPOLE_RIGHT_TAG);
+    const leftLegTip  = leftLegWires[0]!.start;
+    const rightLegTip = rightLegWires[rightLegWires.length - 1]!.end;
     const leftStub  = input.wires.find((w) => w.tag === SLOPING_V_LEFT_STUB_TAG)!;
     const rightStub = input.wires.find((w) => w.tag === SLOPING_V_RIGHT_STUB_TAG)!;
 
     // Stub starts exactly at the tip of each leg
-    expect(leftStub.start[0]).toBeCloseTo(leftLeg.start[0], 6);
-    expect(leftStub.start[1]).toBeCloseTo(leftLeg.start[1], 6);
-    expect(leftStub.start[2]).toBeCloseTo(leftLeg.start[2], 6);
+    expect(leftStub.start[0]).toBeCloseTo(leftLegTip[0], 6);
+    expect(leftStub.start[1]).toBeCloseTo(leftLegTip[1], 6);
+    expect(leftStub.start[2]).toBeCloseTo(leftLegTip[2], 6);
 
-    expect(rightStub.start[0]).toBeCloseTo(rightLeg.end[0], 6);
-    expect(rightStub.start[1]).toBeCloseTo(rightLeg.end[1], 6);
-    expect(rightStub.start[2]).toBeCloseTo(rightLeg.end[2], 6);
+    expect(rightStub.start[0]).toBeCloseTo(rightLegTip[0], 6);
+    expect(rightStub.start[1]).toBeCloseTo(rightLegTip[1], 6);
+    expect(rightStub.start[2]).toBeCloseTo(rightLegTip[2], 6);
 
     // Stub ends near the ground at the constant floor height
     expect(leftStub.end[2]).toBeCloseTo(SLOPING_V_STUB_BOTTOM_Z_M, 6);

--- a/tests/vSegmentation.test.ts
+++ b/tests/vSegmentation.test.ts
@@ -6,7 +6,8 @@ import {
   MIN_SEGS_PER_LEG,
   MAX_SEGS_PER_LEG,
 } from '../src/store/antennaGeometry';
-import { wavelengthMeters, FEED_BRIDGE_LENGTH_M, FEED_BRIDGE_TAG, DIPOLE_LEFT_TAG } from '../src/physics/constants';
+import { wavelengthMeters, FEED_BRIDGE_LENGTH_M, FEED_BRIDGE_TAG, DIPOLE_LEFT_TAG, DIPOLE_RIGHT_TAG } from '../src/physics/constants';
+import type { Wire } from '../src/physics/types';
 
 const BASE_PARAMS = {
   height: 15,
@@ -17,8 +18,14 @@ const BASE_PARAMS = {
 
 const V_PARAMS = { ...BASE_PARAMS, vAngle: 90, legSlope: 0 };
 
-function legSegs(wires: ReturnType<typeof buildSlopingVWires>): number {
-  return wires.find((w) => w.tag === DIPOLE_LEFT_TAG)!.segments;
+/**
+ * Sum NEC segments across every sub-wire that shares the given leg tag.
+ * Sloping-V uses graded segmentation, so a leg is one Wire per graded
+ * prefix segment plus one multi-segment Wire for the uniform tail; the
+ * effective "segments per leg" is the sum across all of them.
+ */
+function legSegs(wires: Wire[], tag: number = DIPOLE_LEFT_TAG): number {
+  return wires.filter((w) => w.tag === tag).reduce((sum, w) => sum + w.segments, 0);
 }
 
 describe('V-antenna wavelength-based segmentation', () => {
@@ -38,9 +45,7 @@ describe('V-antenna wavelength-based segmentation', () => {
       const total = 2 * lambda + FEED_BRIDGE_LENGTH_M;
       const wires = buildSlopingVWires({ ...V_PARAMS, frequency: freq, length: total, legSlope: 15 });
 
-      const leftSegs = wires.find((w) => w.tag === 1)!.segments;
-      const rightSegs = wires.find((w) => w.tag === 2)!.segments;
-      expect(leftSegs).toBe(rightSegs);
+      expect(legSegs(wires, DIPOLE_LEFT_TAG)).toBe(legSegs(wires, DIPOLE_RIGHT_TAG));
     });
   });
 
@@ -68,8 +73,10 @@ describe('V-antenna wavelength-based segmentation', () => {
         buildSlopingVWires({ ...V_PARAMS, frequency: baseFreq * 2, length: total, legSlope: 10 }),
       );
 
-      // At 14.2 MHz the same physical length is 2λ → expect roughly 2× more segments.
-      expect(segsHigh).toBeGreaterThanOrEqual(segsLow * 1.8);
+      // At 14.2 MHz the same physical length is 2λ → tail count doubles.
+      // The graded prefix is a fixed handful, so the overall ratio is
+      // slightly less than 2.
+      expect(segsHigh).toBeGreaterThanOrEqual(segsLow * 1.7);
       expect(segsHigh).toBeLessThanOrEqual(segsLow * 2.2);
     });
 
@@ -83,22 +90,34 @@ describe('V-antenna wavelength-based segmentation', () => {
       const segs1 = legSegs(buildSlopingVWires({ ...V_PARAMS, frequency: freq, length: total1, legSlope: 10 }));
       const segs2 = legSegs(buildSlopingVWires({ ...V_PARAMS, frequency: freq, length: total2, legSlope: 10 }));
 
-      expect(segs2).toBeGreaterThanOrEqual(segs1 * 1.8);
-      expect(segs2).toBeLessThanOrEqual(MAX_SEGS_PER_LEG);
+      // Tail segments scale linearly with leg length; the graded prefix is
+      // a fixed handful of segments. So the ratio approaches 2 but is
+      // slightly biased downward by the shared prefix.
+      expect(segs2).toBeGreaterThanOrEqual(segs1 * 1.7);
+      expect(segs2).toBeLessThanOrEqual(segs1 * 2.2);
     });
   });
 
   describe('total segment count is bounded', () => {
-    it('very long sloping-V is capped at MAX_SEGS_PER_LEG per leg', () => {
+    it('very long sloping-V scales segments with leg length (no hard cap)', () => {
+      // With graded segmentation, the MAX_SEGS_PER_LEG cap no longer applies
+      // to the sloping V — segment count is driven by physics (λ/SEGS_PER_WAVELENGTH).
+      // total = 12λ + bridge → 6λ per leg → expect ~6 × SEGS_PER_WAVELENGTH = ~120
+      // tail segments plus a handful of graded prefix segments.
       const freq = 28.5;
       const lambda = wavelengthMeters(freq);
       const total = 12 * lambda + FEED_BRIDGE_LENGTH_M;
+      const legLambdas = (total - FEED_BRIDGE_LENGTH_M) / 2 / lambda;
       const wires = buildSlopingVWires({ ...V_PARAMS, frequency: freq, length: total, legSlope: 10 });
 
-      expect(legSegs(wires)).toBeLessThanOrEqual(MAX_SEGS_PER_LEG);
+      // At least roughly SEGS_PER_WAVELENGTH per λ of leg.
+      expect(legSegs(wires)).toBeGreaterThanOrEqual(legLambdas * SEGS_PER_WAVELENGTH * 0.9);
+      // No longer capped at the old MAX_SEGS_PER_LEG.
+      expect(legSegs(wires)).toBeGreaterThan(MAX_SEGS_PER_LEG);
     });
 
     it('very long inverted-V is capped at MAX_SEGS_PER_LEG per leg', () => {
+      // Inverted-V still uses uniform segmentation, so its cap still applies.
       const freq = 28.5;
       const lambda = wavelengthMeters(freq);
       const total = 12 * lambda + FEED_BRIDGE_LENGTH_M;
@@ -118,6 +137,80 @@ describe('V-antenna wavelength-based segmentation', () => {
         legSlope: 15,
       });
       expect(legSegs(wires)).toBeGreaterThanOrEqual(MIN_SEGS_PER_LEG);
+    });
+  });
+
+  describe('graded segmentation at the feed', () => {
+    function legSubWires(wires: Wire[], tag: number): Wire[] {
+      return wires.filter((w) => w.tag === tag);
+    }
+
+    // Approximate physical segment length implied by a Wire (NEC distributes
+    // segments evenly along its length).
+    function segmentLengthsOf(w: Wire): number[] {
+      const dx = w.end[0] - w.start[0];
+      const dy = w.end[1] - w.start[1];
+      const dz = w.end[2] - w.start[2];
+      const len = Math.sqrt(dx * dx + dy * dy + dz * dz);
+      return Array(w.segments).fill(len / w.segments);
+    }
+
+    /**
+     * Per-segment lengths along a leg, ordered from apex outward.
+     * Both legs are emitted with sub-wires concatenated head-to-tail, but
+     * with different orientations (left: tip→apex; right: apex→tip), so we
+     * reverse the left-leg order to get a consistent apex-outward sequence.
+     */
+    function apexToTipSegLengths(wires: Wire[], tag: number, side: 'left' | 'right'): number[] {
+      const subs = legSubWires(wires, tag);
+      const all: number[] = [];
+      for (const w of subs) all.push(...segmentLengthsOf(w));
+      return side === 'left' ? all.reverse() : all;
+    }
+
+    it('segment adjacent to the apex matches the feed-bridge length', () => {
+      const freq = 18.118;
+      const lambda = wavelengthMeters(freq);
+      const total = 20 * lambda + FEED_BRIDGE_LENGTH_M; // 10λ per leg
+      const wires = buildSlopingVWires({ ...V_PARAMS, frequency: freq, length: total, legSlope: 10 });
+
+      for (const tag of [DIPOLE_LEFT_TAG, DIPOLE_RIGHT_TAG] as const) {
+        const segs = apexToTipSegLengths(wires, tag, tag === DIPOLE_LEFT_TAG ? 'left' : 'right');
+        // First segment (closest to the apex source) should equal the bridge.
+        expect(segs[0]).toBeCloseTo(FEED_BRIDGE_LENGTH_M, 9);
+      }
+    });
+
+    it('adjacent segments along a leg never differ by more than 2.1×', () => {
+      const freq = 18.118;
+      const lambda = wavelengthMeters(freq);
+      const total = 20 * lambda + FEED_BRIDGE_LENGTH_M; // 10λ per leg
+      const wires = buildSlopingVWires({ ...V_PARAMS, frequency: freq, length: total, legSlope: 10 });
+
+      for (const tag of [DIPOLE_LEFT_TAG, DIPOLE_RIGHT_TAG] as const) {
+        const segs = apexToTipSegLengths(wires, tag, tag === DIPOLE_LEFT_TAG ? 'left' : 'right');
+        for (let i = 1; i < segs.length; i++) {
+          const a = segs[i - 1]!;
+          const b = segs[i]!;
+          const ratio = Math.max(a, b) / Math.min(a, b);
+          expect(ratio).toBeLessThanOrEqual(2.1);
+        }
+      }
+    });
+
+    it('graded prefix grows from bridge length up toward λ/SEGS_PER_WAVELENGTH', () => {
+      const freq = 18.118;
+      const lambda = wavelengthMeters(freq);
+      const total = 20 * lambda + FEED_BRIDGE_LENGTH_M; // 10λ per leg
+      const wires = buildSlopingVWires({ ...V_PARAMS, frequency: freq, length: total, legSlope: 10 });
+      const segs = apexToTipSegLengths(wires, DIPOLE_RIGHT_TAG, 'right');
+
+      // The first few segments should monotonically increase until plateauing
+      // at the uniform tail length, which is bounded by λ/SEGS_PER_WAVELENGTH.
+      const targetTail = lambda / SEGS_PER_WAVELENGTH;
+      expect(segs[0]).toBeLessThan(segs[3]!);
+      const lastSeg = segs[segs.length - 1]!;
+      expect(lastSeg).toBeLessThanOrEqual(targetTail * 1.05);
     });
   });
 


### PR DESCRIPTION
## Summary

Fix a NEC numerical-method failure that produced physically meaningless feedpoint impedance and depressed gain on multi-wavelength sloping-V antennas.

### Root cause

NEC's moment-method solver requires adjacent segment lengths to differ by no more than ~2×. With the previous uniform per-leg segmentation capped at `MAX_SEGS_PER_LEG = 100`, a long sloping V produced ~1.6 m leg segments adjacent to the 0.1 m feed bridge — a **16× ratio**. The solver's basis functions can't resolve the rapid current variation around such a mismatched source, so it converged to a wrong-but-self-consistent answer dominated by the bridge geometry: ~8 + j100 Ω feedpoint and a gain figure 8 dB below the antenna's true directivity.

### Fix

Each sloping-V leg is now emitted as a sequence of NEC wires with **graded (tapered) segment lengths**: starting at the bridge length (0.1 m) and doubling each step up to λ/`SEGS_PER_WAVELENGTH`, then continuing uniformly to the tip. All sub-wires share the leg's existing tag so current-ripple diagnostics, terminal-stub placement, and rendering continue to work without changes elsewhere.

- New `gradedSegmentPlan()` helper in `antennaGeometry.ts`
- `buildSlopingVWires()` rewritten to emit the prefix + uniform-tail structure
- Termination stub placement (`antennaStore.ts`) updated to find tip endpoints from multi-wire legs
- `MAX_SEGS_PER_LEG` cap no longer applies to sloping V (still applies to inverted-V / dipole / delta-loop, which keep uniform segmentation)

### Verification (real Wasm NEC engine, 10λ-per-leg V at 18.118 MHz)

|  | Before | After (real ground) | After (perfect ground) |
|---|---|---|---|
| Gain | 7.93 dBi | 8.3 dBi | **14.8 dBi** |
| Feedpoint R | 8.8 Ω | 920 Ω | 765 Ω |
| Feedpoint X | +j 93.8 Ω | −j 720 Ω | −j 2981 Ω |
| Adjacent-segment ratio at source | 16× ✗ | **1.0× ✓** | **1.0× ✓** |

Perfect-ground gain now matches Kraus theory (D ≈ 4·L_λ → 16 dBi) within ~1 dB. The remaining real-ground deficit is geometric (wire skimming 0.5 m above lossy ground), not numerical.

## Test plan

- [x] All 364 existing tests still pass
- [x] New tests verify graded-segmentation contract: first leg segment matches bridge, adjacent ratios ≤ 2.1×, prefix grows monotonically to ~λ/SEGS_PER_WAVELENGTH
- [x] End-to-end verified against real Wasm NEC engine with a termination sweep at the user's reported configuration


---
_Generated by [Claude Code](https://claude.ai/code/session_01NQ1FS1vku3nahWcCkVEwGJ)_