### PR TITLE
Remove ctrl+C keyboard shortcut for comparison mode

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -131,7 +131,6 @@ function useKeyboardShortcuts(): void {
       if (e.key === 't' || e.key === 'T') toggleTheme();
       else if (e.key === 'u' || e.key === 'U') toggleUnits();
       else if (e.key === 'n' || e.key === 'N') setMode('nvis');
-      else if (e.key === 'c' || e.key === 'C') setMode('comparison');
       else if (e.key === 'm' || e.key === 'M') setMode('normal');
     };
     window.addEventListener('keydown', handler);


### PR DESCRIPTION
Removes the 'c'/'C' key binding that activated comparison mode, as it interfered with the standard copy (Ctrl+C) operation.

Closes #203

Generated with [Claude Code](https://claude.ai/code)