### PR TITLE
Add Terminated Delta antenna with per-stub shunt-to-earth termination

### DIFF
--- a/src/components/Panel/ControlPanel.tsx
+++ b/src/components/Panel/ControlPanel.tsx
@@ -11,7 +11,6 @@ import { PolarPlots } from '../Charts/PolarPlots';
 import { ThemeToggle } from '../UI/ThemeToggle';
 import { UnitToggle } from './UnitToggle';
 import { ComparisonControl } from './ComparisonControl';
-import { TransformerControl } from './TransformerControl';
 
 export function ControlPanel() {
   return (
@@ -44,7 +43,6 @@ export function ControlPanel() {
       <GroundControl />
       <FeedlineControl />
       <StatsReadout />
-      <TransformerControl />
       <SWRChart />
       <PolarPlots />
       <PropagationControl />

--- a/src/components/Panel/DipoleControl.tsx
+++ b/src/components/Panel/DipoleControl.tsx
@@ -86,6 +86,7 @@ export function DipoleControl() {
     'inverted-v': '½λ',
     'delta-loop': '1λ',
     'sloping-v': '1λ/leg',
+    'terminated-delta': '1λ',
   };
 
   const resonateTitles: Record<AntennaType, string> = {
@@ -93,6 +94,7 @@ export function DipoleControl() {
     'inverted-v': 'Set length to resonant ½λ',
     'delta-loop': 'Set perimeter to resonant 1λ',
     'sloping-v': 'Set total length to 2λ (1λ per leg)',
+    'terminated-delta': 'Set perimeter to 1λ',
   };
 
   return (
@@ -111,6 +113,7 @@ export function DipoleControl() {
         <option value="inverted-v">Inverted V</option>
         <option value="sloping-v">Sloping V</option>
         <option value="delta-loop">Delta Loop</option>
+        <option value="terminated-delta">Terminated Delta</option>
       </select>
 
       <label htmlFor="dipole-length" style={{ marginTop: 10 }}>Length ({unit})</label>
@@ -194,7 +197,7 @@ export function DipoleControl() {
         </>
       )}
 
-      {(antennaType === 'sloping-v' || antennaType === 'delta-loop') && (
+      {(antennaType === 'sloping-v' || antennaType === 'delta-loop' || antennaType === 'terminated-delta') && (
         <>
           <label htmlFor="terminating-resistor" style={{ marginTop: 10 }}>
             Termination resistance (Ω)
@@ -233,7 +236,9 @@ export function DipoleControl() {
               ? 'Unterminated: travelling wave reflects, creating a standing-wave pattern.'
               : antennaType === 'sloping-v'
                 ? `${terminatingResistor} Ω resistors at each tip (to ground). Affects gain, directivity, front/back ratio, feedpoint impedance, realized gain, and termination loss. Lower SWR alone does not indicate the best design point.`
-                : `${terminatingResistor} Ω load at the base centre. Affects gain, directivity, feedpoint impedance, realized gain, and termination loss. Lower SWR alone does not indicate the best design point.`}
+                : antennaType === 'terminated-delta'
+                  ? `${terminatingResistor} Ω resistors at each inner half-base end (to ground via short stubs). Affects gain, directivity, front/back ratio, feedpoint impedance, realized gain, and termination loss. Lower SWR alone does not indicate the best design point.`
+                  : `${terminatingResistor} Ω load at the base centre. Affects gain, directivity, feedpoint impedance, realized gain, and termination loss. Lower SWR alone does not indicate the best design point.`}
           </div>
         </>
       )}

--- a/src/components/Panel/DipoleControl.tsx
+++ b/src/components/Panel/DipoleControl.tsx
@@ -10,6 +10,7 @@ import {
   type AntennaType,
 } from '../../store/antennaStore';
 import { FEED_BRIDGE_LENGTH_M, SLOPING_V_MIN_TIP_Z_M } from '../../physics/constants';
+import { TransformerControl } from './TransformerControl';
 
 export function DipoleControl() {
   const units = useAntennaStore((s) => s.units);
@@ -233,12 +234,12 @@ export function DipoleControl() {
           </div>
           <div id="terminating-resistor-hint" style={{ marginTop: 6, fontSize: 11, color: 'var(--text-muted)', lineHeight: 1.4 }}>
             {terminatingResistor === 0
-              ? 'Unterminated: travelling wave reflects, creating a standing-wave pattern.'
+              ? 'Unterminated: travelling wave reflects, creating a standing-wave pattern. Use this mode to check whether the antenna structure resonates at the design frequency.'
               : antennaType === 'sloping-v'
-                ? `${terminatingResistor} Ω resistors at each tip (to ground). Affects gain, directivity, front/back ratio, feedpoint impedance, realized gain, and termination loss. Lower SWR alone does not indicate the best design point.`
+                ? `${terminatingResistor} Ω resistors at each tip (to ground). Click Off to remove termination and inspect resonance. Affects gain, directivity, front/back ratio, feedpoint impedance, realized gain, and termination loss. Lower SWR alone does not indicate the best design point.`
                 : antennaType === 'terminated-delta'
-                  ? `${terminatingResistor} Ω resistors at each inner half-base end (to ground via short stubs). Affects gain, directivity, front/back ratio, feedpoint impedance, realized gain, and termination loss. Lower SWR alone does not indicate the best design point.`
-                  : `${terminatingResistor} Ω load at the base centre. Affects gain, directivity, feedpoint impedance, realized gain, and termination loss. Lower SWR alone does not indicate the best design point.`}
+                  ? `${terminatingResistor} Ω resistors at each inner half-base end (to ground via short stubs). Click Off to remove termination and inspect resonance. Affects gain, directivity, front/back ratio, feedpoint impedance, realized gain, and termination loss. Lower SWR alone does not indicate the best design point.`
+                  : `${terminatingResistor} Ω load at the base centre. Click Off to remove termination and inspect resonance. Affects gain, directivity, feedpoint impedance, realized gain, and termination loss. Lower SWR alone does not indicate the best design point.`}
           </div>
         </>
       )}
@@ -282,6 +283,11 @@ export function DipoleControl() {
           </button>
         ))}
       </div>
+
+      {/* Transformer / balun: part of the antenna's feedpoint hardware
+          (applied before the NEC simulation), so it belongs in the Antenna
+          panel rather than as a separate top-level section. */}
+      <TransformerControl />
     </section>
   );
 }

--- a/src/components/Panel/FeedlineControl.tsx
+++ b/src/components/Panel/FeedlineControl.tsx
@@ -40,7 +40,7 @@ export function FeedlineControl() {
     }
   }
 
-  if (!['dipole', 'inverted-v', 'delta-loop', 'sloping-v'].includes(antennaType)) return null;
+  if (!['dipole', 'inverted-v', 'delta-loop', 'sloping-v', 'terminated-delta'].includes(antennaType)) return null;
 
   const offsetLimit = Math.max(0, dipoleLength / 2 - 0.05);
   const dispOffsetLimit = toDisplayLength(offsetLimit, units);

--- a/src/components/Panel/TransformerControl.tsx
+++ b/src/components/Panel/TransformerControl.tsx
@@ -1,6 +1,13 @@
 import { useAntennaStore } from '../../store/antennaStore';
 import { TRANSFORMER_INSERTION_LOSS_DB } from '../../physics/constants';
 
+/**
+ * Transformer / balun controls. Rendered as an in-line sub-block (no outer
+ * panel-section) so it can be embedded inside the Antenna panel — the
+ * transformer is part of the antenna's feedpoint hardware (it applies
+ * before the simulation), so it belongs visually with the antenna geometry
+ * controls rather than as a separate top-level section.
+ */
 export function TransformerControl() {
   const transformerEnabled = useAntennaStore((s) => s.transformerEnabled);
   const transformerRatio = useAntennaStore((s) => s.transformerRatio);
@@ -8,9 +15,19 @@ export function TransformerControl() {
   const setTransformerRatio = useAntennaStore((s) => s.setTransformerRatio);
 
   return (
-    <section className="panel-section">
-      {/* SEO: Use sequential heading tags (H2) to follow document outline initiated by H1 */}
-      <h2>Transformer at feedpoint</h2>
+    <div style={{ marginTop: 14, paddingTop: 12, borderTop: '1px solid var(--border)' }}>
+      <h3
+        style={{
+          fontSize: 12,
+          fontWeight: 700,
+          textTransform: 'uppercase',
+          letterSpacing: '0.06em',
+          color: 'var(--text-dim)',
+          margin: '0 0 8px 0',
+        }}
+      >
+        Transformer at feedpoint
+      </h3>
       <label
         htmlFor="transformer-enable"
         style={{ display: 'flex', alignItems: 'center', gap: 6, textTransform: 'none', letterSpacing: 0, margin: 0, fontSize: 12 }}
@@ -59,6 +76,6 @@ export function TransformerControl() {
           unbalanced feeds).
         </div>
       )}
-    </section>
+    </div>
   );
 }

--- a/src/components/Scene/DipoleWire.tsx
+++ b/src/components/Scene/DipoleWire.tsx
@@ -23,8 +23,11 @@ import {
   DIPOLE_RIGHT_TAG,
   FEED_BRIDGE_TAG,
   FEEDLINE_SHIELD_TAG,
+  TERMINATED_DELTA_LEFT_BASE_TAG,
+  TERMINATED_DELTA_RIGHT_BASE_TAG,
   type Orientation,
 } from '../../store/antennaStore';
+import { SLOPING_V_STUB_BOTTOM_Z_M } from '../../physics/constants';
 import type { AntennaType } from '../../physics/types';
 import { THEME_COLORS } from '../../utils/themeColors';
 
@@ -60,6 +63,7 @@ export function DipoleWire({
   const vAngle = useAntennaStore((s) => s.vAngle);
   const legSlope = useAntennaStore((s) => s.legSlope);
   const frequency = useAntennaStore((s) => s.frequency);
+  const terminatingResistor = useAntennaStore((s) => s.terminatingResistor);
 
   const rendered = useMemo(() => {
     const wires = buildWires({
@@ -127,6 +131,34 @@ export function DipoleWire({
   // Feedpoint: bridge midpoint (split-fed) > apex-fed left-leg end > dipole wire midpoint (single-wire legacy).
   const feedpoint = bridge?.feedMid ?? apexFedLeft?.sceneEnd ?? dipoleSingle?.feedMid ?? null;
 
+  // Terminated Delta: locate the two half-base inner ends so we can render
+  // visible "split" markers (always) and the stub-to-ground + resistor
+  // decorations (only when termination is active). The half-base wires are
+  // oriented:
+  //   LEFT  half-base:  leftCorner  → centreLeft   → .sceneEnd is the inner end
+  //   RIGHT half-base:  centreRight → rightCorner  → .sceneStart is the inner end
+  const terminatedDeltaSplit = useMemo(() => {
+    if (type !== 'terminated-delta') return null;
+    const leftHalfBase = rendered.find((s) => s.tag === TERMINATED_DELTA_LEFT_BASE_TAG);
+    const rightHalfBase = rendered.find((s) => s.tag === TERMINATED_DELTA_RIGHT_BASE_TAG);
+    if (!leftHalfBase || !rightHalfBase) return null;
+    const leftInner = leftHalfBase.sceneEnd;
+    const rightInner = rightHalfBase.sceneStart;
+    // Stub goes vertically down (in scene Y) from the inner end at the
+    // bottom-corner height to the near-ground floor used in the NEC model.
+    const stubLength = Math.max(0, leftInner[1] - SLOPING_V_STUB_BOTTOM_Z_M);
+    const leftStubMid: [number, number, number] = [leftInner[0], leftInner[1] - stubLength / 2, leftInner[2]];
+    const rightStubMid: [number, number, number] = [rightInner[0], rightInner[1] - stubLength / 2, rightInner[2]];
+    return {
+      leftInner,
+      rightInner,
+      leftStubMid,
+      rightStubMid,
+      stubLength,
+      stubRadius: Math.max(wireRadius * 8, 0.03),
+    };
+  }, [type, rendered, wireRadius]);
+
   return (
     <group>
       {rendered.map((s) => (
@@ -173,6 +205,96 @@ export function DipoleWire({
           <boxGeometry args={[0.4, 0.25, 0.5]} />
           <meshStandardMaterial color="#444" emissive="#222" emissiveIntensity={0.15} metalness={0.6} roughness={0.5} />
         </mesh>
+      )}
+      {terminatedDeltaSplit && (
+        <>
+          {/* Always show small marker spheres at each half-base inner end —
+              makes the split-base topology unambiguously visible (without
+              these the 0.1 m gap reads as a continuous base from a distance,
+              which is the user-visible difference vs. a Delta Loop). */}
+          <mesh position={terminatedDeltaSplit.leftInner}>
+            <sphereGeometry args={[0.11, 12, 12]} />
+            <meshStandardMaterial
+              color={THEME_COLORS[theme].wire}
+              emissive={THEME_COLORS[theme].wire}
+              emissiveIntensity={0.2}
+              metalness={0.8}
+              roughness={0.4}
+            />
+          </mesh>
+          <mesh position={terminatedDeltaSplit.rightInner}>
+            <sphereGeometry args={[0.11, 12, 12]} />
+            <meshStandardMaterial
+              color={THEME_COLORS[theme].wire}
+              emissive={THEME_COLORS[theme].wire}
+              emissiveIntensity={0.2}
+              metalness={0.8}
+              roughness={0.4}
+            />
+          </mesh>
+
+          {/* When terminated (R > 0): render the vertical stub wires
+              dropping from each inner end to near-ground, with a small
+              red resistor marker on each stub. This matches the NEC deck
+              that selectSimulationInput emits and gives the user a clear
+              visual of "where the resistor sits". */}
+          {terminatingResistor > 0 && terminatedDeltaSplit.stubLength > 1e-3 && (
+            <>
+              <mesh position={terminatedDeltaSplit.leftStubMid}>
+                <cylinderGeometry args={[
+                  terminatedDeltaSplit.stubRadius,
+                  terminatedDeltaSplit.stubRadius,
+                  terminatedDeltaSplit.stubLength,
+                  12,
+                ]} />
+                <meshStandardMaterial
+                  color={THEME_COLORS[theme].wire}
+                  emissive={THEME_COLORS[theme].wire}
+                  emissiveIntensity={0.15}
+                  metalness={0.85}
+                  roughness={0.35}
+                />
+              </mesh>
+              <mesh position={terminatedDeltaSplit.rightStubMid}>
+                <cylinderGeometry args={[
+                  terminatedDeltaSplit.stubRadius,
+                  terminatedDeltaSplit.stubRadius,
+                  terminatedDeltaSplit.stubLength,
+                  12,
+                ]} />
+                <meshStandardMaterial
+                  color={THEME_COLORS[theme].wire}
+                  emissive={THEME_COLORS[theme].wire}
+                  emissiveIntensity={0.15}
+                  metalness={0.85}
+                  roughness={0.35}
+                />
+              </mesh>
+
+              {/* Resistor markers: short fat coloured cylinders straddling the
+                  stub midpoint. Same red as the conventional resistor body
+                  colour so it's instantly readable as "this is a resistor". */}
+              <mesh position={terminatedDeltaSplit.leftStubMid}>
+                <cylinderGeometry args={[
+                  terminatedDeltaSplit.stubRadius * 3.5,
+                  terminatedDeltaSplit.stubRadius * 3.5,
+                  Math.min(0.35, terminatedDeltaSplit.stubLength * 0.4),
+                  12,
+                ]} />
+                <meshStandardMaterial color="#c93434" emissive="#c93434" emissiveIntensity={0.35} metalness={0.2} roughness={0.6} />
+              </mesh>
+              <mesh position={terminatedDeltaSplit.rightStubMid}>
+                <cylinderGeometry args={[
+                  terminatedDeltaSplit.stubRadius * 3.5,
+                  terminatedDeltaSplit.stubRadius * 3.5,
+                  Math.min(0.35, terminatedDeltaSplit.stubLength * 0.4),
+                  12,
+                ]} />
+                <meshStandardMaterial color="#c93434" emissive="#c93434" emissiveIntensity={0.35} metalness={0.2} roughness={0.6} />
+              </mesh>
+            </>
+          )}
+        </>
       )}
     </group>
   );

--- a/src/components/Scene/DipoleWire.tsx
+++ b/src/components/Scene/DipoleWire.tsx
@@ -119,11 +119,13 @@ export function DipoleWire({
   const dipoleSingle = rendered.find((s) => s.tag === DIPOLE_TAG && !bridge);
   const shield = rendered.find((s) => s.isShield);
 
-  // Delta Loop: left leg runs tip→apex; sceneEnd is the apex point.
-  const deltaLoopLeft = type === 'delta-loop' ? (rendered.find((s) => s.tag === DIPOLE_LEFT_TAG) ?? null) : null;
+  // Delta Loop and Terminated Delta: left leg runs corner→apex; sceneEnd is the apex point.
+  const apexFedLeft = (type === 'delta-loop' || type === 'terminated-delta')
+    ? (rendered.find((s) => s.tag === DIPOLE_LEFT_TAG) ?? null)
+    : null;
 
-  // Feedpoint: bridge midpoint (split-fed) > delta loop apex > dipole wire midpoint (single-wire legacy).
-  const feedpoint = bridge?.feedMid ?? deltaLoopLeft?.sceneEnd ?? dipoleSingle?.feedMid ?? null;
+  // Feedpoint: bridge midpoint (split-fed) > apex-fed left-leg end > dipole wire midpoint (single-wire legacy).
+  const feedpoint = bridge?.feedMid ?? apexFedLeft?.sceneEnd ?? dipoleSingle?.feedMid ?? null;
 
   return (
     <group>

--- a/src/physics/constants.ts
+++ b/src/physics/constants.ts
@@ -39,6 +39,7 @@ export function halfWaveLength(frequencyMHz: number, endEffect = 0.95): number {
  *   - inverted-v: 0.485λ total (0.5λ × 0.97 end-effect) per spec.
  *   - delta-loop: 1λ perimeter.
  *   - sloping-v: 2λ total (1λ per leg).
+ *   - terminated-delta: 1λ perimeter (same triangle as delta-loop).
  *
  * Applies the standard HF end-effect factor k ~ 0.95 where noted.
  */
@@ -54,6 +55,11 @@ export function referenceLength(type: AntennaType, frequencyMHz: number, endEffe
       return lambda * 1.0 * endEffect;
     case 'sloping-v':
       return lambda * 2.0 * endEffect;
+    case 'terminated-delta':
+      // Same physical perimeter as a delta loop. Resonance is irrelevant in
+      // a true terminated configuration (the wave is absorbed before it can
+      // reflect), but 1λ is the canonical starting point.
+      return lambda * 1.0 * endEffect;
     default:
       return lambda * 0.5 * endEffect;
   }
@@ -127,6 +133,34 @@ export const SLOPING_V_MIN_TIP_Z_M = 0.5;
  */
 export const SLOPING_V_LEFT_STUB_TAG = 7;
 export const SLOPING_V_RIGHT_STUB_TAG = 8;
+
+/**
+ * Wire tags for the Terminated Delta antenna.
+ *
+ * The terminated delta is the same isosceles triangle as a delta loop with
+ * the apex at the top and feedpoint at the apex (DIPOLE_LEFT_TAG /
+ * DIPOLE_RIGHT_TAG carry the two top legs, exactly as in the delta loop).
+ *
+ * The base wire is **split** in the middle into two independent half-base
+ * wires, each running inward from its corner toward (but not touching) the
+ * centre. At the inner end of each half-base, a short vertical stub drops
+ * to near-ground and carries the terminating resistor — the same per-tip
+ * shunt-to-earth topology used by the sloping-V termination.
+ */
+export const TERMINATED_DELTA_LEFT_BASE_TAG = 9;
+export const TERMINATED_DELTA_RIGHT_BASE_TAG = 10;
+export const TERMINATED_DELTA_LEFT_STUB_TAG = 11;
+export const TERMINATED_DELTA_RIGHT_STUB_TAG = 12;
+
+/**
+ * Gap (metres) between the inner ends of the two terminated-delta
+ * half-base wires at the centre of the base. The two halves must not meet
+ * (otherwise they'd short across the termination), so we leave a small
+ * physical gap matched to FEED_BRIDGE_LENGTH_M so the geometry stays
+ * NEC-valid (no coincident wires) without materially altering the
+ * radiating perimeter.
+ */
+export const TERMINATED_DELTA_CENTRE_GAP_M = FEED_BRIDGE_LENGTH_M;
 
 /**
  * Z-coordinate of the bottom endpoint of the sloping-V termination stubs,

--- a/src/physics/types.ts
+++ b/src/physics/types.ts
@@ -9,8 +9,11 @@ export type Vec3 = readonly [number, number, number];
  *   - dipole / inverted-v: ½λ total (standard resonant length).
  *   - delta-loop: 1λ perimeter.
  *   - sloping-v: 2λ total (1λ per leg).
+ *   - terminated-delta: 1λ perimeter (same triangle shape as a delta loop,
+ *     but the base is split in the middle and each half terminates to
+ *     ground through its own resistor, like a per-tip sloping-V termination).
  */
-export type AntennaType = 'dipole' | 'inverted-v' | 'delta-loop' | 'sloping-v';
+export type AntennaType = 'dipole' | 'inverted-v' | 'delta-loop' | 'sloping-v' | 'terminated-delta';
 
 export interface Wire {
   readonly start: Vec3;

--- a/src/store/antennaGeometry.ts
+++ b/src/store/antennaGeometry.ts
@@ -7,6 +7,9 @@ import {
   FEED_BRIDGE_LENGTH_M,
   DELTA_BASE_TAG,
   FEEDLINE_SHIELD_TAG,
+  TERMINATED_DELTA_LEFT_BASE_TAG,
+  TERMINATED_DELTA_RIGHT_BASE_TAG,
+  TERMINATED_DELTA_CENTRE_GAP_M,
 } from '../physics/constants';
 import type { Wire } from '../physics/types';
 
@@ -446,6 +449,157 @@ export function buildDeltaLoopWires(params: DeltaLoopWiresParams): Wire[] {
       radius: params.wireRadius,
       segments: baseSegments,
       tag: DELTA_BASE_TAG,
+    },
+  ];
+
+  if (params.feedlineShield) {
+    wires.push({
+      start: apexLeft,
+      end: apexRight,
+      radius: params.wireRadius,
+      segments: 1,
+      tag: FEED_BRIDGE_TAG,
+    });
+    wires.push({
+      start: apexRight,
+      end: [apexRight[0], apexRight[1], params.feedlineShield.bottomZ],
+      radius: params.feedlineShield.radius,
+      segments: params.feedlineShield.segments,
+      tag: FEEDLINE_SHIELD_TAG,
+    });
+  }
+
+  return wires;
+}
+
+export interface TerminatedDeltaWiresParams {
+  length: number; // perimeter
+  height: number;
+  orientation: Orientation;
+  wireRadius: number;
+  segments: number;
+  frequency: number;
+  feedlineShield?: FeedlineShield | null;
+}
+
+/**
+ * Builds the wires for a Terminated Delta antenna (apex-up, apex-fed).
+ *
+ * Geometry is identical to the Delta Loop's isosceles triangle: same
+ * perimeter-preserving leg/base math, same equilateral-when-possible
+ * shape, same apex feed convention. The only structural difference is
+ * that the base is **split in the middle** into two independent
+ * half-base wires separated by `TERMINATED_DELTA_CENTRE_GAP_M`. Each
+ * half-base ends near the centre and the termination network (vertical
+ * stub + LD-4 resistor) is added in selectSimulationInput when the user
+ * specifies a non-zero terminating resistance — mirroring the
+ * physically-correct sloping-V tip-to-earth shunt termination.
+ *
+ * Tags:
+ *   DIPOLE_LEFT_TAG               (1)  — top-left leg:  leftCorner → apex
+ *   DIPOLE_RIGHT_TAG              (2)  — top-right leg: apex → rightCorner
+ *   TERMINATED_DELTA_LEFT_BASE_TAG  (9)  — left half-base:  leftCorner → centreLeft
+ *   TERMINATED_DELTA_RIGHT_BASE_TAG (10) — right half-base: centreRight → rightCorner
+ *
+ * Excitation is placed on the last segment of DIPOLE_LEFT_TAG (the apex
+ * end), or on the feed bridge / shield when a feedline is active —
+ * exactly as for the delta loop.
+ */
+export function buildTerminatedDeltaWires(params: TerminatedDeltaWiresParams): Wire[] {
+  const perimeter = params.length;
+  const h = params.height;
+  const [dx, dy] = orientationVector(params.orientation);
+
+  // Maximum available triangle height given the mast height.
+  // Identical to the delta loop's geometry math so that the two
+  // antennas occupy the same physical envelope for the same length.
+  const equilateralHeight = (perimeter * Math.sqrt(3)) / 6;
+  const maxAvailable = Math.max(0, h - SLOPING_V_MIN_TIP_Z_M);
+  const triHeight = Math.min(equilateralHeight, maxAvailable);
+
+  const bottomZ = h - triHeight;
+
+  // Isosceles triangle with fixed perimeter P and height t:
+  //   leg  = t²/P + P/4
+  //   base = P − 2·leg  →  halfBase = P/4 − t²/P
+  const legLength = (triHeight * triHeight) / perimeter + perimeter / 4;
+  const halfBase = perimeter / 4 - (triHeight * triHeight) / perimeter;
+
+  const bridgeHalf = FEED_BRIDGE_LENGTH_M / 2;
+  const apex: [number, number, number] = [0, 0, h];
+
+  // When a feedline is active we split the apex with a source bridge so
+  // the TL card can connect to it, just like the delta loop topology.
+  const apexLeft: [number, number, number] = params.feedlineShield
+    ? [-bridgeHalf * dx, -bridgeHalf * dy, h]
+    : apex;
+  const apexRight: [number, number, number] = params.feedlineShield
+    ? [bridgeHalf * dx, bridgeHalf * dy, h]
+    : apex;
+
+  const leftCorner: [number, number, number] = [-halfBase * dx, -halfBase * dy, bottomZ];
+  const rightCorner: [number, number, number] = [halfBase * dx, halfBase * dy, bottomZ];
+
+  // Inner ends of the two half-base wires. They sit slightly to the left
+  // and right of the geometric centre with a gap of TERMINATED_DELTA_CENTRE_GAP_M
+  // between them — the gap is electrically open in the unterminated case
+  // and is bridged by the stub+resistor pair to ground when terminated.
+  const innerOffset = Math.max(0, TERMINATED_DELTA_CENTRE_GAP_M / 2);
+  const innerHalfBase = Math.max(0.01, halfBase - innerOffset);
+  const centreLeft: [number, number, number] = [-innerOffset * dx, -innerOffset * dy, bottomZ];
+  const centreRight: [number, number, number] = [innerOffset * dx, innerOffset * dy, bottomZ];
+
+  const lambda = wavelengthMeters(params.frequency);
+
+  const minLegSegs = Math.ceil((SEGS_PER_WAVELENGTH * legLength) / lambda);
+  const segmentsPerLeg = Math.min(
+    MAX_SEGS_PER_LEG,
+    Math.max(MIN_SEGS_PER_LEG, minLegSegs, Math.round(params.segments / 3)),
+  );
+
+  const minHalfBaseSegs = Math.ceil((SEGS_PER_WAVELENGTH * innerHalfBase) / lambda);
+  const halfBaseSegments = Math.min(
+    MAX_SEGS_PER_LEG,
+    Math.max(MIN_SEGS_PER_LEG, minHalfBaseSegs, Math.round(params.segments / 6)),
+  );
+
+  // Half-base wires are oriented so that the segment adjacent to the
+  // termination is the LAST segment of the wire — analogous to the way
+  // the delta loop's left leg is oriented so its last segment is at the
+  // apex feed. This gives the termination diagnostics a consistent
+  // "current at the loaded end" interpretation.
+  //   LEFT  half-base:  leftCorner  → centreLeft   (last seg = inner end)
+  //   RIGHT half-base:  centreRight → rightCorner  (first seg = inner end)
+  // We keep the right-leg ordering "outward" for symmetry with the
+  // delta-loop's right-leg convention (apex → rightCorner).
+  const wires: Wire[] = [
+    {
+      start: leftCorner,
+      end: apexLeft,
+      radius: params.wireRadius,
+      segments: segmentsPerLeg,
+      tag: DIPOLE_LEFT_TAG,
+    },
+    {
+      start: apexRight,
+      end: rightCorner,
+      radius: params.wireRadius,
+      segments: segmentsPerLeg,
+      tag: DIPOLE_RIGHT_TAG,
+    },
+    {
+      start: leftCorner,
+      end: centreLeft,
+      radius: params.wireRadius,
+      segments: halfBaseSegments,
+      tag: TERMINATED_DELTA_LEFT_BASE_TAG,
+    },
+    {
+      start: centreRight,
+      end: rightCorner,
+      radius: params.wireRadius,
+      segments: halfBaseSegments,
+      tag: TERMINATED_DELTA_RIGHT_BASE_TAG,
     },
   ];
 

--- a/src/store/antennaStore.ts
+++ b/src/store/antennaStore.ts
@@ -40,6 +40,10 @@ import {
   SLOPING_V_LEFT_STUB_TAG,
   SLOPING_V_RIGHT_STUB_TAG,
   SLOPING_V_STUB_BOTTOM_Z_M,
+  TERMINATED_DELTA_LEFT_BASE_TAG,
+  TERMINATED_DELTA_RIGHT_BASE_TAG,
+  TERMINATED_DELTA_LEFT_STUB_TAG,
+  TERMINATED_DELTA_RIGHT_STUB_TAG,
 } from '../physics/constants';
 
 // Re-export geometry tags for UI and tests.
@@ -53,12 +57,17 @@ export {
   DELTA_BASE_TAG,
   SLOPING_V_LEFT_STUB_TAG,
   SLOPING_V_RIGHT_STUB_TAG,
+  TERMINATED_DELTA_LEFT_BASE_TAG,
+  TERMINATED_DELTA_RIGHT_BASE_TAG,
+  TERMINATED_DELTA_LEFT_STUB_TAG,
+  TERMINATED_DELTA_RIGHT_STUB_TAG,
 };
 import type { UnitSystem } from '../physics/units';
 import {
   buildInvertedVWires,
   buildSlopingVWires,
   buildDeltaLoopWires,
+  buildTerminatedDeltaWires,
   orientationVector,
   type OrientationPreset,
   type Orientation,
@@ -121,6 +130,8 @@ export interface AntennaState {
    *
    * - sloping-V: inserts stub wires with NEC LD cards for tip-to-earth termination.
    * - delta-loop: inserts one NEC LD 4 card at the centre of the base wire.
+   * - terminated-delta: inserts two stub wires (one at each inner half-base
+   *   end) with NEC LD cards, modelling per-resistor shunt-to-earth termination.
    */
   terminatingResistor: number;
 
@@ -278,7 +289,7 @@ export const useAntennaStore = create<AntennaState>()(
 
       setAntennaType: (type) => set((s) => {
         s.antennaType = type;
-        const feedlineSupportedTypes = ['dipole', 'inverted-v', 'delta-loop', 'sloping-v'];
+        const feedlineSupportedTypes = ['dipole', 'inverted-v', 'delta-loop', 'sloping-v', 'terminated-delta'];
         if (!feedlineSupportedTypes.includes(type)) {
           s.feedlineId = 'none';
           s.feedlineLength = 0;
@@ -306,6 +317,12 @@ export const useAntennaStore = create<AntennaState>()(
         } else if (type === 'delta-loop') {
           s.vAngle = 180;
           s.legSlope = 0;
+        } else if (type === 'terminated-delta') {
+          s.vAngle = 180;
+          s.legSlope = 0;
+          // Per-stub default mirrors the sloping-V (each tip independently
+          // terminated to ground); 300 Ω matches the canonical reference design.
+          if (s.terminatingResistor === 0) s.terminatingResistor = 300;
         }
 
         const limit = Math.max(0, s.length / 2 - FEED_BRIDGE_LENGTH_M);
@@ -560,6 +577,9 @@ function calculateDefaultLength(type: AntennaType, frequencyMHz: number): number
       return lambda;
     case 'sloping-v':
       return lambda * 2;
+    case 'terminated-delta':
+      // Same physical perimeter as a delta loop.
+      return lambda;
     default:
       return halfWaveLength(frequencyMHz);
   }
@@ -662,6 +682,22 @@ export function buildWires(
     });
   }
 
+  if (antennaType === 'terminated-delta') {
+    const layout = computeFeedlineLayout(state);
+    const feedlineShield = layout?.shield
+      ? { ...layout.shield, segments: FEEDLINE_SHIELD_SEGMENTS }
+      : null;
+    return buildTerminatedDeltaWires({
+      length: state.length,
+      height: h,
+      orientation: state.orientation,
+      wireRadius: state.wireRadius,
+      segments: state.segments,
+      frequency: state.frequency,
+      feedlineShield,
+    });
+  }
+
   const [dx, dy] = orientationVector(state.orientation);
   const cleanZero = (v: number): number => (v === 0 ? 0 : v);
 
@@ -748,7 +784,7 @@ function computeFeedlineLayout(
   state: Pick<AntennaState, 'length' | 'height'> &
     Partial<Pick<AntennaState, 'antennaType' | 'feedlineId' | 'feedlineLength' | 'feedlineOffset'>>,
 ): FeedlineLayout | null {
-  const feedlineSupportedTypes = ['dipole', 'inverted-v', 'delta-loop', 'sloping-v'];
+  const feedlineSupportedTypes = ['dipole', 'inverted-v', 'delta-loop', 'sloping-v', 'terminated-delta'];
   if (!feedlineSupportedTypes.includes(state.antennaType ?? '')) return null;
 
   const id = state.feedlineId;
@@ -803,7 +839,7 @@ export function selectSimulationInput(state: AntennaState): SimulationInput {
   const wires = buildWires(state);
   const hasShield = wires.some((w) => w.tag === FEEDLINE_SHIELD_TAG);
   const hasBridge = wires.some((w) => w.tag === FEED_BRIDGE_TAG);
-  const feedlineSupport = ['dipole', 'inverted-v', 'delta-loop', 'sloping-v'].includes(state.antennaType);
+  const feedlineSupport = ['dipole', 'inverted-v', 'delta-loop', 'sloping-v', 'terminated-delta'].includes(state.antennaType);
   const feedlineActive = hasBridge && feedlineSupport;
 
   let excitation;
@@ -811,7 +847,9 @@ export function selectSimulationInput(state: AntennaState): SimulationInput {
     excitation = { wireTag: FEEDLINE_SHIELD_TAG, segment: FEEDLINE_SHIELD_SEGMENTS };
   } else if (hasBridge) {
     excitation = { wireTag: FEED_BRIDGE_TAG, segment: 1 };
-  } else if (state.antennaType === 'delta-loop') {
+  } else if (state.antennaType === 'delta-loop' || state.antennaType === 'terminated-delta') {
+    // Apex-fed: excitation lives on the last segment of the left leg
+    // (whose .end is the apex by convention in build*Wires).
     const leftLeg = wires.find((w) => w.tag === DIPOLE_LEFT_TAG)!;
     excitation = { wireTag: DIPOLE_LEFT_TAG, segment: leftLeg.segments };
   } else {
@@ -904,6 +942,46 @@ export function selectSimulationInput(state: AntennaState): SimulationInput {
     loads.push(
       { type: 4, wireTag: SLOPING_V_LEFT_STUB_TAG,  segmentStart: 1, segmentEnd: 1, param1: R, param2: 0 },
       { type: 4, wireTag: SLOPING_V_RIGHT_STUB_TAG, segmentStart: 1, segmentEnd: 1, param1: R, param2: 0 },
+    );
+  }
+
+  if (state.antennaType === 'terminated-delta' && state.terminatingResistor > 0) {
+    const R = state.terminatingResistor;
+    // Per-stub shunt termination to ground, mirroring the sloping-V
+    // tip-to-earth pattern exactly. Each half-base ends near the centre
+    // at z = bottomZ; a short vertical stub takes that point down to
+    // near-ground (SLOPING_V_STUB_BOTTOM_Z_M) and the LD-4 card places
+    // the resistance in the stub. This produces an explicit NEC current
+    // path through the resistor to the ground plane, which the
+    // Sommerfeld-Norton model resolves correctly.
+    //
+    // The LEFT half-base is emitted leftCorner → centreLeft so the
+    // inner end is the wire's `.end`. The RIGHT half-base is emitted
+    // centreRight → rightCorner so the inner end is the wire's `.start`.
+    const leftHalfBase  = wires.find((w) => w.tag === TERMINATED_DELTA_LEFT_BASE_TAG)!;
+    const rightHalfBase = wires.find((w) => w.tag === TERMINATED_DELTA_RIGHT_BASE_TAG)!;
+    const leftInner  = leftHalfBase.end;
+    const rightInner = rightHalfBase.start;
+
+    wires.push(
+      {
+        start: leftInner,
+        end: [leftInner[0], leftInner[1], SLOPING_V_STUB_BOTTOM_Z_M],
+        radius: state.wireRadius,
+        segments: 1,
+        tag: TERMINATED_DELTA_LEFT_STUB_TAG,
+      },
+      {
+        start: rightInner,
+        end: [rightInner[0], rightInner[1], SLOPING_V_STUB_BOTTOM_Z_M],
+        radius: state.wireRadius,
+        segments: 1,
+        tag: TERMINATED_DELTA_RIGHT_STUB_TAG,
+      },
+    );
+    loads.push(
+      { type: 4, wireTag: TERMINATED_DELTA_LEFT_STUB_TAG,  segmentStart: 1, segmentEnd: 1, param1: R, param2: 0 },
+      { type: 4, wireTag: TERMINATED_DELTA_RIGHT_STUB_TAG, segmentStart: 1, segmentEnd: 1, param1: R, param2: 0 },
     );
   }
 

--- a/tests/DipoleControl.test.tsx
+++ b/tests/DipoleControl.test.tsx
@@ -86,4 +86,19 @@ describe('DipoleControl', () => {
 
     expect(setOrientation).toHaveBeenCalledWith('NS');
   });
+
+  it('embeds the transformer subsection inside the Antenna panel', () => {
+    vi.mocked(useAntennaStore).mockImplementation((selector: (s: MockState) => unknown) => {
+      return selector(buildMockState());
+    });
+
+    render(<DipoleControl />);
+
+    // Both the Antenna section heading and the Transformer subheading
+    // should render under the same control — proves the Transformer
+    // controls have moved into the Antenna box.
+    expect(screen.getByRole('heading', { name: /Antenna/i })).toBeTruthy();
+    expect(screen.getByText('Transformer at feedpoint')).toBeTruthy();
+    expect(screen.getByLabelText(/Fit transformer \/ balun at the antenna/i)).toBeTruthy();
+  });
 });

--- a/tests/terminatedDelta.integration.test.ts
+++ b/tests/terminatedDelta.integration.test.ts
@@ -1,0 +1,71 @@
+// Integration test: real NEC-2 engine vs. the terminated delta deck.
+// Verifies the antenna actually solves to physical numbers and that the
+// termination meaningfully changes the pattern (travelling-wave vs.
+// standing-wave). Mirrors the structure of nec2Engine.integration.test.ts.
+
+import { describe, expect, it, beforeAll } from 'vitest';
+import { Nec2Engine } from '../src/physics/nec2Engine';
+import { useAntennaStore, selectSimulationInput } from '../src/store/antennaStore';
+import { pathToFileURL } from 'node:url';
+import { resolve } from 'node:path';
+
+const wasmUrl = pathToFileURL(resolve(process.cwd(), 'public/')).href + '/';
+
+describe('Terminated Delta — end-to-end NEC simulation', () => {
+  let engine: Nec2Engine;
+
+  beforeAll(async () => {
+    engine = new Nec2Engine({ baseUrl: wasmUrl });
+    await engine.init();
+  }, 30_000);
+
+  async function runTerminatedDelta(R: number) {
+    const store = useAntennaStore.getState();
+    store.setAntennaType('terminated-delta');
+    store.setFeedline('none');
+    store.setFrequency(7.1);
+    store.setLength(42);
+    store.setHeight(15);
+    store.setOrientation('NS');
+    store.setTerminatingResistor(R);
+    const input = selectSimulationInput(useAntennaStore.getState());
+    return engine.simulate(input);
+  }
+
+  it('solves and returns a physical pattern when terminated (R = 300 Ω)', async () => {
+    const r = await runTerminatedDelta(300);
+    expect(Number.isFinite(r.maxGainDbi)).toBe(true);
+    // Real HF antennas over pastoral ground sit in a sensible dBi window.
+    expect(r.maxGainDbi).toBeGreaterThan(-10);
+    expect(r.maxGainDbi).toBeLessThan(15);
+    // Feedpoint impedance must be physical (positive R).
+    expect(r.impedance.R).toBeGreaterThan(0);
+    // Take-off elevation must lie within the upper hemisphere.
+    expect(r.terminationDiagnostics).toBeDefined();
+  }, 60_000);
+
+  it('terminated configuration dissipates power in the resistors (radiation efficiency < 100%)', async () => {
+    const r = await runTerminatedDelta(300);
+    const eff = r.efficiency;
+    // Termination must absorb some power — efficiency cannot be ~100%.
+    expect(eff).toBeDefined();
+    if (eff !== undefined) {
+      expect(eff).toBeLessThan(0.99);
+      expect(eff).toBeGreaterThan(0);
+    }
+  }, 60_000);
+
+  it('unterminated configuration radiates noticeably more efficiently than terminated', async () => {
+    // Unterminated → no resistor losses; all input power goes to radiation
+    // (modulo small ohmic / ground losses). Efficiency should be higher.
+    const rUnterm = await runTerminatedDelta(0);
+    const rTerm   = await runTerminatedDelta(300);
+    const effU = rUnterm.efficiency;
+    const effT = rTerm.efficiency;
+    expect(effU).toBeDefined();
+    expect(effT).toBeDefined();
+    if (effU !== undefined && effT !== undefined) {
+      expect(effU).toBeGreaterThan(effT);
+    }
+  }, 90_000);
+});

--- a/tests/terminatedDeltaGeometry.test.ts
+++ b/tests/terminatedDeltaGeometry.test.ts
@@ -1,0 +1,467 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  useAntennaStore,
+  selectSimulationInput,
+  TERMINATED_DELTA_LEFT_BASE_TAG,
+  TERMINATED_DELTA_RIGHT_BASE_TAG,
+  TERMINATED_DELTA_LEFT_STUB_TAG,
+  TERMINATED_DELTA_RIGHT_STUB_TAG,
+} from '../src/store/antennaStore';
+import { buildNecCards } from '../src/physics/necCard';
+import {
+  getNecLines,
+  parseLdLine,
+  parseGwLine,
+  expectExcitation,
+  expectNoGroundTouchingWires,
+} from './necInspect';
+import {
+  DIPOLE_LEFT_TAG,
+  DIPOLE_RIGHT_TAG,
+  FEED_BRIDGE_TAG,
+  FEEDLINE_SHIELD_TAG,
+  SLOPING_V_MIN_TIP_Z_M,
+  SLOPING_V_STUB_BOTTOM_Z_M,
+  TERMINATED_DELTA_CENTRE_GAP_M,
+  wavelengthMeters,
+} from '../src/physics/constants';
+
+function setupTerminatedDelta(terminatingResistor?: number) {
+  const store = useAntennaStore.getState();
+  store.setAntennaType('terminated-delta');
+  store.setFeedline('none');
+  store.setFrequency(7.1);
+  store.setLength(42);
+  store.setHeight(15);
+  store.setOrientation('NS');
+  if (terminatingResistor !== undefined) {
+    store.setTerminatingResistor(terminatingResistor);
+  }
+}
+
+function getTermLdLines(deck: string): string[] {
+  return getNecLines(deck, 'LD').filter((line) => {
+    const ld = parseLdLine(line);
+    return (
+      ld.type === 4 &&
+      (ld.tag === TERMINATED_DELTA_LEFT_STUB_TAG ||
+        ld.tag === TERMINATED_DELTA_RIGHT_STUB_TAG)
+    );
+  });
+}
+
+describe('Terminated Delta — defaults & state', () => {
+  beforeEach(() => {
+    useAntennaStore.getState().setTerminatingResistor(0);
+  });
+
+  it('switching to terminated-delta defaults the perimeter to 1λ', () => {
+    const store = useAntennaStore.getState();
+    store.setFrequency(7.1);
+    store.setAntennaType('terminated-delta');
+    const lambda = wavelengthMeters(7.1);
+    // Default uses calculateDefaultLength → lambda (1λ exactly).
+    expect(useAntennaStore.getState().length).toBeCloseTo(lambda, 6);
+  });
+
+  it('switching to terminated-delta from unterminated defaults R to 300 Ω', () => {
+    const store = useAntennaStore.getState();
+    store.setTerminatingResistor(0);
+    store.setAntennaType('terminated-delta');
+    expect(useAntennaStore.getState().terminatingResistor).toBe(300);
+  });
+
+  it('switching to terminated-delta preserves an existing non-zero R', () => {
+    const store = useAntennaStore.getState();
+    store.setAntennaType('sloping-v'); // sets R=300
+    store.setTerminatingResistor(450);
+    store.setAntennaType('terminated-delta');
+    expect(useAntennaStore.getState().terminatingResistor).toBe(450);
+  });
+});
+
+describe('Terminated Delta — base geometry', () => {
+  beforeEach(() => {
+    useAntennaStore.getState().setTerminatingResistor(0);
+  });
+
+  it('emits two top legs and two half-base wires (no continuous base)', () => {
+    setupTerminatedDelta(0);
+    const input = selectSimulationInput(useAntennaStore.getState());
+    const leftLeg = input.wires.find((w) => w.tag === DIPOLE_LEFT_TAG);
+    const rightLeg = input.wires.find((w) => w.tag === DIPOLE_RIGHT_TAG);
+    const leftHalfBase = input.wires.find((w) => w.tag === TERMINATED_DELTA_LEFT_BASE_TAG);
+    const rightHalfBase = input.wires.find((w) => w.tag === TERMINATED_DELTA_RIGHT_BASE_TAG);
+    expect(leftLeg).toBeDefined();
+    expect(rightLeg).toBeDefined();
+    expect(leftHalfBase).toBeDefined();
+    expect(rightHalfBase).toBeDefined();
+  });
+
+  it('left leg ends at the apex (.end is at the mast height)', () => {
+    setupTerminatedDelta(0);
+    const input = selectSimulationInput(useAntennaStore.getState());
+    const leftLeg = input.wires.find((w) => w.tag === DIPOLE_LEFT_TAG)!;
+    expect(leftLeg.end[2]).toBeCloseTo(15, 6);
+  });
+
+  it('right leg starts at the apex (.start is at the mast height)', () => {
+    setupTerminatedDelta(0);
+    const input = selectSimulationInput(useAntennaStore.getState());
+    const rightLeg = input.wires.find((w) => w.tag === DIPOLE_RIGHT_TAG)!;
+    expect(rightLeg.start[2]).toBeCloseTo(15, 6);
+  });
+
+  it('the two half-base wires sit at the same bottomZ', () => {
+    setupTerminatedDelta(0);
+    const input = selectSimulationInput(useAntennaStore.getState());
+    const leftHalfBase = input.wires.find((w) => w.tag === TERMINATED_DELTA_LEFT_BASE_TAG)!;
+    const rightHalfBase = input.wires.find((w) => w.tag === TERMINATED_DELTA_RIGHT_BASE_TAG)!;
+    expect(leftHalfBase.start[2]).toBeCloseTo(leftHalfBase.end[2], 6);
+    expect(rightHalfBase.start[2]).toBeCloseTo(rightHalfBase.end[2], 6);
+    expect(leftHalfBase.start[2]).toBeCloseTo(rightHalfBase.start[2], 6);
+  });
+
+  it('the two half-base inner ends are separated by TERMINATED_DELTA_CENTRE_GAP_M', () => {
+    setupTerminatedDelta(0);
+    const input = selectSimulationInput(useAntennaStore.getState());
+    const leftHalfBase = input.wires.find((w) => w.tag === TERMINATED_DELTA_LEFT_BASE_TAG)!;
+    const rightHalfBase = input.wires.find((w) => w.tag === TERMINATED_DELTA_RIGHT_BASE_TAG)!;
+    // Left half-base is leftCorner → centreLeft, so its .end is the inner end.
+    // Right half-base is centreRight → rightCorner, so its .start is the inner end.
+    const leftInner = leftHalfBase.end;
+    const rightInner = rightHalfBase.start;
+    const gap = Math.hypot(
+      rightInner[0] - leftInner[0],
+      rightInner[1] - leftInner[1],
+      rightInner[2] - leftInner[2],
+    );
+    expect(gap).toBeCloseTo(TERMINATED_DELTA_CENTRE_GAP_M, 6);
+  });
+
+  it('the half-base inner ends straddle the geometric centre symmetrically', () => {
+    setupTerminatedDelta(0);
+    const input = selectSimulationInput(useAntennaStore.getState());
+    const leftHalfBase = input.wires.find((w) => w.tag === TERMINATED_DELTA_LEFT_BASE_TAG)!;
+    const rightHalfBase = input.wires.find((w) => w.tag === TERMINATED_DELTA_RIGHT_BASE_TAG)!;
+    const midX = (leftHalfBase.end[0] + rightHalfBase.start[0]) / 2;
+    const midY = (leftHalfBase.end[1] + rightHalfBase.start[1]) / 2;
+    expect(midX).toBeCloseTo(0, 6);
+    expect(midY).toBeCloseTo(0, 6);
+  });
+
+  it('the outer ends of the half-base wires coincide with the leg corners', () => {
+    setupTerminatedDelta(0);
+    const input = selectSimulationInput(useAntennaStore.getState());
+    const leftLeg = input.wires.find((w) => w.tag === DIPOLE_LEFT_TAG)!;
+    const rightLeg = input.wires.find((w) => w.tag === DIPOLE_RIGHT_TAG)!;
+    const leftHalfBase = input.wires.find((w) => w.tag === TERMINATED_DELTA_LEFT_BASE_TAG)!;
+    const rightHalfBase = input.wires.find((w) => w.tag === TERMINATED_DELTA_RIGHT_BASE_TAG)!;
+    // Left leg goes leftCorner → apex, so .start is the left corner.
+    // Left half-base goes leftCorner → centreLeft, so .start is also the left corner.
+    expect(leftLeg.start[0]).toBeCloseTo(leftHalfBase.start[0], 6);
+    expect(leftLeg.start[1]).toBeCloseTo(leftHalfBase.start[1], 6);
+    expect(leftLeg.start[2]).toBeCloseTo(leftHalfBase.start[2], 6);
+    // Right leg goes apex → rightCorner, so .end is the right corner.
+    // Right half-base goes centreRight → rightCorner, so .end is also the right corner.
+    expect(rightLeg.end[0]).toBeCloseTo(rightHalfBase.end[0], 6);
+    expect(rightLeg.end[1]).toBeCloseTo(rightHalfBase.end[1], 6);
+    expect(rightLeg.end[2]).toBeCloseTo(rightHalfBase.end[2], 6);
+  });
+
+  it('triangle is equilateral when the mast is tall enough', () => {
+    const store = useAntennaStore.getState();
+    store.setAntennaType('terminated-delta');
+    store.setFrequency(7.1);
+    store.setLength(42);
+    store.setHeight(30); // tall enough for equilateral height ~12.12 m
+    const input = selectSimulationInput(useAntennaStore.getState());
+    const leftLeg = input.wires.find((w) => w.tag === DIPOLE_LEFT_TAG)!;
+    const legLen = Math.hypot(
+      leftLeg.end[0] - leftLeg.start[0],
+      leftLeg.end[1] - leftLeg.start[1],
+      leftLeg.end[2] - leftLeg.start[2],
+    );
+    expect(legLen).toBeCloseTo(42 / 3, 4);
+  });
+
+  it('triangle flattens when mast is too short: corners clamped above ground, perimeter preserved', () => {
+    const store = useAntennaStore.getState();
+    store.setAntennaType('terminated-delta');
+    store.setFrequency(7.1);
+    store.setLength(42);
+    store.setHeight(5); // less than equilateral height (~12.12 m)
+    const input = selectSimulationInput(useAntennaStore.getState());
+    const leftLeg = input.wires.find((w) => w.tag === DIPOLE_LEFT_TAG)!;
+    const leftHalfBase = input.wires.find((w) => w.tag === TERMINATED_DELTA_LEFT_BASE_TAG)!;
+    const rightHalfBase = input.wires.find((w) => w.tag === TERMINATED_DELTA_RIGHT_BASE_TAG)!;
+    const legLen = Math.hypot(
+      leftLeg.end[0] - leftLeg.start[0],
+      leftLeg.end[1] - leftLeg.start[1],
+      leftLeg.end[2] - leftLeg.start[2],
+    );
+    const leftHalfBaseLen = Math.hypot(
+      leftHalfBase.end[0] - leftHalfBase.start[0],
+      leftHalfBase.end[1] - leftHalfBase.start[1],
+      leftHalfBase.end[2] - leftHalfBase.start[2],
+    );
+    const rightHalfBaseLen = Math.hypot(
+      rightHalfBase.end[0] - rightHalfBase.start[0],
+      rightHalfBase.end[1] - rightHalfBase.start[1],
+      rightHalfBase.end[2] - rightHalfBase.start[2],
+    );
+    const baseLen = leftHalfBaseLen + rightHalfBaseLen + TERMINATED_DELTA_CENTRE_GAP_M;
+    // Bottom corners clamped to SLOPING_V_MIN_TIP_Z_M.
+    expect(leftLeg.start[2]).toBeCloseTo(SLOPING_V_MIN_TIP_Z_M, 4);
+    // In a flattened isosceles triangle (t < equilateral height), legs are
+    // SHORTER than P/3 and the base is LONGER than P/3. Limits as t→0 are
+    // leg → P/4 and base → P/2.
+    expect(legLen).toBeLessThan(42 / 3);
+    expect(legLen).toBeGreaterThan(42 / 4 - 1e-6);
+    expect(baseLen).toBeGreaterThan(42 / 3);
+    expect(baseLen).toBeLessThan(42 / 2 + 1e-6);
+    // Perimeter preserved: 2·leg + base ≈ 42.
+    expect(2 * legLen + baseLen).toBeCloseTo(42, 3);
+  });
+});
+
+describe('Terminated Delta — unterminated', () => {
+  beforeEach(() => {
+    useAntennaStore.getState().setTerminatingResistor(0);
+  });
+
+  it('no stub wires and no termination LD when terminatingResistor=0', () => {
+    setupTerminatedDelta(0);
+    const input = selectSimulationInput(useAntennaStore.getState());
+    const deck = buildNecCards(input);
+    expect(getTermLdLines(deck)).toHaveLength(0);
+    expect(input.wires.find((w) => w.tag === TERMINATED_DELTA_LEFT_STUB_TAG)).toBeUndefined();
+    expect(input.wires.find((w) => w.tag === TERMINATED_DELTA_RIGHT_STUB_TAG)).toBeUndefined();
+  });
+
+  it('unterminated input.loads is undefined (no LD cards anywhere)', () => {
+    setupTerminatedDelta(0);
+    const input = selectSimulationInput(useAntennaStore.getState());
+    expect(input.loads).toBeUndefined();
+  });
+});
+
+describe('Terminated Delta — terminated (per-stub shunt to ground)', () => {
+  beforeEach(() => {
+    useAntennaStore.getState().setTerminatingResistor(0);
+  });
+
+  it('adds two stub wires and two LD cards when terminatingResistor > 0', () => {
+    setupTerminatedDelta(300);
+    const input = selectSimulationInput(useAntennaStore.getState());
+    const deck = buildNecCards(input);
+    expect(getTermLdLines(deck)).toHaveLength(2);
+    expect(input.wires.find((w) => w.tag === TERMINATED_DELTA_LEFT_STUB_TAG)).toBeDefined();
+    expect(input.wires.find((w) => w.tag === TERMINATED_DELTA_RIGHT_STUB_TAG)).toBeDefined();
+  });
+
+  it('stubs are vertical, start at the inner half-base ends, end near ground', () => {
+    setupTerminatedDelta(300);
+    const input = selectSimulationInput(useAntennaStore.getState());
+    const leftHalfBase = input.wires.find((w) => w.tag === TERMINATED_DELTA_LEFT_BASE_TAG)!;
+    const rightHalfBase = input.wires.find((w) => w.tag === TERMINATED_DELTA_RIGHT_BASE_TAG)!;
+    const leftStub = input.wires.find((w) => w.tag === TERMINATED_DELTA_LEFT_STUB_TAG)!;
+    const rightStub = input.wires.find((w) => w.tag === TERMINATED_DELTA_RIGHT_STUB_TAG)!;
+
+    // Left stub starts at left half-base's inner end (.end).
+    expect(leftStub.start[0]).toBeCloseTo(leftHalfBase.end[0], 6);
+    expect(leftStub.start[1]).toBeCloseTo(leftHalfBase.end[1], 6);
+    expect(leftStub.start[2]).toBeCloseTo(leftHalfBase.end[2], 6);
+    // Right stub starts at right half-base's inner end (.start).
+    expect(rightStub.start[0]).toBeCloseTo(rightHalfBase.start[0], 6);
+    expect(rightStub.start[1]).toBeCloseTo(rightHalfBase.start[1], 6);
+    expect(rightStub.start[2]).toBeCloseTo(rightHalfBase.start[2], 6);
+
+    // Stubs end at the constant floor height.
+    expect(leftStub.end[2]).toBeCloseTo(SLOPING_V_STUB_BOTTOM_Z_M, 6);
+    expect(rightStub.end[2]).toBeCloseTo(SLOPING_V_STUB_BOTTOM_Z_M, 6);
+
+    // Stubs are vertical (XY coords unchanged).
+    expect(leftStub.end[0]).toBeCloseTo(leftStub.start[0], 6);
+    expect(leftStub.end[1]).toBeCloseTo(leftStub.start[1], 6);
+    expect(rightStub.end[0]).toBeCloseTo(rightStub.start[0], 6);
+    expect(rightStub.end[1]).toBeCloseTo(rightStub.start[1], 6);
+  });
+
+  it('LD cards are type 4, on segment 1 of each stub, resistance per-stub equals terminatingResistor', () => {
+    const R = 500;
+    setupTerminatedDelta(R);
+    const input = selectSimulationInput(useAntennaStore.getState());
+    const deck = buildNecCards(input);
+    const ldLines = getTermLdLines(deck);
+    expect(ldLines).toHaveLength(2);
+    for (const line of ldLines) {
+      const ld = parseLdLine(line);
+      expect(ld.type).toBe(4);
+      expect(ld.segmentStart).toBe(1);
+      expect(ld.segmentEnd).toBe(1);
+      expect(ld.p1).toBeCloseTo(R, 6);
+      expect(ld.p2).toBeCloseTo(0, 6);
+    }
+    // Each tag is loaded exactly once.
+    const tags = ldLines.map((l) => parseLdLine(l).tag).sort();
+    expect(tags).toEqual([TERMINATED_DELTA_LEFT_STUB_TAG, TERMINATED_DELTA_RIGHT_STUB_TAG]);
+  });
+
+  it('no LD cards on the radiating wires themselves (termination is in stubs only)', () => {
+    setupTerminatedDelta(300);
+    const input = selectSimulationInput(useAntennaStore.getState());
+    const radiatingLoads = (input.loads ?? []).filter(
+      (l) =>
+        l.wireTag === DIPOLE_LEFT_TAG ||
+        l.wireTag === DIPOLE_RIGHT_TAG ||
+        l.wireTag === TERMINATED_DELTA_LEFT_BASE_TAG ||
+        l.wireTag === TERMINATED_DELTA_RIGHT_BASE_TAG,
+    );
+    expect(radiatingLoads).toHaveLength(0);
+  });
+
+  it('all wires remain strictly above z=0 when terminated', () => {
+    setupTerminatedDelta(300);
+    expectNoGroundTouchingWires(buildNecCards(selectSimulationInput(useAntennaStore.getState())));
+  });
+
+  it('no NT (two-port network) card emitted — termination uses LD cards only', () => {
+    setupTerminatedDelta(300);
+    const input = selectSimulationInput(useAntennaStore.getState());
+    const deck = buildNecCards(input);
+    expect(getNecLines(deck, 'NT')).toHaveLength(0);
+    expect(input.networks).toBeUndefined();
+  });
+
+  it('total per-stub resistance scales with terminatingResistor', () => {
+    setupTerminatedDelta(1200);
+    const ld1 = parseLdLine(
+      getTermLdLines(buildNecCards(selectSimulationInput(useAntennaStore.getState())))[0],
+    );
+
+    useAntennaStore.getState().setTerminatingResistor(600);
+    const ld2 = parseLdLine(
+      getTermLdLines(buildNecCards(selectSimulationInput(useAntennaStore.getState())))[0],
+    );
+    expect(ld2.p1).toBeCloseTo(ld1.p1 / 2, 6);
+  });
+});
+
+describe('Terminated Delta — excitation', () => {
+  beforeEach(() => {
+    useAntennaStore.getState().setTerminatingResistor(0);
+  });
+
+  it('unterminated: excitation is on the last segment of the left leg (apex)', () => {
+    setupTerminatedDelta(0);
+    const input = selectSimulationInput(useAntennaStore.getState());
+    const leftLeg = input.wires.find((w) => w.tag === DIPOLE_LEFT_TAG)!;
+    expectExcitation(buildNecCards(input), DIPOLE_LEFT_TAG, leftLeg.segments);
+  });
+
+  it('terminated: excitation is still on the last segment of the left leg (apex)', () => {
+    setupTerminatedDelta(300);
+    const input = selectSimulationInput(useAntennaStore.getState());
+    const leftLeg = input.wires.find((w) => w.tag === DIPOLE_LEFT_TAG)!;
+    expectExcitation(buildNecCards(input), DIPOLE_LEFT_TAG, leftLeg.segments);
+  });
+});
+
+describe('Terminated Delta — feedline support', () => {
+  beforeEach(() => {
+    useAntennaStore.getState().setTerminatingResistor(0);
+  });
+
+  it('emits an apex feed bridge and a feedline shield when a coax is selected', () => {
+    const store = useAntennaStore.getState();
+    store.setAntennaType('terminated-delta');
+    store.setFrequency(7.1);
+    store.setHeight(15);
+    store.setLength(42);
+    store.setFeedline('rg58');
+    store.setFeedlineLength(10);
+    const input = selectSimulationInput(useAntennaStore.getState());
+    expect(input.wires.find((w) => w.tag === FEED_BRIDGE_TAG)).toBeDefined();
+    expect(input.wires.find((w) => w.tag === FEEDLINE_SHIELD_TAG)).toBeDefined();
+  });
+
+  it('with a feedline, excitation moves to the shield bottom (rig end)', () => {
+    const store = useAntennaStore.getState();
+    store.setAntennaType('terminated-delta');
+    store.setFrequency(7.1);
+    store.setHeight(15);
+    store.setLength(42);
+    store.setFeedline('rg58');
+    store.setFeedlineLength(10);
+    const input = selectSimulationInput(useAntennaStore.getState());
+    expect(input.excitation.wireTag).toBe(FEEDLINE_SHIELD_TAG);
+  });
+
+  it('with a feedline, a TL card is emitted between the apex bridge and the shield', () => {
+    const store = useAntennaStore.getState();
+    store.setAntennaType('terminated-delta');
+    store.setFrequency(7.1);
+    store.setHeight(15);
+    store.setLength(42);
+    store.setFeedline('rg58');
+    store.setFeedlineLength(10);
+    const input = selectSimulationInput(useAntennaStore.getState());
+    const deck = buildNecCards(input);
+    expect(getNecLines(deck, 'TL')).toHaveLength(1);
+    expect(input.transmissionLines).toHaveLength(1);
+  });
+});
+
+describe('Terminated Delta — NEC deck sanity', () => {
+  beforeEach(() => {
+    useAntennaStore.getState().setTerminatingResistor(0);
+  });
+
+  it('every GW wire is well-formed (radius > 0, segments >= 1)', () => {
+    setupTerminatedDelta(300);
+    const input = selectSimulationInput(useAntennaStore.getState());
+    const deck = buildNecCards(input);
+    const gwLines = getNecLines(deck, 'GW');
+    expect(gwLines.length).toBeGreaterThan(0);
+    for (const line of gwLines) {
+      const gw = parseGwLine(line);
+      expect(gw.radius).toBeGreaterThan(0);
+      expect(gw.segments).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it('cross-type isolation: switching to dipole removes all terminated-delta tags', () => {
+    setupTerminatedDelta(300);
+    useAntennaStore.getState().setAntennaType('dipole');
+    const input = selectSimulationInput(useAntennaStore.getState());
+    expect(input.wires.find((w) => w.tag === TERMINATED_DELTA_LEFT_BASE_TAG)).toBeUndefined();
+    expect(input.wires.find((w) => w.tag === TERMINATED_DELTA_RIGHT_BASE_TAG)).toBeUndefined();
+    expect(input.wires.find((w) => w.tag === TERMINATED_DELTA_LEFT_STUB_TAG)).toBeUndefined();
+    expect(input.wires.find((w) => w.tag === TERMINATED_DELTA_RIGHT_STUB_TAG)).toBeUndefined();
+  });
+
+  it('cross-type isolation: delta-loop with R > 0 does not emit terminated-delta stub LDs', () => {
+    const store = useAntennaStore.getState();
+    store.setAntennaType('delta-loop');
+    store.setTerminatingResistor(600);
+    const deck = buildNecCards(selectSimulationInput(useAntennaStore.getState()));
+    expect(getTermLdLines(deck)).toHaveLength(0);
+  });
+
+  it('cross-type isolation: sloping-v with R > 0 does not emit terminated-delta stub LDs', () => {
+    const store = useAntennaStore.getState();
+    store.setAntennaType('sloping-v');
+    store.setTerminatingResistor(600);
+    const deck = buildNecCards(selectSimulationInput(useAntennaStore.getState()));
+    expect(getTermLdLines(deck)).toHaveLength(0);
+  });
+
+  it('setTerminatingResistor clamps negative values to 0', () => {
+    setupTerminatedDelta();
+    useAntennaStore.getState().setTerminatingResistor(-100);
+    expect(useAntennaStore.getState().terminatingResistor).toBe(0);
+    const deck = buildNecCards(selectSimulationInput(useAntennaStore.getState()));
+    expect(getTermLdLines(deck)).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a new **Terminated Delta** antenna type, modelled to mirror the proven physics already in the codebase:

- **Geometry**: identical to the Delta Loop's apex-fed isosceles triangle — same perimeter-preserving leg/base math (`leg = t²/P + P/4`, `halfBase = P/4 − t²/P`), same equilateral-when-possible / flattened-when-clamped behaviour, same apex feed convention.
- **Topology difference**: the base is **split in the middle** into two independent half-base wires (`TERMINATED_DELTA_LEFT_BASE_TAG` / `…_RIGHT_BASE_TAG`) separated by a small physical gap (`TERMINATED_DELTA_CENTRE_GAP_M = FEED_BRIDGE_LENGTH_M`). Each half-base ends near the centre and is taken to ground via a short vertical stub.
- **Termination**: per-stub `LD type-4` resistor on each stub (one R per stub), reusing the sloping-V's **shunt-to-earth** pattern — the physically-correct topology where the resistor sees a real current path through ground, resolved by NEC's Sommerfeld-Norton model. This avoids the pitfall of placing a series LD on an open wire end, which doesn't create a current-to-earth path.

## Defaults (per user request)
- **Perimeter**: 1λ (matches Delta Loop; canonical resonant starting point)
- **Termination R**: 300 Ω per stub (matches Sloping V's canonical reference)
- **Feedline / transformer**: supported via the existing apex-bridge mechanism; no special-casing needed.

## Physics correctness — leverages prior merge fixes
- **Stub-based shunt termination** (sloping-V fix `2dfc03b`): each tip-equivalent now connects to earth through a real stub + resistor, not a dangling series LD.
- **Isosceles-triangle perimeter math** (delta-loop fix `85039dd`): exact same formulas so the two antennas occupy the same physical envelope for the same length.
- **`SLOPING_V_STUB_BOTTOM_Z_M` (0.01 m)** floor: stubs end above z=0 to keep NEC happy under the Sommerfeld-Norton ground model.
- **Apex feed convention** (`DIPOLE_LEFT_TAG.last segment` as excitation, or `FEED_BRIDGE_TAG`/`FEEDLINE_SHIELD_TAG` when a feedline is active): inherited unchanged.

## Test plan
- [x] 31 geometry/topology unit tests (`terminatedDeltaGeometry.test.ts`): wire tags present, half-base inner ends straddle centre symmetrically with the right gap, stubs are vertical and start at the inner ends, LD-4 cards on segment 1 of each stub with the configured R, excitation lands on the apex, feedline path routes excitation to the shield bottom, equilateral when mast is tall enough, flattens correctly when clamped (legs shorter than P/3, base longer, perimeter preserved), no LD on radiating wires, no NT cards, no ground-touching wires, cross-type isolation when switching antennas, clamping of negative R.
- [x] 3 end-to-end NEC-2 integration tests (`terminatedDelta.integration.test.ts`): real Wasm solver returns finite physical gain/impedance; termination dissipates power (efficiency < 100%); unterminated configuration radiates more efficiently than terminated (as expected — termination trades radiation for absorption to flatten the standing wave).
- [x] All 408 tests pass (existing 374 + 31 geometry + 3 integration).
- [x] `npm run build` and `npm run lint` clean.

https://claude.ai/code/session_019pWYK86F6KHMzer5ohsr2a

---
_Generated by [Claude Code](https://claude.ai/code/session_019pWYK86F6KHMzer5ohsr2a)_