### PR TITLE
🎨 Palette: Inline loading states and ARIA busy indicators

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -42,3 +42,7 @@
 ## 2024-05-27 - Inline Constraint Warnings (Geometry Status)
 **Learning:** Found that when a user's requested numeric input (e.g., Sloping V angle) is silently clamped by the system to satisfy physical constraints (e.g., minimum tip height), visual warnings alone are insufficient for accessibility. Without proper ARIA announcements, screen reader users miss the fact that their requested input was overridden by the system, leading to confusion about the actual state of the simulation.
 **Action:** When creating inline warning components that display dynamic constraint violations or system overrides (like `GeometryStatus`), always wrap the notification in a container with `role="status"` and `aria-live="polite"` so screen readers are audibly notified of the clamp.
+
+## 2024-05-28 - Inline Loading States and ARIA Roles
+**Learning:** Found that inline loading states for background computation (like computing SWR sweeps or radar patterns) lacked visual spinners and ARIA roles. While full-page or overlay states used these correctly, the localized components only used static text. This causes an inconsistent user experience and leaves screen reader users completely unaware that computation is occurring.
+**Action:** When creating or auditing localized/inline async loading states, always ensure they use visual indicators (like the `<div className="spinner" />`) properly aligned via flexbox, and explicitly define them as live regions (`role="status"`, `aria-live="polite"`) so they are announced by assistive technologies.

--- a/src/components/Charts/SWRChart.tsx
+++ b/src/components/Charts/SWRChart.tsx
@@ -298,7 +298,9 @@ export function SWRChart() {
       <section className="panel-section" style={{ minHeight: 220 }}>
         {/* SEO: Use sequential heading tags (H2) to follow document outline initiated by H1 */}
         <h2>SWR sweep</h2>
-        <div style={{ color: 'var(--text-muted)', fontSize: 12 }}>Computing frequency sweep…</div>
+        <div role="status" aria-live="polite" style={{ color: 'var(--text-muted)', fontSize: 12, display: 'flex', alignItems: 'center', gap: '8px' }}>
+          <div className="spinner" aria-hidden="true" /> Computing frequency sweep…
+        </div>
       </section>
     );
   }

--- a/src/components/Panel/PropagationControl.tsx
+++ b/src/components/Panel/PropagationControl.tsx
@@ -267,8 +267,8 @@ export function PropagationControl() {
           units={units}
         />
       ) : (
-        <div style={{ fontSize: 12, color: 'var(--text-muted)', textAlign: 'center', padding: '8px 0' }}>
-          Computing antenna pattern…
+        <div role="status" aria-live="polite" style={{ fontSize: 12, color: 'var(--text-muted)', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '8px', padding: '8px 0' }}>
+          <div className="spinner" aria-hidden="true" /> Computing antenna pattern…
         </div>
       )}
 


### PR DESCRIPTION
Added visual spinners and `role="status"`, `aria-live="polite"` attributes to the inline "Computing..." loading states in `SWRChart.tsx` and `PropagationControl.tsx`. This ensures consistency with the main application loading states and dramatically improves accessibility for screen reader users who were previously unaware of background computation states.

---
*PR created automatically by Jules for task [9182669867668817580](https://jules.google.com/task/9182669867668817580) started by @2fst4u*