### PR TITLE
📚 Archivist: Fix Sloping V termination documentation

### DIFF
--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -1,12 +1,24 @@
 ## 2024-05-03 - Package Manager Drift
+
 **Learning:** The documentation originally instructed users to use `pnpm`, but the repository strictly uses `npm` (as evidenced by `package-lock.json`, `.npmrc` with `legacy-peer-deps=true`, and the GitHub Actions test workflow which runs `npm ci`). The `README.md` likely drifted from the actual toolchain over time or inherited an old template.
 **Action:** The `README.md` was updated to accurately reflect `npm` commands to prevent setup failures and confusion.
+
 ## 2025-02-12 - Phantom UI Test Command
+
 **Learning:** `package.json` included a phantom command `"test:ui": "vitest --ui"` which fails out-of-the-box because `@vitest/ui` is deliberately excluded from `devDependencies`. Adding dependencies to fix phantom commands violates strict boundaries on modifying project architecture/configs unnecessarily.
 **Action:** When finding phantom scripts in `package.json`, carefully remove the script to align with the actual project state rather than artificially installing dependencies to "make the documentation work".
+
 ## 2025-05-10 - Canonical Domain URL Drift
+
 **Learning:** The documentation and agent guidelines referenced the root domain `https://gain.observer` as the hosted URL, but the site's metadata (`index.html` canonical/og links) strictly enforces the `www` subdomain (`https://www.gain.observer/`). Inconsistent domain documentation can cause SEO confusion and duplicate indexing.
 **Action:** Ensure all documentation links pointing to the production application match the exact `rel="canonical"` URL defined in the application's main HTML entry point.
+
 ## 2024-05-17 - README Scope Drift
+
 **Learning:** The `README.md` file listed only "horizontal dipoles" under its current scope, while the application actually supports multiple other topologies (e.g., inverted-v, sloping-v, delta-loop), leading to an inaccurate representation of the tool's capabilities.
 **Action:** Regularly audit the capabilities listed in the README against the actual codebase features to prevent scope drift and ensure the documented features accurately reflect the product's true capabilities.
+
+## 2026-05-19 - Sloping V Termination Topology Drift
+
+**Learning:** The documentation for the Sloping V antenna claimed its termination was modeled as a differential resistor across the two tips without a path to ground. However, the engine (`src/store/antennaStore.ts`) actually creates short vertical stub wires from each tip down to near-ground to model realistic shunt-to-earth current paths. The docs had drifted from the active implementation physics.
+**Action:** The `docs/antenna-spec.md` was updated to accurately reflect the per-leg-to-ground stub topology.

--- a/docs/antenna-spec.md
+++ b/docs/antenna-spec.md
@@ -7,6 +7,7 @@ This document defines the physical and mathematical model for all antenna types 
 ## 1. Center-Fed Dipole
 
 ### 1.1 Geometry Definition
+
 - **Apex Location:** Geometric center of the wire at $(0, 0, \text{height})$.
 - **Leg Count & Length:** 1 wire, total length $L$.
 - **Reference Length:** $0.475\lambda$ (Resonance).
@@ -15,24 +16,29 @@ This document defines the physical and mathematical model for all antenna types 
 - **Min Height:** All points must satisfy $z \ge 0.1$ m to avoid NEC-2 `GE 1` instability.
 
 ### 1.2 Feedpoint Definition
+
 - **NEC Excitation:** Single-segment voltage source (`EX`) on Tag 1.
 - **Segment:** Center segment of the wire.
 - **Feed Type:** Single-segment voltage source.
 - **Feedline Support:** Supported (Radiating shield + NEC `TL` card).
 
 ### 1.3 Termination Definition
+
 - **Model:** None. Dipoles are resonant, non-terminated antennas.
 
 ### 1.4 SWR Convention
+
 - **Reference:** 50.0 Ω.
 - **Metric:** Raw feedpoint SWR (Mismatch to 50 Ω).
 
 ### 1.5 Segmentation Rules
+
 - **Density:** 20 segments per $\lambda$ minimum.
 - **Minimum:** 9 segments total.
 - **Alignment:** Must use an **odd** number of segments to ensure a precise center feedpoint.
 
 ### 1.6 Glossary
+
 - **Directivity ($D$):** $D = \frac{4\pi U_{max}}{P_{rad}}$.
 - **Gain ($G$):** $10 \log_{10}(\eta \cdot D)$ dBi.
 - **Realized Gain:** $G(dBi) + 10 \log_{10}(1 - |\Gamma|^2)$.
@@ -45,6 +51,7 @@ This document defines the physical and mathematical model for all antenna types 
 ## 2. Inverted-V
 
 ### 2.1 Geometry Definition
+
 - **Apex Location:** Highest point at $(0, 0, \text{height})$.
 - **Leg Count & Length:** 2 legs, total radiating length $L$ (sum of both legs).
 - **Reference Length:** $0.485\lambda$ (Resonance).
@@ -53,24 +60,29 @@ This document defines the physical and mathematical model for all antenna types 
 - **Min Height:** Tip height must be $\ge 0.1$ m.
 
 ### 2.2 Feedpoint Definition
+
 - **NEC Excitation:** 1-segment "source bridge" (Tag 3) at apex.
 - **Segment:** Segment 1 of Tag 3.
 - **Feed Type:** Balanced bridge segment.
 - **Feedline Support:** Supported (Radiating shield + NEC `TL` card; feedpoint always at apex, offset is not applicable).
 
 ### 2.3 Termination Definition
+
 - **Model:** None.
 
 ### 2.4 SWR Convention
+
 - **Reference:** 50.0 Ω.
 - **Metric:** Raw feedpoint SWR.
 
 ### 2.5 Segmentation Rules
+
 - **Density:** 20 segments per $\lambda$ minimum.
 - **Minimum:** 9 segments per radiating leg.
 - **Alignment:** Legs should have equal segments. Bridge is exactly 1 segment.
 
 ### 2.6 Glossary
+
 - Same as Section 1.6.
 
 ---
@@ -78,6 +90,7 @@ This document defines the physical and mathematical model for all antenna types 
 ## 3. Sloping V (Terminated)
 
 ### 3.1 Geometry Definition
+
 - **Apex Location:** Highest point at $(0, 0, \text{height})$.
 - **Leg Count & Length:** 2 legs, length $L$ **per leg** (Total radiating wire $2L$).
 - **Reference Length:** $2.0\lambda$ per leg (Traveling wave directivity).
@@ -86,34 +99,43 @@ This document defines the physical and mathematical model for all antenna types 
 - **Min Height:** Tip height must be $\ge 0.1$ m.
 
 ### 3.2 Feedpoint Definition
+
 - **NEC Excitation:** 1-segment source bridge at apex.
 - **Segment:** Segment 1 of bridge.
 - **Feed Type:** Balanced bridge segment.
 - **Feedline Support:** Supported (Radiating shield + NEC `TL` card; feedpoint always at apex, offset is not applicable).
 
 ### 3.3 Termination Definition
-- **Topology:** Differential resistor between the two leg tips.
+
+- **Topology:** Resistor from each leg tip to ground via short stub wires.
 - **Diagram:**
   ```
        Apex (Feed)
           / \
          /   \
         /     \
-      Tip-----R-----Tip
+      Tip     Tip
+       |       |
+       R       R
+       |       |
+      GND     GND
   ```
-- **NEC Model:** Single `LD 4` load on a 1-segment non-radiating bridge wire between tips.
-- **Value:** `terminatingResistor` is the **total** differential resistance.
-- **Return Path:** No return to ground. Explicitly rejects vertical drop wires or independent ground terminations.
+- **NEC Model:** `LD 4` loads on short vertical stub wires extending from each tip down to near-ground (`SLOPING_V_STUB_BOTTOM_Z_M`).
+- **Value:** `terminatingResistor` is applied identically to both stubs.
+- **Return Path:** Explicit NEC current path from the wire tip toward the ground plane.
 
 ### 3.4 SWR Convention
+
 - **Reference:** 50.0 Ω.
 - **Statement:** Traveling wave antennas often have high raw SWR (e.g., 600 Ω feed). Raw SWR graph reflects this mismatch, not termination quality.
 
 ### 3.5 Segmentation Rules
+
 - **Density:** 20 segments per $\lambda$ minimum.
 - **Minimum:** 9 segments per radiating leg.
 
 ### 3.6 Glossary
+
 - Same as Section 1.6.
 
 ---
@@ -121,6 +143,7 @@ This document defines the physical and mathematical model for all antenna types 
 ## 4. Delta Loop
 
 ### 4.1 Geometry Definition
+
 - **Apex Location:** Highest point at $(0, 0, \text{height})$.
 - **Leg Count & Length:** 3 wires forming a triangle, total perimeter $L$.
 - **Reference Length:** $1.03\lambda$ (Resonance).
@@ -129,22 +152,27 @@ This document defines the physical and mathematical model for all antenna types 
 - **Min Height:** Bottom wire must be $\ge 0.1$ m above ground.
 
 ### 4.2 Feedpoint Definition
+
 - **NEC Excitation:** Center of the bottom horizontal wire (Tag 2).
 - **Segment:** Center segment of Tag 2.
 - **Feed Type:** Single-segment voltage source.
 - **Feedline Support:** Supported (Radiating shield + NEC `TL` card; feedpoint always at apex, offset is not applicable).
 
 ### 4.3 Termination Definition
+
 - **Model:** None.
 
 ### 4.4 SWR Convention
+
 - **Reference:** 50.0 Ω.
 - **Metric:** Raw feedpoint SWR.
 
 ### 4.5 Segmentation Rules
+
 - **Density:** 20 segments per $\lambda$.
 - **Minimum:** 9 segments per side.
 - **Alignment:** Bottom wire should have an **odd** number of segments for center feed.
 
 ### 4.6 Glossary
+
 - Same as Section 1.6.


### PR DESCRIPTION
💡 **Problem:** The documentation for the Sloping V antenna claimed its termination was modeled as a differential resistor across the two tips without a path to ground. However, the engine (`src/store/antennaStore.ts`) actually creates short vertical stub wires from each tip down to near-ground to model realistic shunt-to-earth current paths. The docs had drifted from the active implementation physics.

🎯 **Fix:** Updated `docs/antenna-spec.md` (section 3.3) to accurately reflect the per-leg-to-ground stub topology, including updating the ASCII diagram and descriptions. Also documented this topology drift in `.jules/archivist.md`.

🧪 **Verification:** Checked `src/store/antennaStore.ts` to confirm the actual NEC modeling logic. Ran `npm run lint` and `npm run test` successfully. Formatted the updated markdown files using `prettier`.

🔎 **Scope:** This PR contains ONLY documentation changes to `docs/antenna-spec.md` and `.jules/archivist.md`.

---
*PR created automatically by Jules for task [15995662988352653270](https://jules.google.com/task/15995662988352653270) started by @2fst4u*