### PR TITLE
🎨 Palette: Add ARIA labels to auxiliary buttons

### DIFF
--- a/src/components/Panel/DipoleControl.tsx
+++ b/src/components/Panel/DipoleControl.tsx
@@ -227,6 +227,7 @@ export function DipoleControl() {
               onClick={() => setTerminatingResistor(0)}
               disabled={terminatingResistor === 0}
               title="Remove termination (unterminated antenna)"
+              aria-label="Turn off termination resistor"
               style={{ flex: '0 0 auto' }}
             >
               Off

--- a/src/components/Panel/FeedlineControl.tsx
+++ b/src/components/Panel/FeedlineControl.tsx
@@ -115,6 +115,7 @@ export function FeedlineControl() {
                   onClick={() => setFeedlineOffset(0)}
                   disabled={Math.abs(feedlineOffset) < 1e-6}
                   title={Math.abs(feedlineOffset) < 1e-6 ? 'Feedpoint is already centred' : 'Centre feedpoint'}
+                  aria-label="Centre feedpoint offset"
                   style={{ flex: '0 0 auto' }}
                 >
                   Centre

--- a/src/components/Panel/GroundControl.tsx
+++ b/src/components/Panel/GroundControl.tsx
@@ -40,6 +40,7 @@ export function GroundControl() {
           style={{ padding: '2px 8px', fontSize: 11 }}
           onClick={() => setExpanded((v) => !v)}
           aria-expanded={expanded}
+          aria-label={expanded ? 'Simple: Hide custom ground settings' : 'Custom: Show custom ground settings'}
           title={expanded ? 'Hide custom settings' : 'Show custom settings'}
         >
           {expanded ? 'Simple' : 'Custom'}

--- a/tests/FeedlineControl.test.tsx
+++ b/tests/FeedlineControl.test.tsx
@@ -20,14 +20,14 @@ describe('FeedlineControl', () => {
 
   it('renders the Centre button when feedline is enabled', () => {
     render(<FeedlineControl />);
-    const centreButton = screen.getByRole('button', { name: 'Centre' });
+    const centreButton = screen.getByRole('button', { name: 'Centre feedpoint offset' });
     expect(centreButton).toBeDefined();
     expect(centreButton.textContent).toBe('Centre');
   });
 
   it('resets feedline offset to 0 when Centre button is clicked', () => {
     render(<FeedlineControl />);
-    const centreButton = screen.getByRole('button', { name: 'Centre' });
+    const centreButton = screen.getByRole('button', { name: 'Centre feedpoint offset' });
 
     fireEvent.click(centreButton);
 
@@ -40,6 +40,6 @@ describe('FeedlineControl', () => {
 
     expect(screen.queryByLabelText(/Length/)).toBeNull();
     expect(screen.queryByLabelText(/Attachment offset/)).toBeNull();
-    expect(screen.queryByRole('button', { name: 'Centre' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Centre feedpoint offset' })).toBeNull();
   });
 });


### PR DESCRIPTION
💡 What: Added descriptive ARIA labels to icon-only or generic text auxiliary buttons ("Off", "Centre", "Simple/Custom").
🎯 Why: To improve accessibility for screen reader users by providing context to what the button interacts with without visual reliance.
♿ Accessibility: Ensures WCAG 2.5.3 (Label in Name) compliance where appropriate.

---
*PR created automatically by Jules for task [10229572310979504346](https://jules.google.com/task/10229572310979504346) started by @2fst4u*