### PR TITLE
Remove delta loop termination option

### DIFF
--- a/src/components/Panel/DipoleControl.tsx
+++ b/src/components/Panel/DipoleControl.tsx
@@ -198,7 +198,7 @@ export function DipoleControl() {
         </>
       )}
 
-      {(antennaType === 'sloping-v' || antennaType === 'delta-loop' || antennaType === 'terminated-delta') && (
+      {(antennaType === 'sloping-v' || antennaType === 'terminated-delta') && (
         <>
           <label htmlFor="terminating-resistor" style={{ marginTop: 10 }}>
             Termination resistance (Ω)
@@ -238,9 +238,7 @@ export function DipoleControl() {
               ? 'Unterminated: travelling wave reflects, creating a standing-wave pattern. Use this mode to check whether the antenna structure resonates at the design frequency.'
               : antennaType === 'sloping-v'
                 ? `${terminatingResistor} Ω resistors at each tip (to ground). Click Off to remove termination and inspect resonance. Affects gain, directivity, front/back ratio, feedpoint impedance, realized gain, and termination loss. Lower SWR alone does not indicate the best design point.`
-                : antennaType === 'terminated-delta'
-                  ? `${terminatingResistor} Ω resistors at each inner half-base end (to ground via short stubs). Click Off to remove termination and inspect resonance. Affects gain, directivity, front/back ratio, feedpoint impedance, realized gain, and termination loss. Lower SWR alone does not indicate the best design point.`
-                  : `${terminatingResistor} Ω load at the base centre. Click Off to remove termination and inspect resonance. Affects gain, directivity, feedpoint impedance, realized gain, and termination loss. Lower SWR alone does not indicate the best design point.`}
+                : `${terminatingResistor} Ω resistors at each inner half-base end (to ground via short stubs). Click Off to remove termination and inspect resonance. Affects gain, directivity, front/back ratio, feedpoint impedance, realized gain, and termination loss. Lower SWR alone does not indicate the best design point.`}
           </div>
         </>
       )}

--- a/src/store/antennaStore.ts
+++ b/src/store/antennaStore.ts
@@ -129,7 +129,6 @@ export interface AntennaState {
    * 0 = unterminated.
    *
    * - sloping-V: inserts stub wires with NEC LD cards for tip-to-earth termination.
-   * - delta-loop: inserts one NEC LD 4 card at the centre of the base wire.
    * - terminated-delta: inserts two stub wires (one at each inner half-base
    *   end) with NEC LD cards, modelling per-resistor shunt-to-earth termination.
    */
@@ -303,6 +302,7 @@ export const useAntennaStore = create<AntennaState>()(
         if (type === 'dipole') {
           s.vAngle = 180;
           s.legSlope = 0;
+          s.terminatingResistor = 0;
         } else if (type === 'sloping-v') {
           // Slope is auto-computed from height and leg length (tips at ground).
           // V-angle snaps to the value giving maximum forward gain; the user
@@ -314,9 +314,11 @@ export const useAntennaStore = create<AntennaState>()(
         } else if (type === 'inverted-v') {
           s.vAngle = 120;
           s.legSlope = 0;
+          s.terminatingResistor = 0;
         } else if (type === 'delta-loop') {
           s.vAngle = 180;
           s.legSlope = 0;
+          s.terminatingResistor = 0;
         } else if (type === 'terminated-delta') {
           s.vAngle = 180;
           s.legSlope = 0;
@@ -888,19 +890,6 @@ export function selectSimulationInput(state: AntennaState): SimulationInput {
         param2: 0,
       });
     }
-  }
-
-  if (state.antennaType === 'delta-loop' && state.terminatingResistor > 0) {
-    const baseWire = wires.find((w) => w.tag === DELTA_BASE_TAG)!;
-    const centerSeg = Math.ceil(baseWire.segments / 2);
-    loads.push({
-      type: 4,
-      wireTag: DELTA_BASE_TAG,
-      segmentStart: centerSeg,
-      segmentEnd: centerSeg,
-      param1: state.terminatingResistor,
-      param2: 0,
-    });
   }
 
   if (state.antennaType === 'sloping-v' && state.terminatingResistor > 0) {

--- a/tests/deltaLoopTermination.test.ts
+++ b/tests/deltaLoopTermination.test.ts
@@ -16,78 +16,30 @@ function setupDeltaLoop(terminatingResistor?: number) {
   }
 }
 
-describe('Delta Loop termination (LD 4 at base centre)', () => {
+describe('Delta Loop termination (removed)', () => {
   beforeEach(() => {
     useAntennaStore.getState().setTerminatingResistor(0);
   });
 
-  it('no LD card when unterminated (terminatingResistor=0)', () => {
-    setupDeltaLoop(0);
+  it('no LD card even if terminatingResistor > 0 (logic removed)', () => {
+    setupDeltaLoop(600);
     const input = selectSimulationInput(useAntennaStore.getState());
     const deck = buildNecCards(input);
     expect(getNecLines(deck, 'LD')).toHaveLength(0);
     expect(input.loads).toBeUndefined();
   });
 
-  it('exactly one LD card when terminatingResistor > 0', () => {
-    setupDeltaLoop(600);
-    const input = selectSimulationInput(useAntennaStore.getState());
-    const deck = buildNecCards(input);
-    expect(getNecLines(deck, 'LD')).toHaveLength(1);
-    expect(input.loads).toHaveLength(1);
-  });
-
-  it('LD card is type 4', () => {
-    setupDeltaLoop(600);
-    const input = selectSimulationInput(useAntennaStore.getState());
-    const deck = buildNecCards(input);
-    const ld = parseLdLine(getNecLines(deck, 'LD')[0]);
-    expect(ld.type).toBe(4);
-  });
-
-  it('LD card targets DELTA_BASE_TAG', () => {
-    setupDeltaLoop(600);
-    const input = selectSimulationInput(useAntennaStore.getState());
-    const deck = buildNecCards(input);
-    const ld = parseLdLine(getNecLines(deck, 'LD')[0]);
-    expect(ld.tag).toBe(DELTA_BASE_TAG);
-  });
-
-  it('LD card targets the centre segment of the base wire', () => {
-    setupDeltaLoop(600);
-    const input = selectSimulationInput(useAntennaStore.getState());
-    const baseWire = input.wires.find((w) => w.tag === DELTA_BASE_TAG)!;
-    const expectedCenter = Math.ceil(baseWire.segments / 2);
-    const deck = buildNecCards(input);
-    const ld = parseLdLine(getNecLines(deck, 'LD')[0]);
-    expect(ld.segmentStart).toBe(expectedCenter);
-    expect(ld.segmentEnd).toBe(expectedCenter);
-  });
-
-  it('LD resistance equals terminatingResistor directly (not halved)', () => {
-    const R = 600;
-    setupDeltaLoop(R);
-    const input = selectSimulationInput(useAntennaStore.getState());
-    const deck = buildNecCards(input);
-    const ld = parseLdLine(getNecLines(deck, 'LD')[0]);
-    expect(ld.p1).toBeCloseTo(R, 9);
-    expect(ld.p2).toBeCloseTo(0, 9);
-  });
-
-  it('LD resistance scales with terminatingResistor', () => {
-    setupDeltaLoop(1200);
-    const input1 = selectSimulationInput(useAntennaStore.getState());
-    const ld1 = parseLdLine(getNecLines(buildNecCards(input1), 'LD')[0]);
-
+  it('setAntennaType("delta-loop") resets terminatingResistor to 0', () => {
+    useAntennaStore.getState().setAntennaType('sloping-v');
     useAntennaStore.getState().setTerminatingResistor(600);
-    const input2 = selectSimulationInput(useAntennaStore.getState());
-    const ld2 = parseLdLine(getNecLines(buildNecCards(input2), 'LD')[0]);
+    expect(useAntennaStore.getState().terminatingResistor).toBe(600);
 
-    expect(ld2.p1).toBeCloseTo(ld1.p1 / 2, 9);
+    useAntennaStore.getState().setAntennaType('delta-loop');
+    expect(useAntennaStore.getState().terminatingResistor).toBe(0);
   });
 
   it('excitation remains on left leg (DIPOLE_LEFT_TAG) last segment', () => {
-    setupDeltaLoop(600);
+    setupDeltaLoop(0);
     const input = selectSimulationInput(useAntennaStore.getState());
     const leftLeg = input.wires.find((w) => w.tag === DIPOLE_LEFT_TAG)!;
     expectExcitation(buildNecCards(input), DIPOLE_LEFT_TAG, leftLeg.segments);

--- a/tests/deltaLoopTermination.test.ts
+++ b/tests/deltaLoopTermination.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { useAntennaStore, selectSimulationInput } from '../src/store/antennaStore';
 import { buildNecCards } from '../src/physics/necCard';
-import { getNecLines, parseLdLine, expectExcitation } from './necInspect';
-import { DELTA_BASE_TAG, DIPOLE_LEFT_TAG } from '../src/physics/constants';
+import { getNecLines, expectExcitation } from './necInspect';
+import { DIPOLE_LEFT_TAG } from '../src/physics/constants';
 
 function setupDeltaLoop(terminatingResistor?: number) {
   const store = useAntennaStore.getState();


### PR DESCRIPTION
Removed the termination option for the delta loop antenna, including both the UI controls and the underlying simulation logic. Added state resetting in the store to ensure switching to delta loop clears any previous termination value. Verified with unit tests and visual inspection.

Fixes #216

---
*PR created automatically by Jules for task [11518031926453278964](https://jules.google.com/task/11518031926453278964) started by @2fst4u*