### PR TITLE
🧹 Sweep: [Remove unused DELTA_LOOP_RIGHT_LEG_TAG variable]

### DIFF
--- a/src/physics/constants.ts
+++ b/src/physics/constants.ts
@@ -71,7 +71,6 @@ export const DIPOLE_LEFT_TAG = 1; // left half of split dipole
 export const DIPOLE_RIGHT_TAG = 2; // right half of split dipole
 export const FEED_BRIDGE_TAG = 3; // 1-segment source bridge
 export const FEEDLINE_SHIELD_TAG = 4; // coax shield (radiating outer surface)
-export const DELTA_LOOP_RIGHT_LEG_TAG = 5; // right leg of delta loop (apex to right corner) — superseded by DIPOLE_RIGHT_TAG; kept for compatibility
 export const DELTA_BASE_TAG = 6; // base wire of delta loop (left corner to right corner)
 
 /**


### PR DESCRIPTION
💡 What: Removed the `DELTA_LOOP_RIGHT_LEG_TAG` constant from `src/physics/constants.ts`.
🎯 Why: It was an unused artifact superseded by `DIPOLE_RIGHT_TAG`, and no longer referenced anywhere in the project. Removing it reduces tech debt and cleans up the namespace.
🔬 Verification: Ran a global search (`grep -rn "DELTA_LOOP_RIGHT_LEG_TAG" src/`) which confirmed it was only defined but never used. Ran `npm run build`, `npm run lint`, and `npm run test` successfully after the deletion.

---
*PR created automatically by Jules for task [8254677665860211845](https://jules.google.com/task/8254677665860211845) started by @2fst4u*