### PR TITLE
Fix balun impedance ratio input backspacing issue

### DIFF
--- a/src/components/Panel/TransformerControl.tsx
+++ b/src/components/Panel/TransformerControl.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useAntennaStore } from '../../store/antennaStore';
 import { TRANSFORMER_INSERTION_LOSS_DB } from '../../physics/constants';
 
@@ -13,6 +14,19 @@ export function TransformerControl() {
   const transformerRatio = useAntennaStore((s) => s.transformerRatio);
   const setTransformerEnabled = useAntennaStore((s) => s.setTransformerEnabled);
   const setTransformerRatio = useAntennaStore((s) => s.setTransformerRatio);
+
+  // Local state to allow natural typing (including empty strings)
+  const [localRatio, setLocalRatio] = useState(transformerRatio.toString());
+  const [isFocused, setIsFocused] = useState(false);
+
+  // Sync local state when the store value changes (e.g. from outside)
+  const [prevRatio, setPrevRatio] = useState(transformerRatio);
+  if (transformerRatio !== prevRatio) {
+    setPrevRatio(transformerRatio);
+    if (!isFocused) {
+      setLocalRatio(transformerRatio.toString());
+    }
+  }
 
   return (
     <section aria-labelledby="transformer-heading" style={{ marginTop: 14, paddingTop: 12, borderTop: '1px solid var(--border)' }}>
@@ -53,11 +67,20 @@ export function TransformerControl() {
             min={1}
             max={10000}
             step={1}
-            value={transformerRatio}
+            value={localRatio}
             aria-describedby="transformer-hint"
+            onFocus={() => setIsFocused(true)}
             onChange={(e) => {
-              const v = parseFloat(e.target.value);
-              if (Number.isFinite(v) && v >= 1) setTransformerRatio(v);
+              const s = e.target.value;
+              setLocalRatio(s);
+              const v = parseFloat(s);
+              if (Number.isFinite(v) && v >= 1) {
+                setTransformerRatio(v);
+              }
+            }}
+            onBlur={() => {
+              setIsFocused(false);
+              setLocalRatio(transformerRatio.toString());
             }}
             style={{ width: '100%', marginTop: 4 }}
           />

--- a/tests/DipoleControl.test.tsx
+++ b/tests/DipoleControl.test.tsx
@@ -21,6 +21,8 @@ interface MockState {
   orientation: string | number;
   vAngle: number;
   terminatingResistor: number;
+  transformerEnabled: boolean;
+  transformerRatio: number;
   setAntennaType: () => void;
   setLength: () => void;
   setHalfWaveLength: () => void;
@@ -29,6 +31,8 @@ interface MockState {
   setOrientation: (o: string | number) => void;
   setVAngle: () => void;
   setTerminatingResistor: () => void;
+  setTransformerEnabled: () => void;
+  setTransformerRatio: () => void;
 }
 
 function buildMockState(overrides: Partial<MockState> = {}): MockState {
@@ -41,6 +45,8 @@ function buildMockState(overrides: Partial<MockState> = {}): MockState {
     orientation: 'EW',
     vAngle: 120,
     terminatingResistor: 0,
+    transformerEnabled: false,
+    transformerRatio: 9,
     setAntennaType: vi.fn(),
     setLength: vi.fn(),
     setHalfWaveLength: vi.fn(),
@@ -49,6 +55,8 @@ function buildMockState(overrides: Partial<MockState> = {}): MockState {
     setOrientation: vi.fn(),
     setVAngle: vi.fn(),
     setTerminatingResistor: vi.fn(),
+    setTransformerEnabled: vi.fn(),
+    setTransformerRatio: vi.fn(),
     ...overrides,
   };
 }


### PR DESCRIPTION
The impedance ratio input in the TransformerControl component was previously tied directly to the numeric store value, which prevented users from backspacing the field to an empty string to enter a new value.

This change introduces a local string state `localRatio` and a focus-tracking flag to decouple the UI's displayed value from the store's numeric state while the user is typing. The store is updated whenever a valid number is entered, and the local state is synchronized back from the store when the input loses focus or when the store changes externally.

Additionally, updated the mock state in `tests/DipoleControl.test.tsx` to include the transformer properties, as DipoleControl embeds TransformerControl and requires these values to render correctly.

Verified the fix using a Playwright script and screenshots. All existing tests and linting pass.

Fixes #223

---
*PR created automatically by Jules for task [7458250760047722891](https://jules.google.com/task/7458250760047722891) started by @2fst4u*