### PR TITLE
🔭 Scout: Add title attribute to external link

### DIFF
--- a/src/components/Panel/ControlPanel.tsx
+++ b/src/components/Panel/ControlPanel.tsx
@@ -57,10 +57,12 @@ export function ControlPanel() {
         color: 'var(--text-muted)',
         textAlign: 'center',
       }}>
+        {/* SEO: Add title attribute to external link for better context and discoverability */}
         <a
           href="https://github.com/2fst4u/gain-observer"
           target="_blank"
           rel="noopener noreferrer"
+          title="View source code on GitHub"
           style={{ color: 'inherit', textDecoration: 'none' }}
           onMouseOver={(e) => (e.currentTarget.style.textDecoration = 'underline')}
           onMouseOut={(e) => (e.currentTarget.style.textDecoration = 'none')}


### PR DESCRIPTION
💡 What: Added a `title` attribute ("View source code on GitHub") to the external GitHub source link in `ControlPanel.tsx`.
🎯 Why: Search engines and assistive technologies use the `title` attribute on anchors to better understand link context and intent when navigating externally. This improves the overall accessibility and discoverability of the link for crawlers without altering the visible UI.
📊 Value: Enhances semantic richness for crawlers and provides an explicit tooltip for desktop users, all while remaining completely invisible to the visual design.
🔬 Measurement: Verify the presence of the `title="View source code on GitHub"` attribute on the `.app-controls footer a` element in the DOM inspector.

---
*PR created automatically by Jules for task [6627701523321246486](https://jules.google.com/task/6627701523321246486) started by @2fst4u*