### PR TITLE
🧹 Sweep: Remove unused parseNtLine function

### DIFF
--- a/.jules/sweep.md
+++ b/.jules/sweep.md
@@ -1,3 +1,6 @@
 ## 2024-05-13 - Knip Unused Export Removal
 **Learning:** `knip` correctly identifies types that are unused outside of the file they are defined in, but removing the `export` keyword can break TypeScript builds if the types are referenced internally by other *exported* interfaces in the same file. I need to be careful when removing `export` from types and verify that they aren't part of an exported interface's signature.
 **Action:** Always check internal usages of a type within the file, especially if it's used in the signature of other exported entities, before deciding to drop the `export` keyword. Run `npm run build` to guarantee safety.
+## 2024-05-22 - [Kept for compatibility]
+**Learning:** Code Cleanup Safety Pattern: Never remove exported constants or variables that are explicitly marked in comments as 'kept for compatibility' (e.g., DELTA_LOOP_RIGHT_LEG_TAG), even if they appear completely unused in the current repository, to avoid breaking external systems or legacy data parsing.
+**Action:** Always read the inline comments of a variable or function before removing it to ensure it is not kept for compatibility reasons.

--- a/tests/necInspect.ts
+++ b/tests/necInspect.ts
@@ -69,29 +69,6 @@ export function parseTlLine(line: string) {
 }
 
 /**
- * Parses an NT (Two-port Network) card line.
- * Format: NT tag1 seg1 tag2 seg2 Y11r Y11i Y12r Y12i Y22r Y22i
- */
-export function parseNtLine(line: string) {
-  const parts = line.trim().split(/\s+/);
-  if (parts[0] !== 'NT') {
-    throw new Error(`Not an NT line: ${line}`);
-  }
-  return {
-    tag1: parseInt(parts[1], 10),
-    seg1: parseInt(parts[2], 10),
-    tag2: parseInt(parts[3], 10),
-    seg2: parseInt(parts[4], 10),
-    y11Real: parseFloat(parts[5]),
-    y11Imag: parseFloat(parts[6]),
-    y12Real: parseFloat(parts[7]),
-    y12Imag: parseFloat(parts[8]),
-    y22Real: parseFloat(parts[9]),
-    y22Imag: parseFloat(parts[10]),
-  };
-}
-
-/**
  * Asserts that no wires in the deck have endpoints at or below z=0.
  * Useful for verifying height regressions.
  */


### PR DESCRIPTION
💡 What: Removed `parseNtLine` test utility function in `tests/necInspect.ts`
🎯 Why: It is never used in the current test suite and simply adds clutter. 
🔬 Verification: Ran `grep -rn "parseNtLine" src/ tests/` which yielded no usages. Tests, linter, and build checks passed successfully.

---
*PR created automatically by Jules for task [9379939618317011230](https://jules.google.com/task/9379939618317011230) started by @2fst4u*