### PR TITLE
🧪 Test: Add displayLengthUnit tests

### DIFF
--- a/tests/units.test.ts
+++ b/tests/units.test.ts
@@ -3,9 +3,15 @@ import {
   toDisplayLength,
   fromDisplayLength,
   formatLength,
+  displayLengthUnit,
 } from '../src/physics/units';
 
 describe('unit conversions', () => {
+  it('displayLengthUnit returns correct suffix for unit system', () => {
+    expect(displayLengthUnit('metric')).toBe('m');
+    expect(displayLengthUnit('imperial')).toBe('ft');
+  });
+
   it('round-trips m → ft → m within float precision', () => {
     const samples = [0, 0.1, 1, 10.05, 21.11, 100];
     for (const m of samples) {


### PR DESCRIPTION
🎯 **What:** Added missing tests for the `displayLengthUnit` utility function in `src/physics/units.ts`, addressing a test gap.
📊 **Coverage:** Covered returning the correct suffix 'm' for the 'metric' system and 'ft' for the 'imperial' system.
✨ **Result:** Enhanced the unit test suite coverage by ensuring the previously untested string representation logic is robustly tested.

---
*PR created automatically by Jules for task [3355072346622440405](https://jules.google.com/task/3355072346622440405) started by @2fst4u*