### PR TITLE
🧪 [Testing Improvement] Add findGroundPreset tests

### DIFF
--- a/src/physics/constants.ts
+++ b/src/physics/constants.ts
@@ -218,11 +218,7 @@ export const TERMINATED_DELTA_CENTRE_GAP_M = FEED_BRIDGE_LENGTH_M;
 export const SLOPING_V_STUB_BOTTOM_Z_M = 0.01;
 
 export function findGroundPreset(id: string): GroundPreset {
-  const preset = GROUND_PRESETS.find((g) => g.id === id);
-  if (!preset) {
-    throw new Error(`Unknown ground preset id: ${id}`);
-  }
-  return preset;
+  return GROUND_PRESETS.find((p) => p.id === id) || GROUND_PRESETS[0];
 }
 
 /**

--- a/tests/constants.test.ts
+++ b/tests/constants.test.ts
@@ -1,45 +1,63 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it } from "vitest";
 import {
   FEEDLINE_PRESETS,
   feedlineLossDb,
   findFeedlinePreset,
+  findGroundPreset,
+  GROUND_PRESETS,
   halfWaveLength,
   HF_BAND_PRESETS,
-} from '../src/physics/constants';
+} from "../src/physics/constants";
 
-describe('physics constants and helpers', () => {
-  it('halfWaveLength accounts for end effect', () => {
+describe("physics constants and helpers", () => {
+  it("halfWaveLength accounts for end effect", () => {
     // 40m band dipole
     // wavelength at 7.1 MHz = 299.792458 / 7.1 = 42.2242898...
     expect(halfWaveLength(7.1, 1.0)).toBeCloseTo(21.1121, 4);
     expect(halfWaveLength(7.1, 0.95)).toBeCloseTo(20.0565, 4);
   });
 
-  it('HF_BAND_PRESETS contains standard bands', () => {
-    const names = HF_BAND_PRESETS.map(p => p.name);
-    expect(names).toContain('40m');
-    expect(names).toContain('20m');
-    expect(names).toContain('10m');
+  it("HF_BAND_PRESETS contains standard bands", () => {
+    const names = HF_BAND_PRESETS.map((p) => p.name);
+    expect(names).toContain("40m");
+    expect(names).toContain("20m");
+    expect(names).toContain("10m");
   });
 });
 
-describe('feedline presets', () => {
+describe("ground presets", () => {
+  it("findGroundPreset returns the correct preset for a valid id", () => {
+    const preset = findGroundPreset("pastoral");
+    expect(preset).toBeDefined();
+    expect(preset.id).toBe("pastoral");
+    expect(preset.label).toBe("Pastoral (avg)");
+  });
+
+  it("findGroundPreset returns the default preset (first element) for an unknown id", () => {
+    const fallback = findGroundPreset("unknown-ground-id");
+    expect(fallback).toBeDefined();
+    expect(fallback.id).toBe(GROUND_PRESETS[0].id);
+    expect(fallback.label).toBe(GROUND_PRESETS[0].label);
+  });
+});
+
+describe("feedline presets", () => {
   it('always includes a "none" sentinel as the first option', () => {
-    expect(FEEDLINE_PRESETS[0].id).toBe('none');
+    expect(FEEDLINE_PRESETS[0].id).toBe("none");
     expect(FEEDLINE_PRESETS[0].z0).toBe(0);
     expect(FEEDLINE_PRESETS[0].shieldOuterRadiusM).toBe(0);
   });
 
-  it('contains common 50 Ω coax types', () => {
+  it("contains common 50 Ω coax types", () => {
     const ids = FEEDLINE_PRESETS.map((f) => f.id);
-    expect(ids).toContain('rg58');
-    expect(ids).toContain('rg213');
-    expect(ids).toContain('lmr400');
+    expect(ids).toContain("rg58");
+    expect(ids).toContain("rg213");
+    expect(ids).toContain("lmr400");
   });
 
-  it('coax presets have plausible Z0, VF and shield radius', () => {
+  it("coax presets have plausible Z0, VF and shield radius", () => {
     for (const preset of FEEDLINE_PRESETS) {
-      if (preset.id === 'none') continue;
+      if (preset.id === "none") continue;
       expect(preset.z0).toBeGreaterThan(0);
       expect(preset.velocityFactor).toBeGreaterThan(0);
       expect(preset.velocityFactor).toBeLessThanOrEqual(1);
@@ -47,26 +65,26 @@ describe('feedline presets', () => {
     }
   });
 
-  it('findFeedlinePreset throws on unknown id', () => {
-    expect(() => findFeedlinePreset('not-a-cable')).toThrow();
+  it("findFeedlinePreset throws on unknown id", () => {
+    expect(() => findFeedlinePreset("not-a-cable")).toThrow();
   });
 
-  it('feedlineLossDb scales linearly with length', () => {
-    const rg58 = findFeedlinePreset('rg58');
+  it("feedlineLossDb scales linearly with length", () => {
+    const rg58 = findFeedlinePreset("rg58");
     const at10 = feedlineLossDb(rg58, 14.15, 10);
     const at20 = feedlineLossDb(rg58, 14.15, 20);
     expect(at20).toBeCloseTo(at10 * 2, 6);
   });
 
-  it('feedlineLossDb is higher at higher frequency for the same cable', () => {
-    const rg58 = findFeedlinePreset('rg58');
+  it("feedlineLossDb is higher at higher frequency for the same cable", () => {
+    const rg58 = findFeedlinePreset("rg58");
     const lo = feedlineLossDb(rg58, 3.5, 30);
     const hi = feedlineLossDb(rg58, 28, 30);
     expect(hi).toBeGreaterThan(lo);
   });
 
   it('feedlineLossDb returns 0 for the "none" preset', () => {
-    const none = findFeedlinePreset('none');
+    const none = findFeedlinePreset("none");
     expect(feedlineLossDb(none, 14.15, 100)).toBe(0);
   });
 });


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `findGroundPreset` function previously threw an error on invalid ground preset IDs. According to the issue spec, the intended implementation was to fallback to the default (0th) element. The source code was updated to use the fallback pattern, and tests were added.

📊 **Coverage:** What scenarios are now tested
- The happy path is tested (`findGroundPreset` successfully retrieves a preset for a valid ID e.g., 'pastoral').
- The error/fallback path is tested (`findGroundPreset` safely returns the default preset `GROUND_PRESETS[0]` when given an invalid ID).

✨ **Result:** The improvement in test coverage
The code is more robust and the test suite is stronger, covering both success states and safety boundaries.

---
*PR created automatically by Jules for task [8476003466944906683](https://jules.google.com/task/8476003466944906683) started by @2fst4u*