### PR TITLE
🧪 test: Add tests for computeOptimalVAngleDeg

### DIFF
--- a/tests/antennaStore.test.ts
+++ b/tests/antennaStore.test.ts
@@ -1,39 +1,40 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it } from "vitest";
 import {
   useAntennaStore,
   buildWires,
   selectSimulationInput,
   computeEffectiveSlope,
   legMultipleFromLength,
+  computeOptimalVAngleDeg,
   DIPOLE_LEFT_TAG,
   DIPOLE_RIGHT_TAG,
   DELTA_BASE_TAG,
   FEEDLINE_SHIELD_TAG,
   VERTICAL_WHIP_TAG,
   type AntennaState,
-} from '../src/store/antennaStore';
+} from "../src/store/antennaStore";
 import {
   DEFAULT_WHIP_LENGTH_M,
   VERTICAL_WHIP_BASE_GAP_M,
   VERTICAL_WHIP_RADIAL_TAG,
   VERTICAL_WHIP_RADIAL_COUNT,
-} from '../src/physics/constants';
+} from "../src/physics/constants";
 
-describe('antennaStore selectors', () => {
-  describe('buildWires', () => {
-    it('generates a single wire when no feedline is configured (EW)', () => {
+describe("antennaStore selectors", () => {
+  describe("buildWires", () => {
+    it("generates a single wire when no feedline is configured (EW)", () => {
       // Arrange
       const state = {
-        antennaType: 'dipole' as const,
+        antennaType: "dipole" as const,
         length: 20,
         height: 10,
-        orientation: 'EW' as const,
+        orientation: "EW" as const,
         wireRadius: 0.001,
         segments: 21,
         frequency: 7.1,
         vAngle: 180,
         legSlope: 0,
-        feedlineId: 'none',
+        feedlineId: "none",
         feedlineLength: 0,
         feedlineOffset: 0,
       };
@@ -52,18 +53,18 @@ describe('antennaStore selectors', () => {
       expect(wires[0].segments).toBe(21);
     });
 
-    it('generates correct wire coordinates for NS orientation (no feedline)', () => {
+    it("generates correct wire coordinates for NS orientation (no feedline)", () => {
       const state = {
-        antennaType: 'dipole' as const,
+        antennaType: "dipole" as const,
         length: 20,
         height: 15,
-        orientation: 'NS' as const,
+        orientation: "NS" as const,
         wireRadius: 0.002,
         segments: 11,
         frequency: 7.1,
         vAngle: 180,
         legSlope: 0,
-        feedlineId: 'none',
+        feedlineId: "none",
         feedlineLength: 0,
         feedlineOffset: 0,
       };
@@ -76,9 +77,9 @@ describe('antennaStore selectors', () => {
       expect(wires[0].end[1]).toBeCloseTo(10, 5);
     });
 
-    it('generates correct wire coordinates for numeric orientation (45 deg)', () => {
+    it("generates correct wire coordinates for numeric orientation (45 deg)", () => {
       const state = {
-        antennaType: 'dipole' as const,
+        antennaType: "dipole" as const,
         length: 10,
         height: 5,
         orientation: 45,
@@ -87,7 +88,7 @@ describe('antennaStore selectors', () => {
         frequency: 7.1,
         vAngle: 180,
         legSlope: 0,
-        feedlineId: 'none',
+        feedlineId: "none",
         feedlineLength: 0,
         feedlineOffset: 0,
       };
@@ -103,18 +104,18 @@ describe('antennaStore selectors', () => {
       expect(wires[0].end[1]).toBeCloseTo(half * sin45, 5);
     });
 
-    it('builds split-dipole + bridge + shield when feedline is configured', () => {
+    it("builds split-dipole + bridge + shield when feedline is configured", () => {
       const wires = buildWires({
-        antennaType: 'dipole' as const,
+        antennaType: "dipole" as const,
         length: 20,
         height: 10,
-        orientation: 'EW' as const,
+        orientation: "EW" as const,
         wireRadius: 0.001,
         segments: 21,
         frequency: 7.1,
         vAngle: 180,
         legSlope: 0,
-        feedlineId: 'rg58',
+        feedlineId: "rg58",
         feedlineLength: 8,
         feedlineOffset: 0,
       });
@@ -134,18 +135,18 @@ describe('antennaStore selectors', () => {
       expect(right.start).toEqual(bridge.end);
     });
 
-    it('shifts the source bridge along the dipole axis when offset is nonzero', () => {
+    it("shifts the source bridge along the dipole axis when offset is nonzero", () => {
       const wires = buildWires({
-        antennaType: 'dipole' as const,
+        antennaType: "dipole" as const,
         length: 20,
         height: 10,
-        orientation: 'EW' as const,
+        orientation: "EW" as const,
         wireRadius: 0.001,
         segments: 21,
         frequency: 7.1,
         vAngle: 180,
         legSlope: 0,
-        feedlineId: 'rg58',
+        feedlineId: "rg58",
         feedlineLength: 8,
         feedlineOffset: 2, // 2 m east of centre
       });
@@ -163,18 +164,18 @@ describe('antennaStore selectors', () => {
       expect(leftLen).toBeGreaterThan(rightLen);
     });
 
-    it('clamps offset so the bridge cannot escape the dipole', () => {
+    it("clamps offset so the bridge cannot escape the dipole", () => {
       const wires = buildWires({
-        antennaType: 'dipole' as const,
+        antennaType: "dipole" as const,
         length: 4,
         height: 10,
-        orientation: 'EW' as const,
+        orientation: "EW" as const,
         wireRadius: 0.001,
         segments: 21,
         frequency: 7.1,
         vAngle: 180,
         legSlope: 0,
-        feedlineId: 'rg58',
+        feedlineId: "rg58",
         feedlineLength: 5,
         feedlineOffset: 999, // absurdly large
       });
@@ -186,8 +187,8 @@ describe('antennaStore selectors', () => {
     });
   });
 
-  describe('ground logic (via selectSimulationInput)', () => {
-    it('returns free space ground when height is <= 0', () => {
+  describe("ground logic (via selectSimulationInput)", () => {
+    it("returns free space ground when height is <= 0", () => {
       // Arrange
       const state = useAntennaStore.getState();
 
@@ -195,28 +196,38 @@ describe('antennaStore selectors', () => {
       const input = selectSimulationInput({ ...state, height: 0 });
 
       // Assert
-      expect(input.ground.type).toBe('free');
+      expect(input.ground.type).toBe("free");
     });
 
-    it('returns perfect ground when groundId is perfect', () => {
+    it("returns perfect ground when groundId is perfect", () => {
       const state = useAntennaStore.getState();
-      const input = selectSimulationInput({ ...state, height: 10, groundId: 'perfect' });
-      expect(input.ground.type).toBe('perfect');
+      const input = selectSimulationInput({
+        ...state,
+        height: 10,
+        groundId: "perfect",
+      });
+      expect(input.ground.type).toBe("perfect");
     });
 
-    it('returns real ground with sigma and epsilon when groundId is custom', () => {
+    it("returns real ground with sigma and epsilon when groundId is custom", () => {
       const state = useAntennaStore.getState();
-      const input = selectSimulationInput({ ...state, height: 10, groundId: 'custom', groundSigma: 0.005, groundEpsilon: 13 });
-      expect(input.ground.type).toBe('real');
-      if (input.ground.type === 'real') {
+      const input = selectSimulationInput({
+        ...state,
+        height: 10,
+        groundId: "custom",
+        groundSigma: 0.005,
+        groundEpsilon: 13,
+      });
+      expect(input.ground.type).toBe("real");
+      if (input.ground.type === "real") {
         expect(input.ground.sigma).toBe(0.005);
         expect(input.ground.epsilon).toBe(13);
       }
     });
   });
 
-  describe('selectSimulationInput', () => {
-    it('combines state into simulation input correctly (no feedline)', () => {
+  describe("selectSimulationInput", () => {
+    it("combines state into simulation input correctly (no feedline)", () => {
       // Arrange
       const state = useAntennaStore.getState();
       const testState = {
@@ -224,10 +235,10 @@ describe('antennaStore selectors', () => {
         frequency: 14.1,
         length: 10,
         height: 5,
-        orientation: 'EW' as const,
+        orientation: "EW" as const,
         segments: 11,
-        antennaType: 'dipole' as const,
-        feedlineId: 'none',
+        antennaType: "dipole" as const,
+        feedlineId: "none",
         feedlineLength: 0,
       };
 
@@ -246,15 +257,15 @@ describe('antennaStore selectors', () => {
       expect(input.loads).toBeUndefined();
     });
 
-    it('builds split-dipole topology with TL card when a feedline is configured', () => {
+    it("builds split-dipole topology with TL card when a feedline is configured", () => {
       const state = useAntennaStore.getState();
       const testState = {
         ...state,
         frequency: 14.1,
         height: 10,
         segments: 21,
-        antennaType: 'dipole' as const,
-        feedlineId: 'rg58',
+        antennaType: "dipole" as const,
+        feedlineId: "rg58",
         feedlineLength: 8,
         feedlineOffset: 0,
         transformerEnabled: false,
@@ -276,7 +287,7 @@ describe('antennaStore selectors', () => {
       expect(input.transmissionLines).toHaveLength(1);
       const tl = input.transmissionLines![0];
       expect(tl.fromTag).toBe(3); // source bridge
-      expect(tl.toTag).toBe(4);   // shield
+      expect(tl.toTag).toBe(4); // shield
       expect(tl.z0).toBe(50);
       // Electrical length = physical / VF (RG-58 VF = 0.66).
       expect(tl.lengthM).toBeCloseTo(8 / 0.66, 5);
@@ -284,13 +295,13 @@ describe('antennaStore selectors', () => {
       expect(input.loads).toBeUndefined();
     });
 
-    it('shield is attached to one side of the bridge (asymmetric feed)', () => {
+    it("shield is attached to one side of the bridge (asymmetric feed)", () => {
       const state = useAntennaStore.getState();
       const input = selectSimulationInput({
         ...state,
         height: 10,
-        antennaType: 'dipole',
-        feedlineId: 'rg58',
+        antennaType: "dipole",
+        feedlineId: "rg58",
         feedlineLength: 8,
         feedlineOffset: 1.5,
       });
@@ -300,18 +311,18 @@ describe('antennaStore selectors', () => {
       expect(shield.start).toEqual(right.start);
     });
 
-    it('generates sloping-V geometry correctly', () => {
+    it("generates sloping-V geometry correctly", () => {
       const state = {
-        antennaType: 'sloping-v' as const,
+        antennaType: "sloping-v" as const,
         length: 80, // ~2 lambda
         height: 10,
-        orientation: 'EW' as const,
+        orientation: "EW" as const,
         wireRadius: 0.001,
         segments: 21,
         frequency: 7.1,
         vAngle: 90,
         legSlope: 30,
-        feedlineId: 'none',
+        feedlineId: "none",
       };
 
       const wires = buildWires(state);
@@ -353,18 +364,18 @@ describe('antennaStore selectors', () => {
       expect(rightTipWire.end[2]).toBeCloseTo(0.5, 5);
     });
 
-    it('clamps sloping-V slope to prevent tips hitting ground', () => {
+    it("clamps sloping-V slope to prevent tips hitting ground", () => {
       const state = {
-        antennaType: 'sloping-v' as const,
+        antennaType: "sloping-v" as const,
         length: 100, // half = 50
         height: 10,
-        orientation: 'EW' as const,
+        orientation: "EW" as const,
         wireRadius: 0.001,
         segments: 21,
         frequency: 7.1,
         vAngle: 180,
         legSlope: 45, // requested 45 deg
-        feedlineId: 'none',
+        feedlineId: "none",
       };
 
       const wires = buildWires(state);
@@ -379,13 +390,13 @@ describe('antennaStore selectors', () => {
       expect(rightWires[rightWires.length - 1]!.end[2]).toBeCloseTo(0.5, 5);
     });
 
-    it('adds an LD choke on the shield when transformer is fitted at the antenna', () => {
+    it("adds an LD choke on the shield when transformer is fitted at the antenna", () => {
       const state = useAntennaStore.getState();
       const testState = {
         ...state,
         height: 10,
-        antennaType: 'dipole' as const,
-        feedlineId: 'rg213',
+        antennaType: "dipole" as const,
+        feedlineId: "rg213",
         feedlineLength: 6,
         feedlineOffset: 0,
         transformerEnabled: true,
@@ -403,24 +414,24 @@ describe('antennaStore selectors', () => {
       expect(ld.param2).toBe(0);
     });
 
-    it('adds shield wire and TL card for sloping-v with feedline', () => {
+    it("adds shield wire and TL card for sloping-v with feedline", () => {
       const state = useAntennaStore.getState();
       const input = selectSimulationInput({
         ...state,
-        antennaType: 'sloping-v',
+        antennaType: "sloping-v",
         length: 80,
         height: 10,
         vAngle: 90,
         legSlope: 0,
         terminatingResistor: 0,
-        feedlineId: 'rg58',
+        feedlineId: "rg58",
         feedlineLength: 8,
         feedlineOffset: 0,
         transformerEnabled: false,
       });
 
       // bridge + 2 legs + shield (no stubs since terminatingResistor=0)
-      expect(input.wires.some(w => w.tag === 4)).toBe(true);
+      expect(input.wires.some((w) => w.tag === 4)).toBe(true);
       expect(input.excitation.wireTag).toBe(4);
       expect(input.transmissionLines).toHaveLength(1);
       const tl = input.transmissionLines![0];
@@ -428,13 +439,13 @@ describe('antennaStore selectors', () => {
       expect(tl.toTag).toBe(4);
     });
 
-    it('clamps shield bottom above ground when feedline length exceeds height', () => {
+    it("clamps shield bottom above ground when feedline length exceeds height", () => {
       const state = useAntennaStore.getState();
       const testState = {
         ...state,
-        antennaType: 'dipole' as const,
+        antennaType: "dipole" as const,
         height: 5,
-        feedlineId: 'rg213',
+        feedlineId: "rg213",
         feedlineLength: 30, // would push bottom into the ground
       };
 
@@ -450,78 +461,111 @@ describe('antennaStore selectors', () => {
   });
 });
 
-describe('antennaStore actions', () => {
-  describe('topology and defaults', () => {
-    it('sets initial defaults correctly per spec', () => {
+describe("computeOptimalVAngleDeg", () => {
+  it("computes baseline Kraus formula when no height provided", () => {
+    const vAngle = computeOptimalVAngleDeg(40, 14.1);
+    expect(vAngle).toBeCloseTo(105.6, 1);
+  });
+
+  it("adjusts formula when valid height is provided", () => {
+    const vAngle = computeOptimalVAngleDeg(40, 14.1, 15);
+    expect(vAngle).toBeCloseTo(56.65, 1);
+  });
+
+  it("clamps minimum angle to 10 degrees", () => {
+    const vAngle = computeOptimalVAngleDeg(30, 14.1, 15);
+    expect(vAngle).toBe(10);
+  });
+
+  it("clamps maximum angle to 180 degrees", () => {
+    const vAngle = computeOptimalVAngleDeg(10, 1.8);
+    expect(vAngle).toBe(180);
+  });
+
+  it("handles near-zero leg length safely", () => {
+    const vAngle = computeOptimalVAngleDeg(0.05, 14.1);
+    expect(vAngle).toBe(180);
+  });
+});
+
+describe("antennaStore actions", () => {
+  describe("topology and defaults", () => {
+    it("sets initial defaults correctly per spec", () => {
       const s = useAntennaStore.getState();
-      expect(s.antennaType).toBe('dipole');
+      expect(s.antennaType).toBe("dipole");
       expect(s.vAngle).toBe(180);
       expect(s.legSlope).toBe(0);
     });
 
-    it('setAntennaType(sloping-v) preserves feedline cable/length but resets offset', () => {
+    it("setAntennaType(sloping-v) preserves feedline cable/length but resets offset", () => {
       const store = useAntennaStore.getState();
-      store.setAntennaType('dipole');
-      store.setFeedline('rg58');
+      store.setAntennaType("dipole");
+      store.setFeedline("rg58");
       store.setFeedlineLength(10);
       store.setFeedlineOffset(1);
 
-      store.setAntennaType('sloping-v');
+      store.setAntennaType("sloping-v");
       const s = useAntennaStore.getState();
-      expect(s.antennaType).toBe('sloping-v');
-      expect(s.feedlineId).toBe('rg58');
+      expect(s.antennaType).toBe("sloping-v");
+      expect(s.feedlineId).toBe("rg58");
       expect(s.feedlineLength).toBe(10);
       expect(s.feedlineOffset).toBe(0);
     });
 
-    it('setAntennaType(inverted-v) preserves feedline cable/length but resets offset', () => {
+    it("setAntennaType(inverted-v) preserves feedline cable/length but resets offset", () => {
       const store = useAntennaStore.getState();
-      store.setAntennaType('dipole');
-      store.setFeedline('rg58');
+      store.setAntennaType("dipole");
+      store.setFeedline("rg58");
       store.setFeedlineLength(10);
       store.setFeedlineOffset(2);
 
-      store.setAntennaType('inverted-v');
+      store.setAntennaType("inverted-v");
       const s = useAntennaStore.getState();
-      expect(s.feedlineId).toBe('rg58');
+      expect(s.feedlineId).toBe("rg58");
       expect(s.feedlineLength).toBe(10);
       expect(s.feedlineOffset).toBe(0);
     });
 
-    it('setAntennaType(delta-loop) preserves feedline cable/length but resets offset', () => {
+    it("setAntennaType(delta-loop) preserves feedline cable/length but resets offset", () => {
       const store = useAntennaStore.getState();
-      store.setAntennaType('dipole');
-      store.setFeedline('rg213');
+      store.setAntennaType("dipole");
+      store.setFeedline("rg213");
       store.setFeedlineLength(15);
       store.setFeedlineOffset(3);
 
-      store.setAntennaType('delta-loop');
+      store.setAntennaType("delta-loop");
       const s = useAntennaStore.getState();
-      expect(s.feedlineId).toBe('rg213');
+      expect(s.feedlineId).toBe("rg213");
       expect(s.feedlineLength).toBe(15);
       expect(s.feedlineOffset).toBe(0);
     });
 
-    it('setAntennaType sets correct default lengths and angles for each type', () => {
+    it("setAntennaType sets correct default lengths and angles for each type", () => {
       const store = useAntennaStore.getState();
       const freq = 7.1;
       const lambda = 299.792458 / freq;
       store.setFrequency(freq);
 
-      store.setAntennaType('dipole');
-      expect(useAntennaStore.getState().length).toBeCloseTo(lambda * 0.5 * 0.95, 3);
+      store.setAntennaType("dipole");
+      expect(useAntennaStore.getState().length).toBeCloseTo(
+        lambda * 0.5 * 0.95,
+        3,
+      );
       expect(useAntennaStore.getState().vAngle).toBe(180);
       expect(useAntennaStore.getState().legSlope).toBe(0);
 
-      store.setAntennaType('inverted-v');
-      expect(useAntennaStore.getState().length).toBeCloseTo(lambda * 0.5 * 0.97, 3);
+      store.setAntennaType("inverted-v");
+      expect(useAntennaStore.getState().length).toBeCloseTo(
+        lambda * 0.5 * 0.97,
+        3,
+      );
       expect(useAntennaStore.getState().vAngle).toBe(120);
       expect(useAntennaStore.getState().legSlope).toBe(0);
 
-      store.setAntennaType('delta-loop');
+      store.setAntennaType("delta-loop");
       expect(useAntennaStore.getState().length).toBeCloseTo(lambda, 3);
 
-      store.setAntennaType('sloping-v');
+      store.setAntennaType("sloping-v");
       // Default is 2λ total (1λ per leg) — minimum for end-fire travelling-wave behaviour.
       expect(useAntennaStore.getState().length).toBeCloseTo(lambda * 2, 3);
       // V-angle from physics formula: cosV = (1 − 0.371λ/L) / cos(slope).
@@ -529,47 +573,46 @@ describe('antennaStore actions', () => {
       expect(useAntennaStore.getState().vAngle).toBeCloseTo(99.65, 1);
       // legSlope is unused for sloping-V (slope is auto-computed); reset to 0.
       expect(useAntennaStore.getState().legSlope).toBe(0);
-
     });
 
     it('setAntennaType("sloping-v") sets default terminatingResistor=300 when currently 0', () => {
       const store = useAntennaStore.getState();
       store.setTerminatingResistor(0);
-      store.setAntennaType('sloping-v');
+      store.setAntennaType("sloping-v");
       expect(useAntennaStore.getState().terminatingResistor).toBe(300);
     });
 
     it('setAntennaType("sloping-v") preserves a pre-set non-zero terminatingResistor', () => {
       const store = useAntennaStore.getState();
       store.setTerminatingResistor(400);
-      store.setAntennaType('sloping-v');
+      store.setAntennaType("sloping-v");
       expect(useAntennaStore.getState().terminatingResistor).toBe(400);
     });
 
-    it('setHalfWaveLength is topology-aware', () => {
+    it("setHalfWaveLength is topology-aware", () => {
       const store = useAntennaStore.getState();
       const freq = 14.1;
       const lambda = 299.792458 / freq;
       store.setFrequency(freq);
 
-      store.setAntennaType('delta-loop');
+      store.setAntennaType("delta-loop");
       store.setLength(5); // manual override
       store.setHalfWaveLength();
       expect(useAntennaStore.getState().length).toBeCloseTo(lambda, 3);
 
-      store.setAntennaType('sloping-v');
+      store.setAntennaType("sloping-v");
       store.setLength(5);
       store.setHalfWaveLength();
       // Length 5m is far less than 1λ, so legMultipleFromLength rounds to 1 → 2λ total.
       expect(useAntennaStore.getState().length).toBeCloseTo(lambda * 2, 3);
     });
 
-    it('setHalfWaveLength snaps to nearest whole-wavelength multiple at new frequency for travelling-wave types', () => {
+    it("setHalfWaveLength snaps to nearest whole-wavelength multiple at new frequency for travelling-wave types", () => {
       const store = useAntennaStore.getState();
       const freq = 14.1;
       const lambda = 299.792458 / freq;
       store.setFrequency(freq);
-      store.setAntennaType('sloping-v');
+      store.setAntennaType("sloping-v");
       store.setLegLengthMultiple(3); // 3λ/leg = 6λ total
       expect(useAntennaStore.getState().length).toBeCloseTo(lambda * 6, 2);
 
@@ -584,12 +627,12 @@ describe('antennaStore actions', () => {
       expect(useAntennaStore.getState().length).toBeCloseTo(newLambda * 4, 2);
     });
 
-    it('setLegLengthMultiple sets length and snaps V-angle for sloping-v', () => {
+    it("setLegLengthMultiple sets length and snaps V-angle for sloping-v", () => {
       const store = useAntennaStore.getState();
       const freq = 14.1;
       const lambda = 299.792458 / freq;
       store.setFrequency(freq);
-      store.setAntennaType('sloping-v');
+      store.setAntennaType("sloping-v");
       store.setHeight(12);
 
       store.setLegLengthMultiple(2);
@@ -613,29 +656,29 @@ describe('antennaStore actions', () => {
       expect(useAntennaStore.getState().length).toBeCloseTo(lambda * 20, 2);
     });
 
-    it('setLegLengthMultiple is a no-op for non-travelling-wave types', () => {
+    it("setLegLengthMultiple is a no-op for non-travelling-wave types", () => {
       const store = useAntennaStore.getState();
       store.setFrequency(14.1);
-      store.setAntennaType('dipole');
+      store.setAntennaType("dipole");
       const before = useAntennaStore.getState().length;
       store.setLegLengthMultiple(3);
       expect(useAntennaStore.getState().length).toBe(before);
     });
 
-    it('legMultipleFromLength rounds to nearest integer', () => {
+    it("legMultipleFromLength rounds to nearest integer", () => {
       const freq = 14.1;
       const lambda = 299.792458 / freq;
-      expect(legMultipleFromLength(lambda * 2, freq)).toBe(1);   // 1λ/leg
-      expect(legMultipleFromLength(lambda * 4, freq)).toBe(2);   // 2λ/leg
-      expect(legMultipleFromLength(lambda * 6, freq)).toBe(3);   // 3λ/leg
-      expect(legMultipleFromLength(lambda * 10, freq)).toBe(5);  // 5λ/leg
-      expect(legMultipleFromLength(lambda * 16, freq)).toBe(8);  // 8λ/leg
+      expect(legMultipleFromLength(lambda * 2, freq)).toBe(1); // 1λ/leg
+      expect(legMultipleFromLength(lambda * 4, freq)).toBe(2); // 2λ/leg
+      expect(legMultipleFromLength(lambda * 6, freq)).toBe(3); // 3λ/leg
+      expect(legMultipleFromLength(lambda * 10, freq)).toBe(5); // 5λ/leg
+      expect(legMultipleFromLength(lambda * 16, freq)).toBe(8); // 8λ/leg
       expect(legMultipleFromLength(lambda * 20, freq)).toBe(10); // 10λ/leg
       // Slightly under a half-integer — rounds down
-      expect(legMultipleFromLength(lambda * 5, freq)).toBe(2);   // 2.499λ/leg → 2
+      expect(legMultipleFromLength(lambda * 5, freq)).toBe(2); // 2.499λ/leg → 2
     });
 
-    it('clamps vAngle to [10, 180]', () => {
+    it("clamps vAngle to [10, 180]", () => {
       const store = useAntennaStore.getState();
       store.setVAngle(5);
       expect(useAntennaStore.getState().vAngle).toBe(10);
@@ -645,7 +688,7 @@ describe('antennaStore actions', () => {
       expect(useAntennaStore.getState().vAngle).toBe(45);
     });
 
-    it('clamps legSlope to [0, 90]', () => {
+    it("clamps legSlope to [0, 90]", () => {
       const store = useAntennaStore.getState();
       store.setLegSlope(-10);
       expect(useAntennaStore.getState().legSlope).toBe(0);
@@ -656,7 +699,7 @@ describe('antennaStore actions', () => {
     });
   });
 
-  it('updates orientation and normalizes correctly', () => {
+  it("updates orientation and normalizes correctly", () => {
     const store = useAntennaStore.getState();
 
     store.setOrientation(370);
@@ -665,11 +708,11 @@ describe('antennaStore actions', () => {
     store.setOrientation(-10);
     expect(useAntennaStore.getState().orientation).toBe(350);
 
-    store.setOrientation('NS');
-    expect(useAntennaStore.getState().orientation).toBe('NS');
+    store.setOrientation("NS");
+    expect(useAntennaStore.getState().orientation).toBe("NS");
   });
 
-  it('updates frequency and clamps correctly', () => {
+  it("updates frequency and clamps correctly", () => {
     // Arrange
     const store = useAntennaStore.getState();
 
@@ -692,31 +735,31 @@ describe('antennaStore actions', () => {
     expect(useAntennaStore.getState().frequency).toBe(14.1);
   });
 
-  describe('feedline', () => {
-    it('clears feedline state when switching to sloping-v preserves cable but resets offset', () => {
+  describe("feedline", () => {
+    it("clears feedline state when switching to sloping-v preserves cable but resets offset", () => {
       const store = useAntennaStore.getState();
-      store.setAntennaType('dipole');
-      store.setFeedline('rg58');
+      store.setAntennaType("dipole");
+      store.setFeedline("rg58");
       store.setFeedlineLength(15);
       store.setFeedlineOffset(2);
       store.setTransformerEnabled(true);
 
-      store.setAntennaType('sloping-v');
+      store.setAntennaType("sloping-v");
 
       const s = useAntennaStore.getState();
-      expect(s.antennaType).toBe('sloping-v');
-      expect(s.feedlineId).toBe('rg58');
+      expect(s.antennaType).toBe("sloping-v");
+      expect(s.feedlineId).toBe("rg58");
       expect(s.feedlineLength).toBe(15);
       expect(s.feedlineOffset).toBe(0);
       expect(s.transformerEnabled).toBe(true);
     });
 
-    it('updates feedline preset id', () => {
+    it("updates feedline preset id", () => {
       const store = useAntennaStore.getState();
-      store.setFeedline('rg213');
-      expect(useAntennaStore.getState().feedlineId).toBe('rg213');
-      store.setFeedline('none');
-      expect(useAntennaStore.getState().feedlineId).toBe('none');
+      store.setFeedline("rg213");
+      expect(useAntennaStore.getState().feedlineId).toBe("rg213");
+      store.setFeedline("none");
+      expect(useAntennaStore.getState().feedlineId).toBe("none");
     });
 
     it('uses fallback feedline on unknown feedline id', () => {
@@ -725,7 +768,7 @@ describe('antennaStore actions', () => {
       expect(useAntennaStore.getState().feedlineId).toBe('none');
     });
 
-    it('clamps feedline length to a reasonable range', () => {
+    it("clamps feedline length to a reasonable range", () => {
       const store = useAntennaStore.getState();
       store.setFeedlineLength(-5);
       expect(useAntennaStore.getState().feedlineLength).toBe(0);
@@ -735,7 +778,7 @@ describe('antennaStore actions', () => {
       expect(useAntennaStore.getState().feedlineLength).toBe(15);
     });
 
-    it('toggles transformer enabled flag', () => {
+    it("toggles transformer enabled flag", () => {
       const store = useAntennaStore.getState();
       store.setTransformerEnabled(true);
       expect(useAntennaStore.getState().transformerEnabled).toBe(true);
@@ -743,18 +786,20 @@ describe('antennaStore actions', () => {
       expect(useAntennaStore.getState().transformerEnabled).toBe(false);
     });
 
-    it('clamps feedline offset to ±length/2', () => {
+    it("clamps feedline offset to ±length/2", () => {
       const store = useAntennaStore.getState();
       store.setLength(10); // half = 5
       store.setFeedlineOffset(50);
       expect(useAntennaStore.getState().feedlineOffset).toBeLessThanOrEqual(5);
       store.setFeedlineOffset(-50);
-      expect(useAntennaStore.getState().feedlineOffset).toBeGreaterThanOrEqual(-5);
+      expect(useAntennaStore.getState().feedlineOffset).toBeGreaterThanOrEqual(
+        -5,
+      );
       store.setFeedlineOffset(2);
       expect(useAntennaStore.getState().feedlineOffset).toBe(2);
     });
 
-    it('re-clamps offset when the dipole length is shortened', () => {
+    it("re-clamps offset when the dipole length is shortened", () => {
       const store = useAntennaStore.getState();
       store.setLength(10);
       store.setFeedlineOffset(4);
@@ -767,8 +812,8 @@ describe('antennaStore actions', () => {
     });
   });
 
-  describe('propagation', () => {
-    it('clamps T-index to the practical range', () => {
+  describe("propagation", () => {
+    it("clamps T-index to the practical range", () => {
       const store = useAntennaStore.getState();
       store.setTIndex(99999);
       expect(useAntennaStore.getState().tIndex).toBe(250);
@@ -778,7 +823,7 @@ describe('antennaStore actions', () => {
       expect(useAntennaStore.getState().tIndex).toBe(75);
     });
 
-    it('accepts and clears latitude', () => {
+    it("accepts and clears latitude", () => {
       const store = useAntennaStore.getState();
       store.setLatitude(51.5);
       expect(useAntennaStore.getState().latitudeDeg).toBe(51.5);
@@ -786,7 +831,7 @@ describe('antennaStore actions', () => {
       expect(useAntennaStore.getState().latitudeDeg).toBeNull();
     });
 
-    it('clamps latitude to ±90', () => {
+    it("clamps latitude to ±90", () => {
       const store = useAntennaStore.getState();
       store.setLatitude(120);
       expect(useAntennaStore.getState().latitudeDeg).toBe(90);
@@ -794,7 +839,7 @@ describe('antennaStore actions', () => {
       expect(useAntennaStore.getState().latitudeDeg).toBe(-90);
     });
 
-    it('wraps longitude into ±180', () => {
+    it("wraps longitude into ±180", () => {
       const store = useAntennaStore.getState();
       store.setLongitude(200);
       expect(useAntennaStore.getState().longitudeDeg).toBeCloseTo(-160, 5);
@@ -802,7 +847,7 @@ describe('antennaStore actions', () => {
       expect(useAntennaStore.getState().longitudeDeg).toBeCloseTo(160, 5);
     });
 
-    it('clamps month override and accepts null', () => {
+    it("clamps month override and accepts null", () => {
       const store = useAntennaStore.getState();
       store.setMonthOverride(15);
       expect(useAntennaStore.getState().monthOverride).toBe(12);
@@ -812,7 +857,7 @@ describe('antennaStore actions', () => {
       expect(useAntennaStore.getState().monthOverride).toBeNull();
     });
 
-    it('clamps UTC hour override and accepts null', () => {
+    it("clamps UTC hour override and accepts null", () => {
       const store = useAntennaStore.getState();
       store.setUtcHourOverride(50);
       expect(useAntennaStore.getState().utcHourOverride).toBe(23.99);
@@ -822,22 +867,22 @@ describe('antennaStore actions', () => {
       expect(useAntennaStore.getState().utcHourOverride).toBeNull();
     });
 
-    it('updates geolocation status', () => {
+    it("updates geolocation status", () => {
       const store = useAntennaStore.getState();
-      store.setGeolocationStatus('requesting');
-      expect(useAntennaStore.getState().geolocationStatus).toBe('requesting');
-      store.setGeolocationStatus('denied');
-      expect(useAntennaStore.getState().geolocationStatus).toBe('denied');
+      store.setGeolocationStatus("requesting");
+      expect(useAntennaStore.getState().geolocationStatus).toBe("requesting");
+      store.setGeolocationStatus("denied");
+      expect(useAntennaStore.getState().geolocationStatus).toBe("denied");
     });
   });
 
-  describe('Sloping V Geometry', () => {
-    it('performs the hand-check at 7.1 MHz, height 10m, slope 45 deg', () => {
+  describe("Sloping V Geometry", () => {
+    it("performs the hand-check at 7.1 MHz, height 10m, slope 45 deg", () => {
       // λ = 299.792458 / 7.1 = 42.2243m.
       // Sloping V ref length = λ * 2 * 0.95 = 80.2262m.
       const length = 80.22615;
       const state = {
-        antennaType: 'sloping-v' as const,
+        antennaType: "sloping-v" as const,
         length,
         height: 10,
         legSlope: 45,
@@ -852,9 +897,9 @@ describe('antennaStore actions', () => {
       expect(result.tipHeightM).toBeCloseTo(0.5, 5);
     });
 
-    it('reports clamped=false when slope is shallow', () => {
+    it("reports clamped=false when slope is shallow", () => {
       const state = {
-        antennaType: 'sloping-v' as const,
+        antennaType: "sloping-v" as const,
         length: 20,
         height: 10,
         legSlope: 10,
@@ -864,16 +909,16 @@ describe('antennaStore actions', () => {
       expect(result.effectiveDeg).toBe(10);
     });
 
-    it('sets excitation on the apex bridge for sloping-v (no feedline)', () => {
+    it("sets excitation on the apex bridge for sloping-v (no feedline)", () => {
       const state = {
         ...useAntennaStore.getState(),
-        antennaType: 'sloping-v' as const,
+        antennaType: "sloping-v" as const,
         length: 80,
         height: 10,
         legSlope: 15,
         vAngle: 90,
         terminatingResistor: 0, // no stubs; test focuses on excitation placement
-        feedlineId: 'none',
+        feedlineId: "none",
       };
       const input = selectSimulationInput(state as AntennaState);
       // Graded segmentation produces multiple sub-wires per leg; only the
@@ -885,11 +930,11 @@ describe('antennaStore actions', () => {
     });
   });
 
-  describe('Inverted V Geometry', () => {
+  describe("Inverted V Geometry", () => {
     const commonState = {
       length: 20,
       height: 10,
-      orientation: 'EW' as const,
+      orientation: "EW" as const,
       wireRadius: 0.001,
       segments: 21,
       frequency: 7.1,
@@ -897,69 +942,105 @@ describe('antennaStore actions', () => {
       legSlope: 0,
     };
 
-    it('places the apex at the specified height', () => {
-      const wires = buildWires({ ...commonState, antennaType: 'inverted-v' });
-      const bridge = wires.find(w => w.tag === 3)!;
+    it("places the apex at the specified height", () => {
+      const wires = buildWires({ ...commonState, antennaType: "inverted-v" });
+      const bridge = wires.find((w) => w.tag === 3)!;
       expect(bridge.start[2]).toBeCloseTo(10);
       expect(bridge.end[2]).toBeCloseTo(10);
     });
 
-    it('calculates leg endpoints correctly based on vAngle', () => {
+    it("calculates leg endpoints correctly based on vAngle", () => {
       // Total length 20m. Bridge 0.1m. Each leg = (20 - 0.1) / 2 = 9.95m.
       // For 120 deg apex, drop angle is 30 deg.
       // Drop = 9.95 * sin(30) = 4.975m.
       // Tip Z = 10 - 4.975 = 5.025m.
-      const wires = buildWires({ ...commonState, antennaType: 'inverted-v', vAngle: 120 });
-      const leftWire = wires.find(w => w.tag === DIPOLE_LEFT_TAG)!;
+      const wires = buildWires({
+        ...commonState,
+        antennaType: "inverted-v",
+        vAngle: 120,
+      });
+      const leftWire = wires.find((w) => w.tag === DIPOLE_LEFT_TAG)!;
       expect(leftWire.start[2]).toBeCloseTo(5.025);
     });
 
-    it('clamps tip height to SLOPING_V_MIN_TIP_Z_M (0.5m)', () => {
+    it("clamps tip height to SLOPING_V_MIN_TIP_Z_M (0.5m)", () => {
       // Length 20m (9.975m per leg), Height 2m.
       // 60 deg drop (vAngle 60) would drop 9.975 * sin(60) = 8.638m.
       // 2 - 8.638 = -6.638m (underground).
       // Max drop allowed = 2 - 0.5 = 1.5m.
-      const wires = buildWires({ ...commonState, antennaType: 'inverted-v', height: 2, vAngle: 60 });
-      const leftWire = wires.find(w => w.tag === DIPOLE_LEFT_TAG)!;
+      const wires = buildWires({
+        ...commonState,
+        antennaType: "inverted-v",
+        height: 2,
+        vAngle: 60,
+      });
+      const leftWire = wires.find((w) => w.tag === DIPOLE_LEFT_TAG)!;
       expect(leftWire.start[2]).toBeGreaterThanOrEqual(0.49);
       expect(leftWire.start[2]).toBeLessThanOrEqual(0.51);
     });
 
-    it('places excitation on the apex bridge when no feedline', () => {
-      const state = { ...useAntennaStore.getState(), ...commonState, antennaType: 'inverted-v', feedlineId: 'none' };
+    it("places excitation on the apex bridge when no feedline", () => {
+      const state = {
+        ...useAntennaStore.getState(),
+        ...commonState,
+        antennaType: "inverted-v",
+        feedlineId: "none",
+      };
       const input = selectSimulationInput(state as AntennaState);
       expect(input.excitation.wireTag).toBe(3);
       expect(input.excitation.segment).toBe(1);
     });
 
-    it('uses at least 20 segments per wavelength on each leg', () => {
+    it("uses at least 20 segments per wavelength on each leg", () => {
       const lambda = 299.792458 / 7.1;
-      const state = { ...commonState, antennaType: 'inverted-v', frequency: 7.1, length: lambda / 2, segments: 10 };
+      const state = {
+        ...commonState,
+        antennaType: "inverted-v",
+        frequency: 7.1,
+        length: lambda / 2,
+        segments: 10,
+      };
       const wires = buildWires(state as Parameters<typeof buildWires>[0]);
 
-      const expected = Math.max(9, Math.ceil(20 * (state.length / 2) / lambda));
+      const expected = Math.max(
+        9,
+        Math.ceil((20 * (state.length / 2)) / lambda),
+      );
       expect(wires[0].segments).toBeGreaterThanOrEqual(expected);
 
       // Try a longer wire: 2 lambda per leg.
       // Expected segments = ceil(20 * 2) = 40.
-      const longState = { ...commonState, antennaType: 'inverted-v', frequency: 7.1, length: lambda * 4, segments: 10 };
-      const longWires = buildWires(longState as Parameters<typeof buildWires>[0]);
+      const longState = {
+        ...commonState,
+        antennaType: "inverted-v",
+        frequency: 7.1,
+        length: lambda * 4,
+        segments: 10,
+      };
+      const longWires = buildWires(
+        longState as Parameters<typeof buildWires>[0],
+      );
       expect(longWires[0].segments).toBeGreaterThanOrEqual(40);
     });
 
-    it('emits no transmission lines or loads for Inverted V without feedline', () => {
-      const state = { ...useAntennaStore.getState(), ...commonState, antennaType: 'inverted-v', feedlineId: 'none' };
+    it("emits no transmission lines or loads for Inverted V without feedline", () => {
+      const state = {
+        ...useAntennaStore.getState(),
+        ...commonState,
+        antennaType: "inverted-v",
+        feedlineId: "none",
+      };
       const input = selectSimulationInput(state as AntennaState);
       expect(input.transmissionLines).toBeUndefined();
       expect(input.loads).toBeUndefined();
     });
 
-    it('adds shield wire and TL card for Inverted V with feedline', () => {
+    it("adds shield wire and TL card for Inverted V with feedline", () => {
       const state = {
         ...useAntennaStore.getState(),
         ...commonState,
-        antennaType: 'inverted-v' as const,
-        feedlineId: 'rg58',
+        antennaType: "inverted-v" as const,
+        feedlineId: "rg58",
         feedlineLength: 8,
         feedlineOffset: 0,
         transformerEnabled: false,
@@ -983,15 +1064,15 @@ describe('antennaStore actions', () => {
     });
   });
 
-  describe('Delta Loop Geometry', () => {
+  describe("Delta Loop Geometry", () => {
     // λ at 7.1 MHz ≈ 42.224 m; default delta loop perimeter = 1λ
     const lambda = 299.792458 / 7.1;
 
     const baseState = {
-      antennaType: 'delta-loop' as const,
-      length: lambda,         // perimeter = 1λ
+      antennaType: "delta-loop" as const,
+      length: lambda, // perimeter = 1λ
       height: 15,
-      orientation: 'EW' as const,
+      orientation: "EW" as const,
       wireRadius: 0.001,
       segments: 21,
       frequency: 7.1,
@@ -1000,14 +1081,14 @@ describe('antennaStore actions', () => {
       terminatingResistor: 0,
     };
 
-    it('produces exactly 3 wires with distinct tags', () => {
+    it("produces exactly 3 wires with distinct tags", () => {
       const wires = buildWires(baseState);
       expect(wires).toHaveLength(3);
       const tags = wires.map((w) => w.tag).sort((a, b) => a - b);
       expect(tags).toEqual([DIPOLE_LEFT_TAG, DIPOLE_RIGHT_TAG, DELTA_BASE_TAG]);
     });
 
-    it('apex is at full mast height on all leg endpoints', () => {
+    it("apex is at full mast height on all leg endpoints", () => {
       const wires = buildWires(baseState);
       const leftLeg = wires.find((w) => w.tag === DIPOLE_LEFT_TAG)!;
       const rightLeg = wires.find((w) => w.tag === DIPOLE_RIGHT_TAG)!;
@@ -1021,7 +1102,7 @@ describe('antennaStore actions', () => {
       expect(leftLeg.end[2]).toBeCloseTo(rightLeg.start[2]);
     });
 
-    it('equilateral triangle when mast height allows it (7.1 MHz, 15 m)', () => {
+    it("equilateral triangle when mast height allows it (7.1 MHz, 15 m)", () => {
       // P = λ ≈ 42.224 m. Equilateral height = P * sqrt(3) / 6 ≈ 12.18 m.
       // 15 m - 0.5 m = 14.5 m available, so equilateral fits.
       const wires = buildWires(baseState);
@@ -1042,7 +1123,7 @@ describe('antennaStore actions', () => {
       expect(triHeight).toBeCloseTo(equilateralHeight, 2);
     });
 
-    it('preserves full perimeter when height forces isosceles shape', () => {
+    it("preserves full perimeter when height forces isosceles shape", () => {
       // Mast height 5 m: equilateral height ≈ 12.18 m, but available is 4.5 m.
       const shortState = { ...baseState, height: 5 };
       const wires = buildWires(shortState);
@@ -1054,7 +1135,8 @@ describe('antennaStore actions', () => {
       const dist3d = (
         a: readonly [number, number, number],
         b: readonly [number, number, number],
-      ) => Math.sqrt((a[0] - b[0]) ** 2 + (a[1] - b[1]) ** 2 + (a[2] - b[2]) ** 2);
+      ) =>
+        Math.sqrt((a[0] - b[0]) ** 2 + (a[1] - b[1]) ** 2 + (a[2] - b[2]) ** 2);
 
       const leftLen = dist3d(leftLeg.start, leftLeg.end);
       const rightLen = dist3d(rightLeg.start, rightLeg.end);
@@ -1064,7 +1146,7 @@ describe('antennaStore actions', () => {
       expect(actualPerimeter).toBeCloseTo(lambda, 1);
     });
 
-    it('base corners stay above minimum height (SLOPING_V_MIN_TIP_Z_M = 0.5 m)', () => {
+    it("base corners stay above minimum height (SLOPING_V_MIN_TIP_Z_M = 0.5 m)", () => {
       // Very short mast — base must not go below 0.5 m.
       const shortState = { ...baseState, height: 2 };
       const wires = buildWires(shortState);
@@ -1073,8 +1155,12 @@ describe('antennaStore actions', () => {
       expect(base.end[2]).toBeGreaterThanOrEqual(0.49);
     });
 
-    it('excitation lands on the left leg at its last (apex) segment when no feedline', () => {
-      const state = { ...useAntennaStore.getState(), ...baseState, feedlineId: 'none' };
+    it("excitation lands on the left leg at its last (apex) segment when no feedline", () => {
+      const state = {
+        ...useAntennaStore.getState(),
+        ...baseState,
+        feedlineId: "none",
+      };
       const input = selectSimulationInput(state as AntennaState);
 
       const leftLeg = input.wires.find((w) => w.tag === DIPOLE_LEFT_TAG)!;
@@ -1082,18 +1168,22 @@ describe('antennaStore actions', () => {
       expect(input.excitation.segment).toBe(leftLeg.segments);
     });
 
-    it('emits no transmission lines or loads without feedline', () => {
-      const state = { ...useAntennaStore.getState(), ...baseState, feedlineId: 'none' };
+    it("emits no transmission lines or loads without feedline", () => {
+      const state = {
+        ...useAntennaStore.getState(),
+        ...baseState,
+        feedlineId: "none",
+      };
       const input = selectSimulationInput(state as AntennaState);
       expect(input.transmissionLines).toBeUndefined();
       expect(input.loads).toBeUndefined();
     });
 
-    it('adds bridge + shield wire and TL card for delta loop with feedline', () => {
+    it("adds bridge + shield wire and TL card for delta loop with feedline", () => {
       const state = {
         ...useAntennaStore.getState(),
         ...baseState,
-        feedlineId: 'rg58',
+        feedlineId: "rg58",
         feedlineLength: 10,
         feedlineOffset: 0,
         transformerEnabled: false,
@@ -1115,81 +1205,86 @@ describe('antennaStore actions', () => {
       expect(shield.start[2]).toBeCloseTo(baseState.height);
     });
 
-    describe('Delta Loop Preset Verification — low mast heights', () => {
+    describe("Delta Loop Preset Verification — low mast heights", () => {
       // Regression: at h=8 and h=8.5 the feedline shield was incorrectly
       // extended below the delta loop base wire, causing the NEC MOM solver
       // to produce -999.99 sentinel gains and negative resistance. The fix
       // clamps the shield bottom to the base wire z-coordinate so the shield
       // never crosses the base wire plane.
       it.each([
-        { name: '160m', mhz: 1.900, height: 8 },
-        { name: '160m', mhz: 1.900, height: 8.5 },
-        { name: '80m',  mhz: 3.650, height: 8 },
-        { name: '80m',  mhz: 3.650, height: 8.5 },
-        { name: '60m',  mhz: 5.358, height: 8 },
-        { name: '60m',  mhz: 5.358, height: 8.5 },
-        { name: '160m', mhz: 1.900, height: 10 },
-        { name: '80m',  mhz: 3.650, height: 10 },
-        { name: '60m',  mhz: 5.358, height: 10 },
-      ])('$name h=$height feedline=rg58: shield stays above base wire', ({ mhz, height }) => {
-        const lambda = 299.792458 / mhz;
-        const state = {
-          ...useAntennaStore.getState(),
-          antennaType: 'delta-loop' as const,
-          frequency: mhz,
-          length: lambda,
-          height,
-          orientation: 'EW' as const,
-          wireRadius: 0.001,
-          segments: 21,
-          vAngle: 180,
-          legSlope: 0,
-          terminatingResistor: 0,
-          feedlineId: 'rg58',
-          feedlineLength: 10,
-          feedlineOffset: 0,
-          transformerEnabled: false,
-        };
-        const input = selectSimulationInput(state as AntennaState);
+        { name: "160m", mhz: 1.9, height: 8 },
+        { name: "160m", mhz: 1.9, height: 8.5 },
+        { name: "80m", mhz: 3.65, height: 8 },
+        { name: "80m", mhz: 3.65, height: 8.5 },
+        { name: "60m", mhz: 5.358, height: 8 },
+        { name: "60m", mhz: 5.358, height: 8.5 },
+        { name: "160m", mhz: 1.9, height: 10 },
+        { name: "80m", mhz: 3.65, height: 10 },
+        { name: "60m", mhz: 5.358, height: 10 },
+      ])(
+        "$name h=$height feedline=rg58: shield stays above base wire",
+        ({ mhz, height }) => {
+          const lambda = 299.792458 / mhz;
+          const state = {
+            ...useAntennaStore.getState(),
+            antennaType: "delta-loop" as const,
+            frequency: mhz,
+            length: lambda,
+            height,
+            orientation: "EW" as const,
+            wireRadius: 0.001,
+            segments: 21,
+            vAngle: 180,
+            legSlope: 0,
+            terminatingResistor: 0,
+            feedlineId: "rg58",
+            feedlineLength: 10,
+            feedlineOffset: 0,
+            transformerEnabled: false,
+          };
+          const input = selectSimulationInput(state as AntennaState);
 
-        const base = input.wires.find((w) => w.tag === DELTA_BASE_TAG)!;
-        const shield = input.wires.find((w) => w.tag === FEEDLINE_SHIELD_TAG)!;
+          const base = input.wires.find((w) => w.tag === DELTA_BASE_TAG)!;
+          const shield = input.wires.find(
+            (w) => w.tag === FEEDLINE_SHIELD_TAG,
+          )!;
 
-        // Base wire must be above ground.
-        expect(base.start[2]).toBeGreaterThanOrEqual(0.49);
-        expect(base.end[2]).toBeGreaterThanOrEqual(0.49);
+          // Base wire must be above ground.
+          expect(base.start[2]).toBeGreaterThanOrEqual(0.49);
+          expect(base.end[2]).toBeGreaterThanOrEqual(0.49);
 
-        // Shield must be present (feedline is active for delta-loop with rg58).
-        expect(shield).toBeDefined();
+          // Shield must be present (feedline is active for delta-loop with rg58).
+          expect(shield).toBeDefined();
 
-        // Shield bottom must be at or above the base wire height.
-        // This is the NEC stability fix: a shield that crosses the base wire
-        // plane produces ill-conditioned MOM matrix entries.
-        const baseZ = base.start[2];
-        expect(shield.end[2]).toBeGreaterThanOrEqual(baseZ - 0.001);
+          // Shield bottom must be at or above the base wire height.
+          // This is the NEC stability fix: a shield that crosses the base wire
+          // plane produces ill-conditioned MOM matrix entries.
+          const baseZ = base.start[2];
+          expect(shield.end[2]).toBeGreaterThanOrEqual(baseZ - 0.001);
 
-        // Basic geometry sanity.
-        for (const w of input.wires) {
-          expect(w.segments).toBeGreaterThan(0);
-          const len = Math.hypot(
-            w.end[0] - w.start[0],
-            w.end[1] - w.start[1],
-            w.end[2] - w.start[2],
-          );
-          expect(len).toBeGreaterThan(0.05);
-          w.start.forEach((v) => expect(v).not.toBeNaN());
-          w.end.forEach((v) => expect(v).not.toBeNaN());
-        }
-      });
+          // Basic geometry sanity.
+          for (const w of input.wires) {
+            expect(w.segments).toBeGreaterThan(0);
+            const len = Math.hypot(
+              w.end[0] - w.start[0],
+              w.end[1] - w.start[1],
+              w.end[2] - w.start[2],
+            );
+            expect(len).toBeGreaterThan(0.05);
+            w.start.forEach((v) => expect(v).not.toBeNaN());
+            w.end.forEach((v) => expect(v).not.toBeNaN());
+          }
+        },
+      );
     });
   });
 
-  describe('Vertical Whip Geometry', () => {
+  describe("Vertical Whip Geometry", () => {
     const baseState = {
-      antennaType: 'vertical-whip' as const,
+      antennaType: "vertical-whip" as const,
       length: DEFAULT_WHIP_LENGTH_M, // 32 ft default
       height: 0,
-      orientation: 'EW' as const,
+      orientation: "EW" as const,
       wireRadius: 0.001,
       segments: 21,
       frequency: 7.1,
@@ -1197,7 +1292,7 @@ describe('antennaStore actions', () => {
       legSlope: 0,
     };
 
-    it('produces exactly one vertical wire tagged VERTICAL_WHIP_TAG', () => {
+    it("produces exactly one vertical wire tagged VERTICAL_WHIP_TAG", () => {
       const wires = buildWires(baseState);
       expect(wires).toHaveLength(1);
       const w = wires[0]!;
@@ -1209,7 +1304,7 @@ describe('antennaStore actions', () => {
       expect(w.end[1]).toBeCloseTo(0, 6);
     });
 
-    it('lifts the base by VERTICAL_WHIP_BASE_GAP_M when height = 0 (sitting on ground)', () => {
+    it("lifts the base by VERTICAL_WHIP_BASE_GAP_M when height = 0 (sitting on ground)", () => {
       // The whip is electrically isolated from ground (sitting on a mount).
       // Without the 1 cm gap NEC would connect the z=0 endpoint to its
       // image and silently turn the antenna into a properly-grounded
@@ -1218,23 +1313,28 @@ describe('antennaStore actions', () => {
       const wires = buildWires(baseState);
       const w = wires.find((x) => x.tag === VERTICAL_WHIP_TAG)!;
       expect(w.start[2]).toBeCloseTo(VERTICAL_WHIP_BASE_GAP_M, 6);
-      expect(w.end[2]).toBeCloseTo(VERTICAL_WHIP_BASE_GAP_M + DEFAULT_WHIP_LENGTH_M, 6);
+      expect(w.end[2]).toBeCloseTo(
+        VERTICAL_WHIP_BASE_GAP_M + DEFAULT_WHIP_LENGTH_M,
+        6,
+      );
     });
 
-    it('places base at the configured height when height > base gap', () => {
+    it("places base at the configured height when height > base gap", () => {
       const wires = buildWires({ ...baseState, height: 3 });
       const w = wires.find((x) => x.tag === VERTICAL_WHIP_TAG)!;
       expect(w.start[2]).toBeCloseTo(3, 6);
       expect(w.end[2]).toBeCloseTo(3 + DEFAULT_WHIP_LENGTH_M, 6);
     });
 
-    it('emits no radials by default (freestanding whip)', () => {
+    it("emits no radials by default (freestanding whip)", () => {
       const wires = buildWires(baseState);
       expect(wires).toHaveLength(1);
-      expect(wires.filter((w) => w.tag === VERTICAL_WHIP_RADIAL_TAG)).toHaveLength(0);
+      expect(
+        wires.filter((w) => w.tag === VERTICAL_WHIP_RADIAL_TAG),
+      ).toHaveLength(0);
     });
 
-    it('emits VERTICAL_WHIP_RADIAL_COUNT radials at the base when counterpoise is enabled', () => {
+    it("emits VERTICAL_WHIP_RADIAL_COUNT radials at the base when counterpoise is enabled", () => {
       const wires = buildWires({ ...baseState, whipCounterpoise: true });
       const whip = wires.find((w) => w.tag === VERTICAL_WHIP_TAG)!;
       const radials = wires.filter((w) => w.tag === VERTICAL_WHIP_RADIAL_TAG);
@@ -1254,39 +1354,49 @@ describe('antennaStore actions', () => {
       }
     });
 
-    it('feeds the base segment (segment 1 of the whip)', () => {
-      const state = { ...useAntennaStore.getState(), ...baseState } as AntennaState;
+    it("feeds the base segment (segment 1 of the whip)", () => {
+      const state = {
+        ...useAntennaStore.getState(),
+        ...baseState,
+      } as AntennaState;
       const input = selectSimulationInput(state);
       expect(input.excitation.wireTag).toBe(VERTICAL_WHIP_TAG);
       expect(input.excitation.segment).toBe(1);
     });
 
-    it('keeps the configured ground when height = 0 (ground-mounted monopole)', () => {
+    it("keeps the configured ground when height = 0 (ground-mounted monopole)", () => {
       const state = {
         ...useAntennaStore.getState(),
         ...baseState,
         height: 0,
-        groundId: 'pastoral',
+        groundId: "pastoral",
       } as AntennaState;
       const input = selectSimulationInput(state);
-      expect(input.ground.type).toBe('real');
+      expect(input.ground.type).toBe("real");
     });
 
-    it('does NOT change ground behavior for horizontal antennas at h=0 (still free space)', () => {
+    it("does NOT change ground behavior for horizontal antennas at h=0 (still free space)", () => {
       const state = useAntennaStore.getState();
-      const input = selectSimulationInput({ ...state, antennaType: 'dipole', height: 0 });
-      expect(input.ground.type).toBe('free');
+      const input = selectSimulationInput({
+        ...state,
+        antennaType: "dipole",
+        height: 0,
+      });
+      expect(input.ground.type).toBe("free");
     });
 
-    it('emits no transmission lines, loads, or networks', () => {
-      const state = { ...useAntennaStore.getState(), ...baseState } as AntennaState;
+    it("emits no transmission lines, loads, or networks", () => {
+      const state = {
+        ...useAntennaStore.getState(),
+        ...baseState,
+      } as AntennaState;
       const input = selectSimulationInput(state);
       expect(input.transmissionLines).toBeUndefined();
       expect(input.loads).toBeUndefined();
       expect(input.networks).toBeUndefined();
     });
 
-    it('uses at least SEGS_PER_WAVELENGTH segments per wavelength on the whip', () => {
+    it("uses at least SEGS_PER_WAVELENGTH segments per wavelength on the whip", () => {
       const lambda = 299.792458 / 7.1;
       // Use a longer whip so the natural segs/λ count exceeds MIN_SEGS_PER_LEG.
       const longWhip = lambda; // 1λ tall (~42 m at 7.1 MHz)
@@ -1296,13 +1406,13 @@ describe('antennaStore actions', () => {
     });
   });
 
-  describe('Vertical Whip actions', () => {
+  describe("Vertical Whip actions", () => {
     it('setAntennaType("vertical-whip") sets defaults: length = 32 ft, height = 0', () => {
       const store = useAntennaStore.getState();
       store.setHeight(15);
-      store.setAntennaType('vertical-whip');
+      store.setAntennaType("vertical-whip");
       const s = useAntennaStore.getState();
-      expect(s.antennaType).toBe('vertical-whip');
+      expect(s.antennaType).toBe("vertical-whip");
       expect(s.length).toBeCloseTo(DEFAULT_WHIP_LENGTH_M, 6);
       expect(s.height).toBe(0);
       // No V-angle / termination / slope state should leak into the whip.
@@ -1313,26 +1423,26 @@ describe('antennaStore actions', () => {
 
     it('setAntennaType("vertical-whip") clears any active feedline (verticals are unsupported by the feedline model)', () => {
       const store = useAntennaStore.getState();
-      store.setAntennaType('dipole');
-      store.setFeedline('rg58');
+      store.setAntennaType("dipole");
+      store.setFeedline("rg58");
       store.setFeedlineLength(10);
 
-      store.setAntennaType('vertical-whip');
+      store.setAntennaType("vertical-whip");
       const s = useAntennaStore.getState();
-      expect(s.feedlineId).toBe('none');
+      expect(s.feedlineId).toBe("none");
       expect(s.feedlineLength).toBe(0);
     });
 
     it('setAntennaType("vertical-whip") forces the transformer off (its UI is hidden for verticals)', () => {
       const store = useAntennaStore.getState();
-      store.setAntennaType('dipole');
+      store.setAntennaType("dipole");
       store.setTransformerEnabled(true);
 
-      store.setAntennaType('vertical-whip');
+      store.setAntennaType("vertical-whip");
       expect(useAntennaStore.getState().transformerEnabled).toBe(false);
     });
 
-    it('setWhipCounterpoise toggles the radial-counterpoise flag', () => {
+    it("setWhipCounterpoise toggles the radial-counterpoise flag", () => {
       const store = useAntennaStore.getState();
       store.setWhipCounterpoise(true);
       expect(useAntennaStore.getState().whipCounterpoise).toBe(true);
@@ -1340,25 +1450,28 @@ describe('antennaStore actions', () => {
       expect(useAntennaStore.getState().whipCounterpoise).toBe(false);
     });
 
-    it('setAntennaType preserves the whipCounterpoise setting across type switches', () => {
+    it("setAntennaType preserves the whipCounterpoise setting across type switches", () => {
       const store = useAntennaStore.getState();
-      store.setAntennaType('vertical-whip');
+      store.setAntennaType("vertical-whip");
       store.setWhipCounterpoise(true);
-      store.setAntennaType('dipole');
+      store.setAntennaType("dipole");
       expect(useAntennaStore.getState().whipCounterpoise).toBe(true);
-      store.setAntennaType('vertical-whip');
+      store.setAntennaType("vertical-whip");
       expect(useAntennaStore.getState().whipCounterpoise).toBe(true);
     });
 
-    it('setHalfWaveLength sets the whip to resonant ¼λ', () => {
+    it("setHalfWaveLength sets the whip to resonant ¼λ", () => {
       const store = useAntennaStore.getState();
       const freq = 14.1;
       const lambda = 299.792458 / freq;
       store.setFrequency(freq);
-      store.setAntennaType('vertical-whip');
+      store.setAntennaType("vertical-whip");
       // Default after setAntennaType is 32 ft; tap the resonate button.
       store.setHalfWaveLength();
-      expect(useAntennaStore.getState().length).toBeCloseTo(lambda * 0.25 * 0.95, 4);
+      expect(useAntennaStore.getState().length).toBeCloseTo(
+        lambda * 0.25 * 0.95,
+        4,
+      );
     });
   });
 });


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This adds missing unit tests for the mathematically pure function `computeOptimalVAngleDeg` located in `src/store/antennaStore.ts:581`, which calculates the ideal internal angle for sloping-v antennas.

📊 **Coverage:** What scenarios are now tested
- Kraus baseline calculation for frequency/length with no height limit.
- Modified calculation that correctly adjusts for max tilt given a specific feed height.
- Clamping of the minimum result angle to 10 degrees.
- Clamping of the maximum result angle to 180 degrees.
- Safe handling of nearly non-existent wire geometry length (0.05m total).

✨ **Result:** The improvement in test coverage
`tests/antennaStore.test.ts` now explicitly covers this standalone math function across different parameter combinations and edge conditions. Tests all pass successfully.

---
*PR created automatically by Jules for task [3868476763553048381](https://jules.google.com/task/3868476763553048381) started by @2fst4u*