### PR TITLE
Fix mast height reversion when switching from Vertical Whip

### DIFF
--- a/src/store/antennaStore.ts
+++ b/src/store/antennaStore.ts
@@ -251,7 +251,7 @@ export interface AntennaState {
 }
 
 const INITIAL_FREQ = 7.1; // 40m band per user spec
-const INITIAL_HEIGHT = 10; // metres
+export const INITIAL_HEIGHT = 10; // metres
 const INITIAL_TYPE: AntennaType = 'dipole';
 const INITIAL_LENGTH = referenceLength(INITIAL_TYPE, INITIAL_FREQ); // resonant reference length
 
@@ -306,7 +306,16 @@ export const useAntennaStore = create<AntennaState>()(
       comparisonReference: null,
 
       setAntennaType: (type) => set((s) => {
+        const previousType = s.antennaType;
         s.antennaType = type;
+
+        // Vertical whips default to height=0 (sitting on ground). When
+        // switching back to a horizontal antenna, restore the default
+        // mast height so it doesn't stay stuck at 0m.
+        if (previousType === 'vertical-whip' && type !== 'vertical-whip' && s.height === 0) {
+          s.height = INITIAL_HEIGHT;
+        }
+
         if (!FEEDLINE_SUPPORTED_TYPES.has(type)) {
           s.feedlineId = 'none';
           s.feedlineLength = 0;

--- a/tests/repro_issue.test.ts
+++ b/tests/repro_issue.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { useAntennaStore, INITIAL_HEIGHT } from '../src/store/antennaStore';
+
+describe('Reproduction of height issue when switching from whip', () => {
+  it('should reset height to default when switching from vertical-whip to dipole', () => {
+    const store = useAntennaStore.getState();
+
+    // 1. Start with dipole (default height should be INITIAL_HEIGHT)
+    store.setAntennaType('dipole');
+    expect(useAntennaStore.getState().height).toBe(INITIAL_HEIGHT);
+
+    // 2. Switch to vertical-whip (height should become 0)
+    store.setAntennaType('vertical-whip');
+    expect(useAntennaStore.getState().height).toBe(0);
+
+    // 3. Switch back to dipole (height should revert to INITIAL_HEIGHT)
+    store.setAntennaType('dipole');
+    expect(useAntennaStore.getState().height).toBe(INITIAL_HEIGHT);
+  });
+});


### PR DESCRIPTION
Fixed a rendering issue where the mast height would stay stuck at 0m after switching from a Vertical Whip antenna to another antenna type.

Key changes:
- Modified the `setAntennaType` action in `src/store/antennaStore.ts` to detect when a user switches away from a `vertical-whip` type. If the height is currently 0m (the default for whips), it is reset to the project default `INITIAL_HEIGHT` (10m).
- Exported `INITIAL_HEIGHT` from the store to allow for cleaner testing.
- Added a new test file `tests/repro_issue.test.ts` that specifically verifies this state transition.

Verification performed:
- Ran `npm run test` (all 481 tests passed, including the new one).
- Ran `npm run build` and `npm run lint` (both passed).
- Performed visual verification using a Playwright script, confirming the UI correctly reflects the height change when switching types.

Fixes #242

---
*PR created automatically by Jules for task [7072618767309064029](https://jules.google.com/task/7072618767309064029) started by @2fst4u*