### PR TITLE
🧪 [Testing] Add tests for missing nec2Engine initialization error

### DIFF
--- a/tests/nec2Engine.test.ts
+++ b/tests/nec2Engine.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { Nec2Engine } from '../src/physics/nec2Engine';
+import type { SimulationInput } from '../src/physics/types';
+
+describe('Nec2Engine unit tests', () => {
+  it('simulate() throws initialization error if factory fails to initialize', async () => {
+    const engine = new Nec2Engine();
+    // Stub init to simulate a silent failure where this.factory remains null
+    engine.init = async () => {};
+
+    const dummyInput = {} as SimulationInput;
+
+    await expect(engine.simulate(dummyInput)).rejects.toThrow(
+      'NEC-2 engine failed to initialise'
+    );
+  });
+
+  it('sweepImpedance() throws initialization error if factory fails to initialize', async () => {
+    const engine = new Nec2Engine();
+    // Stub init to simulate a silent failure where this.factory remains null
+    engine.init = async () => {};
+
+    const dummyInput = {} as SimulationInput;
+
+    await expect(engine.sweepImpedance(dummyInput)).rejects.toThrow(
+      'NEC-2 engine failed to initialise'
+    );
+  });
+});


### PR DESCRIPTION
🎯 **What:** This PR addresses a testing gap where the `Nec2Engine` class correctly throws an error when its initialization fails (i.e. `this.factory` remains `null`), but the behavior was not backed by tests.

📊 **Coverage:** Created `tests/nec2Engine.test.ts` with isolated unit tests that stub the `init` method to silently fail, asserting that both `simulate()` and `sweepImpedance()` reject with the message `'NEC-2 engine failed to initialise'`.

✨ **Result:** Improved test reliability by ensuring the boundary error states for the core WASM engine are permanently verified without needing to load the real binary.

---
*PR created automatically by Jules for task [7982362291072940933](https://jules.google.com/task/7982362291072940933) started by @2fst4u*