### PR TITLE
🧪 [testing improvement] Add unit tests for antennaGeometry pure functions

### DIFF
--- a/tests/antennaGeometry.test.ts
+++ b/tests/antennaGeometry.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { gradedSegmentPlan, orientationVector } from '../src/store/antennaGeometry';
+
+describe('gradedSegmentPlan', () => {
+  it('returns empty plan for zero or negative length', () => {
+    expect(gradedSegmentPlan(0, 1, 2)).toEqual({ prefixLens: [], tailLen: 0, tailCount: 0 });
+    expect(gradedSegmentPlan(-5, 1, 2)).toEqual({ prefixLens: [], tailLen: 0, tailCount: 0 });
+  });
+
+  it('calculates geometric growth and uniform tail correctly', () => {
+    // total = 10, start = 1, max = 4, growth = 2
+    // Loop 1: cur=1 -> accum=1, cur=2
+    // Loop 2: cur=2 -> accum=3, cur=4
+    // Loop ends (cur=4 is not < maxSegLen)
+    // remaining = 7. tailCount = round(7 / 4) = 2. tailLen = 7 / 2 = 3.5
+    const plan = gradedSegmentPlan(10, 1, 4, 2);
+    expect(plan.prefixLens).toEqual([1, 2]);
+    expect(plan.tailCount).toBe(2);
+    expect(plan.tailLen).toBeCloseTo(3.5);
+  });
+
+  it('handles small remaining length without creating tails if close to 0', () => {
+    // total = 1e-10, start = 1, max = 4, growth = 2
+    // Loop won't run because 1 < 1e-10 is false
+    // accum = 0, remaining = 1e-10 which is < 1e-9
+    const plan = gradedSegmentPlan(1e-10, 1, 4, 2);
+    expect(plan.prefixLens).toEqual([]);
+    expect(plan.tailCount).toBe(0);
+    expect(plan.tailLen).toBe(0);
+  });
+
+  it('clamps startSegLen and maxSegLen to prevent infinite loops / div by 0', () => {
+    // testing minimum lengths handled by Math.max(..., 1e-9)
+    const plan = gradedSegmentPlan(1, 0, 0, 2);
+    // startSegLen = 1e-9, maxSegLen = 1e-9
+    // loop won't execute because cur < maxSegLen is 1e-9 < 1e-9 (false)
+    // remaining = 1. tailCount = round(1 / 1e-9) = 1e9.
+    // tailLen = 1 / 1e9 = 1e-9
+    expect(plan.prefixLens).toEqual([]);
+    expect(plan.tailCount).toBe(1000000000);
+    expect(plan.tailLen).toBeCloseTo(1e-9);
+  });
+});
+
+describe('orientationVector', () => {
+  it('handles NS preset (0 degrees)', () => {
+    const [x, y] = orientationVector('NS');
+    expect(x).toBeCloseTo(0);
+    expect(y).toBeCloseTo(1);
+  });
+
+  it('handles EW preset (90 degrees)', () => {
+    const [x, y] = orientationVector('EW');
+    expect(x).toBeCloseTo(1);
+    expect(y).toBeCloseTo(0);
+  });
+
+  it('handles NE-SW preset (45 degrees)', () => {
+    const [x, y] = orientationVector('NE-SW');
+    expect(x).toBeCloseTo(Math.SQRT1_2); // cos(45deg)
+    expect(y).toBeCloseTo(Math.SQRT1_2); // sin(45deg)
+  });
+
+  it('handles NW-SE preset (315 degrees)', () => {
+    const [x, y] = orientationVector('NW-SE');
+    expect(x).toBeCloseTo(-Math.SQRT1_2); // cos(-225deg) = -0.707
+    expect(y).toBeCloseTo(Math.SQRT1_2);  // sin(-225deg) = 0.707
+  });
+
+  it('handles arbitrary numeric degrees', () => {
+    // 180 deg (South)
+    const [x, y] = orientationVector(180);
+    // (90 - 180) = -90. cos(-90)=0, sin(-90)=-1
+    expect(x).toBeCloseTo(0);
+    expect(y).toBeCloseTo(-1);
+  });
+
+  it('handles unrecognised string by falling back to 0 degrees', () => {
+    // @ts-expect-error intentionally invalid input
+    const [x, y] = orientationVector('INVALID');
+    // switch won't match, deg stays 0
+    expect(x).toBeCloseTo(0);
+    expect(y).toBeCloseTo(1);
+  });
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of specific unit tests for `gradedSegmentPlan` and `orientationVector` inside `src/store/antennaGeometry.ts`.
📊 **Coverage:** Tests verify zero/invalid inputs, typical scaling arrays, infinite-loop guard logic for `gradedSegmentPlan`, and valid vs invalid angles/presets for `orientationVector`.
✨ **Result:** Test coverage for the pure math helper logic in the antenna module is now properly checked in isolation using standard vitest setups.

---
*PR created automatically by Jules for task [3707938390718569355](https://jules.google.com/task/3707938390718569355) started by @2fst4u*