### PR TITLE
🧪 Add test for nec2Engine sweep exit status error

### DIFF
--- a/tests/nec2Engine.test.ts
+++ b/tests/nec2Engine.test.ts
@@ -26,4 +26,42 @@ describe('Nec2Engine unit tests', () => {
       'NEC-2 engine failed to initialise'
     );
   });
+
+  it('sweepImpedance() throws error if sweep exits with non-zero status', async () => {
+    const engine = new Nec2Engine();
+
+    // Stub factory to return an instance with failing callMain
+    engine['factory'] = async (opts?: { printErr?: (msg: string) => void }) => {
+      // simulate printing stderr for the tail
+      if (opts?.printErr) {
+        opts.printErr('some error line 1');
+        opts.printErr('some error line 2');
+      }
+      return {
+        FS: {
+          writeFile: () => {},
+          readFile: () => new Uint8Array([]),
+        },
+        callMain: () => 1, // Non-zero exit code
+      } as unknown;
+    };
+
+    const dummyInput = {
+      frequencyMHz: 14.1,
+      wires: [],
+      ground: { type: 'perfect' },
+      excitation: {
+        wireTag: 1,
+        segment: 1,
+        voltage: 1,
+      },
+      patternResolution: { thetaSteps: 1, phiSteps: 1 },
+      loads: [],
+      transmissionLines: [],
+    } as unknown as SimulationInput;
+
+    await expect(engine.sweepImpedance(dummyInput)).rejects.toThrow(
+      'nec2c sweep exited with status 1. some error line 1 | some error line 2'
+    );
+  });
 });


### PR DESCRIPTION
🎯 **What:** Adds a missing test for the scenario where the NEC2 WASM engine exits with a non-zero status during an impedance sweep in `nec2Engine.ts`.
📊 **Coverage:** Specifically covers the `rc !== 0` check in the `solveImpedanceSweep` method, mocking the factory to simulate failure and stderr output.
✨ **Result:** Test coverage improved for engine error states.

Fixes missing test for `nec2c sweep exited with status` error condition.

---
*PR created automatically by Jules for task [802321608659843521](https://jules.google.com/task/802321608659843521) started by @2fst4u*