### PR TITLE
🧪 [testing improvement] Add tests for Nec2Engine non-zero exit status error handling

### DIFF
--- a/tests/nec2Engine.error.test.ts
+++ b/tests/nec2Engine.error.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Nec2Engine } from '../src/physics/nec2Engine';
+import { SimulationInput } from '../src/physics/types';
+
+describe('Nec2Engine error handling', () => {
+  it('throws an error with stderr when nec2c exits with a non-zero status code', async () => {
+    const engine = new Nec2Engine({ baseUrl: '/' });
+
+    // Mock the init promise to bypass actual wasm loading
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (engine as any).ready = true;
+
+    const mockInstance = {
+      FS: {
+        writeFile: vi.fn(),
+        readFile: vi.fn(),
+      },
+      callMain: vi.fn().mockReturnValue(1), // return non-zero status
+    };
+
+    // Inject a mock factory
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (engine as any).factory = async (options: any) => {
+      // Simulate nec2c writing to stderr before exiting
+      if (options.printErr) {
+        options.printErr('Fatal error: geometry invalid');
+        options.printErr('Segmentation fault');
+      }
+      return mockInstance;
+    };
+
+    const dummyInput: SimulationInput = {
+      wires: [{ start: [0, 0, 1], end: [0, 0, 2], radius: 0.001, segments: 11, tag: 1 }],
+      frequencyMHz: 14,
+      ground: { type: 'free' },
+      excitation: { wireTag: 1, segment: 6 },
+      patternResolution: { thetaSteps: 5, phiSteps: 8 },
+    };
+
+    await expect(engine.simulate(dummyInput)).rejects.toThrow(
+      'nec2c exited with status 1. Fatal error: geometry invalid | Segmentation fault'
+    );
+  });
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `Nec2Engine` simulation function contains logic to capture `stderr` and throw a descriptive error if the WASM `nec2c` module exits with a non-zero status. However, this specific error path was not covered by the existing test suite, creating a risk that changes to the WASM integration could break error propagation without detection.

📊 **Coverage:** What scenarios are now tested
This PR adds a test that isolates the `Nec2Engine` logic from the real WASM binary. It injects a mock WASM factory that simulates a failure scenario where `callMain` returns `1` and outputs dummy error messages to `stderr`. The test asserts that the engine correctly captures these messages, formats them, and throws the expected `Error`.

✨ **Result:** The improvement in test coverage
We now have robust coverage of the WASM failure path. This ensures that if the NEC-2 engine crashes or returns an error due to invalid geometry or a segmentation fault, the application will reliably throw a detailed error containing the engine's last few lines of `stderr`, aiding in debugging.

---
*PR created automatically by Jules for task [2761951931105022000](https://jules.google.com/task/2761951931105022000) started by @2fst4u*