### PR TITLE
🛡️ Sentinel: [HIGH] Prevent XSS by validating dynamic import URLs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -18,3 +18,7 @@
 **Vulnerability:** Unspecified radix in `parseInt` calls processing UI string inputs can lead to unexpected numeric evaluation (e.g. interpreting leading zeros as octal in legacy or non-strict environments).
 **Learning:** Relying on implicit base-10 parsing is a classic defensive programming weakness. Specifying radix 10 explicitly guarantees correct parsing behavior and satisfies SAST tools and strict linters, reinforcing input handling correctness.
 **Prevention:** Always provide the radix argument explicitly when using `parseInt`, e.g., `parseInt(value, 10)`.
+## 2026-05-18 - Validate Dynamic Import URLs
+**Vulnerability:** Dynamic imports (`import()`) in browser or Node environments can execute arbitrary code if the URL passed is controlled by an attacker and formatted as a `data:` or `blob:` URI. The application dynamically imported the web worker wrapper without verifying the resulting URL protocol.
+**Learning:** Always use `new URL(url, base)` to construct an absolute URL object and explicitly check its `.protocol` property against an allowlist of safe protocols (e.g., `['http:', 'https:', 'file:']`) immediately before the `import()` call.
+**Prevention:** In functions resolving asset paths for dynamic imports, enforce protocol allowlisting to block XSS and malicious remote execution, guaranteeing defense-in-depth even if the base path is poisoned.

--- a/src/physics/nec2Engine.ts
+++ b/src/physics/nec2Engine.ts
@@ -72,6 +72,13 @@ async function loadNec2Factory(baseUrl: string): Promise<EmscriptenFactory> {
         : '';
     url = new URL(`${baseUrl}nec2.js`, origin || 'http://localhost/').href;
   }
+
+  // Validate the resulting URL protocol to prevent XSS via data:/blob: URIs
+  const parsedUrl = new URL(url, 'http://localhost/');
+  if (!['http:', 'https:', 'file:'].includes(parsedUrl.protocol)) {
+    throw new Error(`Insecure dynamic import protocol: ${parsedUrl.protocol}`);
+  }
+
   const mod = (await import(/* @vite-ignore */ url)) as { default: EmscriptenFactory };
   return mod.default;
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Dynamic imports (`import()`) can execute arbitrary code if the URL passed is controlled by an attacker and formatted as a `data:` or `blob:` URI. The application dynamically imported the web worker wrapper without verifying the resulting URL protocol.
🎯 Impact: Could allow Cross-Site Scripting (XSS) or arbitrary code execution via poisoned asset base URLs.
🔧 Fix: Used `new URL(url, 'http://localhost/')` to construct a URL object and explicitly check its `.protocol` property against an allowlist of safe protocols (`['http:', 'https:', 'file:']`) immediately before the `import()` call.
✅ Verification: Ran `npm run test` and `npm run lint` successfully.

Learnings added to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [6618545697627030496](https://jules.google.com/task/6618545697627030496) started by @2fst4u*