### PR TITLE
⚡ Bolt: Combine multiple O(N) array finds into a single O(N) loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -134,3 +134,7 @@
 
 **Learning:** When checking string membership against a static, known list of options, defining an array inline and using `.includes()` requires reallocation on every execution and runs in $O(N)$ time. By extracting the static array into a module-scoped `Set`, we avoid memory reallocation and change the check to $O(1)$ time, yielding a measurable performance boost.
 **Action:** Always extract static membership checks (like enum-like string arrays) into a module-scoped `Set` and use `Set.has()` in frequently-executed render paths or hot loops.
+## 2025-05-18 - Single Pass Lookups
+
+**Learning:** Finding multiple unique elements within an array using repeated `Array.find()` calls creates a significant $O(N \times M)$ overhead, particularly in hot rendering paths.
+**Action:** Replace multiple sequential `Array.find()` calls with a single standard $O(N)$ `for` loop that captures all required elements simultaneously. This minimizes array traversal and improves render performance.

--- a/src/components/Scene/DipoleWire.tsx
+++ b/src/components/Scene/DipoleWire.tsx
@@ -136,20 +136,32 @@ export function DipoleWire({
   }, [type, length, height, orientation, wireRadius, segments, feedlineId, feedlineLength, feedlineOffset, vAngle, legSlope, frequency, whipCounterpoise]);
 
   // Locate elements we want to decorate.
-  const bridge = rendered.find((s) => s.isBridge);
-  const dipoleSingle = rendered.find((s) => s.tag === DIPOLE_TAG && !bridge);
-  const shield = rendered.find((s) => s.isShield);
+  // ⚡ Bolt: Performance Optimization
+  // Combined 7 separate O(N) `rendered.find()` calls into a single O(N) pass.
+  // This reduces array traversal overhead, especially when `rendered` has many segments.
+  let bridge: typeof rendered[0] | undefined;
+  let dipoleSingle: typeof rendered[0] | undefined;
+  let shield: typeof rendered[0] | undefined;
+  let apexFedLeft: typeof rendered[0] | null = null;
+  let verticalWhip: typeof rendered[0] | null = null;
+  let termDeltaLeftBase: typeof rendered[0] | undefined;
+  let termDeltaRightBase: typeof rendered[0] | undefined;
 
-  // Delta Loop and Terminated Delta: left leg runs corner→apex; sceneEnd is the apex point.
-  const apexFedLeft = (type === 'delta-loop' || type === 'terminated-delta')
-    ? (rendered.find((s) => s.tag === DIPOLE_LEFT_TAG) ?? null)
-    : null;
+  for (let i = 0; i < rendered.length; i++) {
+    const s = rendered[i]!;
+    if (s.isBridge && !bridge) bridge = s;
+    if (s.isShield && !shield) shield = s;
+    if (s.tag === DIPOLE_TAG && !dipoleSingle) dipoleSingle = s;
+    if (s.tag === DIPOLE_LEFT_TAG && !apexFedLeft) apexFedLeft = s;
+    if (s.tag === VERTICAL_WHIP_TAG && !verticalWhip) verticalWhip = s;
+    if (s.tag === TERMINATED_DELTA_LEFT_BASE_TAG && !termDeltaLeftBase) termDeltaLeftBase = s;
+    if (s.tag === TERMINATED_DELTA_RIGHT_BASE_TAG && !termDeltaRightBase) termDeltaRightBase = s;
+  }
 
-  // Vertical whip: the wire is emitted base → top, so .sceneStart is the
-  // base feedpoint. Falls through to dipoleSingle? otherwise.
-  const verticalWhip = type === 'vertical-whip'
-    ? (rendered.find((s) => s.tag === VERTICAL_WHIP_TAG) ?? null)
-    : null;
+  if (bridge && dipoleSingle) dipoleSingle = undefined;
+
+  if (type !== 'delta-loop' && type !== 'terminated-delta') apexFedLeft = null;
+  if (type !== 'vertical-whip') verticalWhip = null;
 
   // Feedpoint: bridge midpoint (split-fed) > apex-fed left-leg end >
   // vertical-whip base > dipole wire midpoint (single-wire legacy).
@@ -168,8 +180,8 @@ export function DipoleWire({
   // the resistor sits on it.
   const terminatedDeltaSplit = useMemo(() => {
     if (type !== 'terminated-delta') return null;
-    const leftHalfBase = rendered.find((s) => s.tag === TERMINATED_DELTA_LEFT_BASE_TAG);
-    const rightHalfBase = rendered.find((s) => s.tag === TERMINATED_DELTA_RIGHT_BASE_TAG);
+    const leftHalfBase = termDeltaLeftBase;
+    const rightHalfBase = termDeltaRightBase;
     if (!leftHalfBase || !rightHalfBase) return null;
     const leftInner = leftHalfBase.sceneEnd;
     const rightInner = rightHalfBase.sceneStart;
@@ -201,7 +213,7 @@ export function DipoleWire({
       bridgeQuat,
       resistorRadius: Math.max(wireRadius * 8, 0.04),
     };
-  }, [type, rendered, wireRadius]);
+  }, [type, termDeltaLeftBase, termDeltaRightBase, wireRadius]);
 
   return (
     <group>


### PR DESCRIPTION
💡 **What:** Replaced 7 separate `Array.find()` calls in `DipoleWire.tsx` with a single O(N) `for` loop that captures all required elements simultaneously.
🎯 **Why:** Calling `Array.find()` repeatedly on the same array during every render pass causes unnecessary O(N x M) overhead. Consolidating this to a single O(N) traversal reduces array traversal overhead, leading to faster render cycles when antenna geometry changes.
📊 **Impact:** Reduces array iteration overhead significantly during `DipoleWire` rendering by eliminating 6 redundant passes over the `rendered` array.
🔬 **Measurement:** Verify tests run and `DipoleWire` correctly identifies specific wires (e.g., bridge, shield, specific delta-loop base wires). Tested locally via `npm run test` and `npm run lint`.

---
*PR created automatically by Jules for task [7066928605331369769](https://jules.google.com/task/7066928605331369769) started by @2fst4u*