### PR TITLE
feat: PWA cache-busting for Cloudflare Pages deployments

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -17,3 +17,11 @@
   Cross-Origin-Embedder-Policy: require-corp
   # Prevent other origins from reading the application's resources
   Cross-Origin-Resource-Policy: same-origin
+  # SPA shell, SW, manifest, and unhashed public files must always revalidate so
+  # browsers pick up new Cloudflare deployments without stale-shell 404s.
+  Cache-Control: no-cache
+
+# Vite-hashed assets are content-addressed – safe to cache permanently.
+# This rule overrides the Cache-Control set above for the /assets/* namespace.
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Injected at build time by vite.config.ts `define`.
+ * Value is CF_PAGES_COMMIT_SHA during Cloudflare Pages builds, or an ISO
+ * timestamp during local development.  Use for debug / cache-busting.
+ */
+declare const __BUILD_ID__: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,7 +8,26 @@ import { VitePWA } from 'vite-plugin-pwa';
 // - nec2.js is loaded dynamically at runtime from /nec2.js (served from public/).
 //   It is NOT imported by the bundle so Vite won't try to transform it.
 // - We mark three/examples as transpile-friendly via optimizeDeps for dev.
+//
+// Cache-busting strategy (PWA + Cloudflare Pages):
+// - HTTP layer  : public/_headers sets Cache-Control: no-cache for the SPA shell,
+//                 service worker, manifest and unhashed public files; /assets/* gets
+//                 immutable (content-addressed by Vite hash).
+// - SW layer    : buildId is injected into the Workbox precache manifest as a
+//                 revision entry so the generated sw.js always differs between
+//                 Cloudflare deployments even when no source files changed.
+//                 CF_PAGES_COMMIT_SHA is set automatically during CF Pages builds;
+//                 we fall back to an ISO timestamp for local dev.
+// - SW lifecycle: clientsClaim + cleanupOutdatedCaches ensure the new SW takes
+//                 control of all open tabs immediately and evicts stale caches.
+
+const buildId: string = process.env.CF_PAGES_COMMIT_SHA ?? new Date().toISOString();
+
 export default defineConfig({
+  define: {
+    // Exposed to app code as __BUILD_ID__ (declared in src/vite-env.d.ts).
+    __BUILD_ID__: JSON.stringify(buildId),
+  },
   plugins: [
     react(),
     VitePWA({
@@ -33,6 +52,17 @@ export default defineConfig({
       workbox: {
         globPatterns: ['**/*.{js,css,html,ico,png,svg,wasm}'],
         maximumFileSizeToCacheInBytes: 5 * 1024 * 1024,
+        // Take control of all tabs immediately after activation so users
+        // don't remain on a stale bundle until their next hard reload.
+        clientsClaim: true,
+        // Purge precaches from old SW versions to free storage and avoid
+        // serving mixed old/new assets.
+        cleanupOutdatedCaches: true,
+        // Include a build-specific revision so the SW manifest changes on
+        // every Cloudflare deployment, guaranteeing browsers fetch a new sw.js.
+        additionalManifestEntries: [
+          { url: 'index.html', revision: buildId },
+        ],
       },
     }),
   ],


### PR DESCRIPTION
## Problem

Three independent caches could all serve stale content after a Cloudflare Pages deployment:

1. **Browser HTTP cache** — `index.html` had no `Cache-Control` header, so browsers could serve the old shell (pointing to old Vite-hashed asset URLs that no longer exist on the server → 404s).
2. **Service worker precache** — if no source files changed between two deployments the generated `sw.js` was byte-for-byte identical, so the browser never detected a new SW to install.
3. **Stale SW caches** — old SW precache entries from previous builds were never explicitly evicted.

## Solution (three layers)

### HTTP layer — `public/_headers`
| Path | `Cache-Control` |
|------|----------------|
| `/*` (SPA shell, SW, manifest, `nec2.*`) | `no-cache` — always revalidate |
| `/assets/*` (Vite-hashed bundles) | `public, max-age=31536000, immutable` |

The wildcard rule covers `index.html`, `sw.js`, `manifest.webmanifest`, and the unhashed `nec2.js`/`nec2.wasm` binaries. The `/assets/*` override lets Vite content-hashed files be cached permanently (the hash changes on content change).

### Service-worker layer — `vite.config.ts`
- **`__BUILD_ID__`** is injected via `define` using `CF_PAGES_COMMIT_SHA` (set automatically by Cloudflare Pages) with a local ISO-timestamp fallback. It becomes the Workbox precache **revision** for `index.html`, so `sw.js` is always a new byte-sequence on every deployment regardless of whether source files changed.
- **`clientsClaim: true`** — new SW takes over all open tabs immediately on activation instead of waiting for the user to navigate.
- **`cleanupOutdatedCaches: true`** — stale precaches from prior SW versions are purged after each update.

### TypeScript — `src/vite-env.d.ts`
Declares the `__BUILD_ID__` ambient constant so it can be referenced in app code (e.g. for version display or debug logging) without TypeScript errors.

## Verification

```
✓ 531 tests pass (vitest run)
✓ ESLint clean
✓ Production build succeeds
✓ dist/sw.js contains: clientsClaim, skipWaiting, cleanupOutdatedCaches
✓ index.html precache revision = ISO timestamp (will be commit SHA in CI)
```

https://claude.ai/code/session_01GXpfyscymKmDKcNK2PdDQb

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXpfyscymKmDKcNK2PdDQb)_