### PR TITLE
Remove NVIS mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A 3D, responsive, physics-accurate visualiser for HF antenna radiation patterns,
 
 While this repository is fully open source and developers are welcome to fork or clone it to run locally, the primary way to use the application is via the hosted URL at **[www.gain.observer](https://www.gain.observer/)**.
 
-Current scope (Phase 1): horizontal dipoles, inverted Vs, sloping Vs, delta loops, and terminated delta loops, 1.8–30 MHz, real-ground support, offset feed points, feedlines & baluns, NVIS and comparison modes, SWR/polar cut charts, dark/light theming, metric/imperial toggle.
+Current scope (Phase 1): horizontal dipoles, inverted Vs, sloping Vs, delta loops, and terminated delta loops, 1.8–30 MHz, real-ground support, offset feed points, feedlines & baluns, comparison mode, SWR/polar cut charts, dark/light theming, metric/imperial toggle.
 
 ## Stack
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.1.0",
   "type": "module",
-  "description": "HF antenna gain visualizer — 3D radiation patterns, SWR, and NVIS/comparison modes powered by NEC-2 (WebAssembly).",
+  "description": "HF antenna gain visualizer — 3D radiation patterns, SWR, and comparison mode powered by NEC-2 (WebAssembly).",
   "license": "GPL-3.0-or-later",
   "scripts": {
     "dev": "vite",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -142,7 +142,6 @@ function useKeyboardShortcuts(): void {
       if (e.target instanceof HTMLInputElement || e.target instanceof HTMLSelectElement) return;
       if (e.key === 't' || e.key === 'T') toggleTheme();
       else if (e.key === 'u' || e.key === 'U') toggleUnits();
-      else if (e.key === 'n' || e.key === 'N') setMode('nvis');
       else if (e.key === 'm' || e.key === 'M') setMode('normal');
     };
     window.addEventListener('keydown', handler);

--- a/src/components/Panel/ModeSelector.tsx
+++ b/src/components/Panel/ModeSelector.tsx
@@ -3,7 +3,6 @@ import type { Mode } from '../../store/antennaStore';
 
 const MODES: Array<{ id: Mode; label: string; hint: string; shortcut: string }> = [
   { id: 'normal', label: 'Normal', hint: 'Standard DX pattern view', shortcut: 'm' },
-  { id: 'nvis', label: 'NVIS', hint: 'Highlights zenith lobe for regional comms', shortcut: 'n' },
   { id: 'comparison', label: 'Compare', hint: 'Side-by-side two configs', shortcut: 'c' },
 ];
 

--- a/src/components/Panel/StatsReadout.tsx
+++ b/src/components/Panel/StatsReadout.tsx
@@ -154,9 +154,6 @@ export function StatsReadout() {
       {mode === 'comparison' && reference && (
         <ComparisonStats current={result} reference={reference.result} />
       )}
-      {mode === 'nvis' && (
-        <NvisStats />
-      )}
       <TerminationSection diagnostics={result.terminationDiagnostics} />
     </section>
   );
@@ -280,31 +277,3 @@ function TerminationSection({ diagnostics }: { diagnostics: TerminationDiagnosti
   );
 }
 
-function NvisStats() {
-  const result = useAntennaStore((s) => s.result);
-  if (!result) return null;
-  // Compute NVIS metric: gain at theta=0 (i.e. zenith).
-  // At zenith, far-field gain is independent of phi, so we can just sample data[0]
-  // instead of averaging across all phi steps.
-  const p = result.pattern;
-  const zenithGain = p.phiSteps > 0 ? (p.data[0] ?? 0) : 0;
-  const ratio = zenithGain - result.maxGainDbi;
-
-  return (
-    <>
-      <hr style={{ border: 0, borderTop: '1px solid var(--border)', margin: '8px 0' }} />
-      {/* SEO: Added H3 to complete the document outline for NVIS stats, matching siblings */}
-      <h3 style={{ fontSize: 11, margin: 0, color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: 6 }}>
-        NVIS effectiveness
-      </h3>
-      <div className="stat">
-        <span className="stat-label">Zenith gain (NVIS)</span>
-        <span className="stat-value">{zenithGain.toFixed(2)} dBi</span>
-      </div>
-      <div className="stat">
-        <span className="stat-label">NVIS vs peak</span>
-        <span className="stat-value">{ratio.toFixed(2)} dB</span>
-      </div>
-    </>
-  );
-}

--- a/src/components/Scene/AntennaScene.tsx
+++ b/src/components/Scene/AntennaScene.tsx
@@ -39,7 +39,6 @@ export function AntennaScene({ snapshot = null }: AntennaSceneProps) {
     dbRange,
     colorMaxDb,
     colormap,
-    mode,
     theme,
   } = useAntennaStore(useShallow((s) => ({
     liveType: s.antennaType,
@@ -60,7 +59,6 @@ export function AntennaScene({ snapshot = null }: AntennaSceneProps) {
     dbRange: s.dbRange,
     colorMaxDb: s.colorMaxDb,
     colormap: s.colormap,
-    mode: s.mode,
     theme: s.theme,
   })));
 
@@ -110,7 +108,6 @@ export function AntennaScene({ snapshot = null }: AntennaSceneProps) {
           dbRange={dbRange}
           colorMaxDb={colorMaxDb}
           colormap={colormap}
-          mode={mode}
         />
       </Suspense>
 

--- a/src/components/Scene/RadiationPattern.tsx
+++ b/src/components/Scene/RadiationPattern.tsx
@@ -123,7 +123,7 @@ export function RadiationPattern({
   // 3. Compute vertex colors. Re-run if gains, colormap, or mode change.
   const vertexColors = useMemo(() => {
     if (!result || !vertexGains) return null;
-    const { count, angles } = cachedGeo;
+    const { count } = cachedGeo;
     const colors = new Float32Array(count * 4);
 
     // Fetch the colormap table outside the hot loop

--- a/src/components/Scene/RadiationPattern.tsx
+++ b/src/components/Scene/RadiationPattern.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo } from 'react';
 import * as THREE from 'three';
 import { useAdaptiveLOD } from '../../hooks/useAdaptiveLOD';
 import type { SimulationResult } from '../../physics/types';
-import type { Colormap, Mode } from '../../store/antennaStore';
+import type { Colormap } from '../../store/antennaStore';
 import { pickTable, sampleColormapFast } from '../../utils/colormap';
 
 interface Props {
@@ -12,7 +12,6 @@ interface Props {
   readonly dbRange: number;
   readonly colorMaxDb: number;
   readonly colormap: Colormap;
-  readonly mode: Mode;
 }
 
 export function RadiationPattern({
@@ -22,7 +21,6 @@ export function RadiationPattern({
   dbRange,
   colorMaxDb,
   colormap,
-  mode,
 }: Props) {
   const lod = useAdaptiveLOD();
 
@@ -134,21 +132,17 @@ export function RadiationPattern({
     // Pre-calculate color scale invariants for inline linear mapping
     const minDb = colorMaxDb - dbRange;
     const invRange = 1 / dbRange;
-    const isNvis = mode === 'nvis';
 
     for (let i = 0; i < count; i++) {
       const gainDb = vertexGains[i]!;
-      let t = gainDb >= colorMaxDb ? 1 : (gainDb <= minDb ? 0 : (gainDb - minDb) * invRange);
-      if (isNvis && angles[i * 2]! < 30) {
-        t = t > 0.9 ? 1 : t + 0.1;
-      }
+      const t = gainDb >= colorMaxDb ? 1 : (gainDb <= minDb ? 0 : (gainDb - minDb) * invRange);
 
       const idx = i * 4;
       sampleColormapFast(table, t, colors, idx);
       colors[idx + 3] = 1;
     }
     return colors;
-  }, [vertexGains, colormap, colorMaxDb, dbRange, mode, cachedGeo, result]);
+  }, [vertexGains, colormap, colorMaxDb, dbRange, cachedGeo, result]);
 
   // 4. Cache the geometry with positions and normals.
   // This avoids recomputing normals when only colors change.

--- a/src/store/antennaStore.ts
+++ b/src/store/antennaStore.ts
@@ -83,7 +83,7 @@ export type { OrientationPreset, Orientation };
 const FEEDLINE_SUPPORTED_TYPES = new Set<string>(['dipole', 'inverted-v', 'delta-loop', 'sloping-v', 'terminated-delta']);
 
 export type Theme = 'dark' | 'light';
-export type Mode = 'normal' | 'nvis' | 'comparison';
+export type Mode = 'normal' | 'comparison';
 export type Colormap = 'viridis' | 'turbo' | 'jet';
 
 export interface ComparisonSnapshot {

--- a/tests/App.test.tsx
+++ b/tests/App.test.tsx
@@ -64,26 +64,14 @@ describe('App', () => {
       expect(useAntennaStore.getState().units).toBe('metric');
     });
 
-    it('changes mode to nvis on "n" or "N"', () => {
-      render(<App />);
-      expect(useAntennaStore.getState().mode).toBe('normal');
-
-      fireEvent.keyDown(window, { key: 'n' });
-      expect(useAntennaStore.getState().mode).toBe('nvis');
-
-      useAntennaStore.setState({ mode: 'normal' });
-      fireEvent.keyDown(window, { key: 'N' });
-      expect(useAntennaStore.getState().mode).toBe('nvis');
-    });
-
     it('changes mode to normal on "m" or "M"', () => {
-      useAntennaStore.setState({ mode: 'nvis' });
+      useAntennaStore.setState({ mode: 'comparison' });
       render(<App />);
 
       fireEvent.keyDown(window, { key: 'm' });
       expect(useAntennaStore.getState().mode).toBe('normal');
 
-      useAntennaStore.setState({ mode: 'nvis' });
+      useAntennaStore.setState({ mode: 'comparison' });
       fireEvent.keyDown(window, { key: 'M' });
       expect(useAntennaStore.getState().mode).toBe('normal');
     });

--- a/tests/ModeSelector.test.tsx
+++ b/tests/ModeSelector.test.tsx
@@ -16,16 +16,15 @@ describe('ModeSelector', () => {
   it('renders all mode buttons', () => {
     render(<ModeSelector />);
     expect(screen.getByRole('button', { name: 'Normal' })).toBeDefined();
-    expect(screen.getByRole('button', { name: 'NVIS' })).toBeDefined();
     expect(screen.getByRole('button', { name: 'Compare' })).toBeDefined();
   });
 
   it('highlights the active mode', () => {
-    useAntennaStore.setState({ mode: 'nvis' });
+    useAntennaStore.setState({ mode: 'comparison' });
     render(<ModeSelector />);
-    const nvisButton = screen.getByRole('button', { name: 'NVIS' });
-    expect(nvisButton.className).toContain('active');
-    expect(nvisButton.getAttribute('aria-pressed')).toBe('true');
+    const compareButton = screen.getByRole('button', { name: 'Compare' });
+    expect(compareButton.className).toContain('active');
+    expect(compareButton.getAttribute('aria-pressed')).toBe('true');
   });
 
   it('updates the mode when a button is clicked', () => {

--- a/tests/RadiationPattern.test.tsx
+++ b/tests/RadiationPattern.test.tsx
@@ -39,7 +39,6 @@ describe('RadiationPattern', () => {
         dbRange={40}
         colorMaxDb={10}
         colormap="turbo"
-        mode="dx"
       />
     );
     expect(container.firstChild).toBeNull();
@@ -65,7 +64,6 @@ describe('RadiationPattern', () => {
         dbRange={40}
         colorMaxDb={10}
         colormap="turbo"
-        mode="dx"
       />
     );
 
@@ -75,33 +73,5 @@ describe('RadiationPattern', () => {
 
     const material = container.querySelector('meshstandardmaterial');
     expect(material).not.toBeNull();
-  });
-
-  it('handles NVIS mode specific color adjustments', () => {
-    const thetaSteps = 37;
-    const phiSteps = 72;
-    const mockResult = {
-      pattern: {
-        data: new Float32Array(thetaSteps * phiSteps).fill(5),
-        dTheta: 5,
-        dPhi: 5,
-        thetaSteps,
-        phiSteps,
-      }
-    } as unknown as SimulationResult; // Cast to exact type
-
-    const { container } = render(
-      <RadiationPattern
-        result={mockResult}
-        patternScale={1}
-        dbRange={40}
-        colorMaxDb={10}
-        colormap="turbo"
-        mode="nvis"
-      />
-    );
-
-    const mesh = container.querySelector('mesh');
-    expect(mesh).not.toBeNull();
   });
 });

--- a/tests/StatsReadout.test.tsx
+++ b/tests/StatsReadout.test.tsx
@@ -11,7 +11,7 @@ describe('StatsReadout', () => {
     useAntennaStore.setState({
       antennaType: 'dipole',
       result: null,
-      mode: 'standard',
+      mode: 'normal',
       comparisonReference: null,
     });
   });
@@ -193,28 +193,4 @@ describe('StatsReadout', () => {
     expect(container.textContent).not.toContain('Termination reduces reflections');
   });
 
-  it('renders NVIS stats when mode is nvis', () => {
-    useAntennaStore.setState({
-      mode: 'nvis',
-      result: {
-        maxGainDbi: 5,
-        pattern: {
-          data: new Float32Array([2.5]), // Zenith gain
-          phiSteps: 72,
-          thetaSteps: 37,
-        },
-        computeTimeMs: 10,
-        takeoffElevationDeg: 90,
-        takeoffAzimuthDeg: 0,
-        impedance: { R: 50, X: 0 },
-        swr: 1.0
-      } as unknown as import('../src/physics/types').SimulationResult,
-    });
-
-    const { getByText } = render(<StatsReadout />);
-    expect(getByText('Zenith gain (NVIS)')).not.toBeNull();
-    expect(getByText('2.50 dBi')).not.toBeNull();
-    // ratio: 2.5 - 5 = -2.5
-    expect(getByText('-2.50 dB')).not.toBeNull();
-  });
 });


### PR DESCRIPTION
NVIS mode provided no value that the existing zenith stats and polar cut charts don't already cover. The radiation pattern data is unchanged by the toggle — the mode only applied a weak colour boost to high-elevation vertices and showed a stats panel that duplicated information available in normal mode.

## Changes

- Drop `'nvis'` from the `Mode` union type (`'normal' | 'comparison'` only)
- Remove `N` keyboard shortcut from `App.tsx`
- Remove NVIS button from `ModeSelector`
- Remove `NvisStats` component and its conditional render from `StatsReadout`
- Remove `isNvis` colour-boost logic from `RadiationPattern`; `mode` was only used for that, so the prop is removed entirely from `RadiationPattern` and its call site in `AntennaScene`
- Update all affected tests; fix pre-existing `mode: 'standard'` typo in `StatsReadout.test` `beforeEach`
- Update `package.json` description and README

All 528 tests pass.

https://claude.ai/code/session_01NZFQQJLX5mzBLpitJzY1XG

---
_Generated by [Claude Code](https://claude.ai/code/session_01NZFQQJLX5mzBLpitJzY1XG)_