### PR TITLE
🧹 Sweep: remove unused legacy setters from antennaStore

### DIFF
--- a/src/store/antennaStore.ts
+++ b/src/store/antennaStore.ts
@@ -550,12 +550,6 @@ export const useAntennaStore = create<AntennaState>()(
   ),
 );
 
-/**
- * Legacy setters maintained for backward compatibility.
- */
-export const setType = (t: AntennaType) => useAntennaStore.getState().setAntennaType(t);
-export const setSlope = (deg: number) => useAntennaStore.getState().setLegSlope(deg);
-
 function clampFreq(f: number): number {
   if (!Number.isFinite(f)) return 7.1;
   return Math.max(1.8, Math.min(30, f));


### PR DESCRIPTION
💡 What:
Removed the unused `setType` and `setSlope` functions from `src/store/antennaStore.ts`.

🎯 Why:
These were legacy setters kept for backward compatibility and are no longer used anywhere in the codebase. Removing them cleans up dead code.

🔬 Verification:
Ran `npx knip` to verify these were unused exports. Did a global text search (`grep`) across the codebase to ensure no internal or external references existed. Verified the cleanup with `npm run lint`, `npm run test`, and `npm run build`, all of which passed successfully.

---
*PR created automatically by Jules for task [14972189344446148606](https://jules.google.com/task/14972189344446148606) started by @2fst4u*