### PR TITLE
feat: add End-Fed Half-Wave (EFHW) antenna type

### DIFF
--- a/docs/future-antenna-designs.md
+++ b/docs/future-antenna-designs.md
@@ -16,10 +16,6 @@ Half-wave dipole where both ends are connected by a second parallel conductor, f
 
 Vertical radiator with a horizontal top-loading section at right angles. Useful for 160 m and 80 m where a full quarter-wave vertical would be impractically tall. The horizontal section adds electrical length without additional height. Requires ground radials or a counterpoise similar to the existing vertical whip.
 
-## End-Fed Half-Wave (EFHW)
-
-Single wire fed at one end, resonant at half a wavelength. Very popular for portable and SOTA operation due to minimal ground requirements. The high feed impedance (~2500–5000 Ω) is handled by a matching transformer (49:1 or 64:1 unun), which can be modelled as a series LC load. Pattern and gain are close to a dipole, though the off-center feed produces slight asymmetry.
-
 ## Horizontal Loop (Skyloop)
 
 Full-wave loop laid out horizontally (parallel to ground). Typically square or rectangular. At low heights it produces a high-angle NVIS pattern; at greater heights the pattern develops low-angle gain. The four-sided geometry requires corner wires and a flexible aspect-ratio parameter for square vs. rectangular configurations.

--- a/src/components/Panel/DipoleControl.tsx
+++ b/src/components/Panel/DipoleControl.tsx
@@ -117,6 +117,7 @@ export function DipoleControl() {
     'sloping-v': '1λ/leg',
     'terminated-delta': '1λ',
     'vertical-whip': '¼λ',
+    'efhw': '½λ',
   };
 
   const resonateTitles: Record<AntennaType, string> = {
@@ -126,10 +127,12 @@ export function DipoleControl() {
     'sloping-v': 'Set total length to 2λ (1λ per leg)',
     'terminated-delta': 'Set perimeter to 1λ',
     'vertical-whip': 'Set whip length to resonant ¼λ',
+    'efhw': 'Set wire length to resonant ½λ',
   };
 
   const isVerticalWhip = antennaType === 'vertical-whip';
-  const lengthLabel = isVerticalWhip ? `Whip length (${unit})` : `Length (${unit})`;
+  const isEfhw = antennaType === 'efhw';
+  const lengthLabel = isVerticalWhip ? `Whip length (${unit})` : isEfhw ? `Wire length (${unit})` : `Length (${unit})`;
   const heightLabel = isVerticalWhip
     ? `Base height above ground (${unit}) — ${dispHeight.toFixed(1)}`
     : `Height above ground (${unit}) — ${dispHeight.toFixed(1)}`;
@@ -148,6 +151,7 @@ export function DipoleControl() {
       >
         <option value="dipole">Horizontal Dipole</option>
         <option value="inverted-v">Inverted V</option>
+        <option value="efhw">End-Fed Half-Wave (EFHW)</option>
         <option value="sloping-v">Sloping V</option>
         <option value="delta-loop">Delta Loop</option>
         <option value="terminated-delta">Terminated Delta</option>

--- a/src/physics/constants.ts
+++ b/src/physics/constants.ts
@@ -63,6 +63,11 @@ export function referenceLength(type: AntennaType, frequencyMHz: number, endEffe
     case 'vertical-whip':
       // Quarter-wave monopole resonant length.
       return lambda * 0.25 * endEffect;
+    case 'efhw':
+      // End-fed half-wave resonant length. End-effect factor matches the
+      // center-fed dipole (0.95) — the current distribution is sinusoidal
+      // along the wire regardless of where the feed is placed.
+      return lambda * 0.5 * endEffect;
     default:
       return lambda * 0.5 * endEffect;
   }
@@ -164,6 +169,13 @@ export const TERMINATED_DELTA_BRIDGE_TAG = 11;
  * at the base of the whip rather than at its midpoint.
  */
 export const VERTICAL_WHIP_TAG = 12;
+
+/**
+ * Wire tag for the end-fed half-wave (EFHW) antenna. A single horizontal
+ * wire fed at segment 1 (the near end). The far end is an open circuit,
+ * producing the characteristic high feed impedance (~2500–5000 Ω).
+ */
+export const EFHW_TAG = 14;
 
 /**
  * Default whip length in metres = 32 ft (32 × 0.3048).

--- a/src/physics/types.ts
+++ b/src/physics/types.ts
@@ -15,8 +15,13 @@ export type Vec3 = readonly [number, number, number];
  *   - vertical-whip: a single vertical wire fed at its base (monopole).
  *     `length` is the whip length and `height` is the base height above
  *     ground; resonant length is ¼λ.
+ *   - efhw: end-fed half-wave wire, fed at one end. Very popular for
+ *     portable / SOTA use. Feed impedance is ~2500–5000 Ω; a 49:1 unun
+ *     at the feed transforms it to ~50 Ω. Pattern is close to a dipole
+ *     but with slight asymmetry from the off-centre feed.
+ *     `length` is the total wire length; resonant length is ½λ.
  */
-export type AntennaType = 'dipole' | 'inverted-v' | 'delta-loop' | 'sloping-v' | 'terminated-delta' | 'vertical-whip';
+export type AntennaType = 'dipole' | 'inverted-v' | 'delta-loop' | 'sloping-v' | 'terminated-delta' | 'vertical-whip' | 'efhw';
 
 export interface Wire {
   readonly start: Vec3;

--- a/src/store/antennaGeometry.ts
+++ b/src/store/antennaGeometry.ts
@@ -14,6 +14,7 @@ import {
   VERTICAL_WHIP_BASE_GAP_M,
   VERTICAL_WHIP_RADIAL_TAG,
   VERTICAL_WHIP_RADIAL_COUNT,
+  EFHW_TAG,
 } from '../physics/constants';
 import type { Wire } from '../physics/types';
 
@@ -721,4 +722,55 @@ export function buildVerticalWhipWires(params: VerticalWhipWiresParams): Wire[] 
   }
 
   return wires;
+}
+
+export interface EfhwWiresParams {
+  /** Total wire length in metres. Resonant at ½λ × end-effect. */
+  length: number;
+  /** Height of the wire above ground, metres. */
+  height: number;
+  orientation: Orientation;
+  wireRadius: number;
+  segments: number;
+  frequency: number;
+}
+
+/**
+ * Builds the wires for an End-Fed Half-Wave (EFHW) antenna.
+ *
+ * Geometry is a single horizontal wire of `params.length` metres, with
+ * one end at the origin (the **feed end**) and the other end extending
+ * along the chosen orientation vector. The source is placed on segment 1
+ * (the near/feed end), where the characteristic impedance is very high
+ * (~2500–5000 Ω for a resonant half-wave). A 49:1 unun at the feed end
+ * transforms this to a practical 50 Ω match.
+ *
+ * Tag:
+ *   EFHW_TAG (14) — the single radiating wire.
+ *
+ * Excitation is placed on segment 1 of EFHW_TAG (the feed end).
+ */
+export function buildEfhwWires(params: EfhwWiresParams): Wire[] {
+  const length = Math.max(0.1, params.length);
+  const h = params.height;
+  const [dx, dy] = orientationVector(params.orientation);
+  const cleanZero = (v: number): number => (v === 0 ? 0 : v);
+
+  const lambda = wavelengthMeters(params.frequency);
+  const minSegs = Math.ceil((SEGS_PER_WAVELENGTH * length) / lambda);
+  const segments = Math.min(
+    MAX_SEGS_PER_LEG,
+    Math.max(MIN_SEGS_PER_LEG, minSegs, params.segments),
+  );
+
+  // Feed end is at the origin; wire extends along the orientation vector.
+  return [
+    {
+      start: [0, 0, h],
+      end: [cleanZero(length * dx), cleanZero(length * dy), h],
+      radius: params.wireRadius,
+      segments,
+      tag: EFHW_TAG,
+    },
+  ];
 }

--- a/src/store/antennaStore.ts
+++ b/src/store/antennaStore.ts
@@ -46,6 +46,7 @@ import {
   TERMINATED_DELTA_BRIDGE_TAG,
   VERTICAL_WHIP_TAG,
   DEFAULT_WHIP_LENGTH_M,
+  EFHW_TAG,
 } from '../physics/constants';
 
 // Re-export geometry tags for UI and tests.
@@ -63,6 +64,7 @@ export {
   TERMINATED_DELTA_RIGHT_BASE_TAG,
   TERMINATED_DELTA_BRIDGE_TAG,
   VERTICAL_WHIP_TAG,
+  EFHW_TAG,
 };
 import type { UnitSystem } from '../physics/units';
 import {
@@ -71,6 +73,7 @@ import {
   buildDeltaLoopWires,
   buildTerminatedDeltaWires,
   buildVerticalWhipWires,
+  buildEfhwWires,
   orientationVector,
   type OrientationPreset,
   type Orientation,
@@ -374,6 +377,18 @@ export const useAntennaStore = create<AntennaState>()(
           // user can still disable it to see what happens without.
           s.transformerEnabled = true;
           s.transformerRatio = 9;
+        } else if (type === 'efhw') {
+          // End-fed half-wave: single wire, no termination, no V angle.
+          s.vAngle = 180;
+          s.legSlope = 0;
+          s.terminatingResistor = 0;
+          // The EFHW feed impedance is ~2500–5000 Ω. A 49:1 unun (7:1 turns
+          // ratio, impedance ratio = 49) brings it down to ~50–100 Ω.
+          // Default the transformer on so the out-of-the-box result shows
+          // what the operator would actually see at the radio. The user can
+          // disable it to inspect the raw antenna impedance.
+          s.transformerEnabled = true;
+          s.transformerRatio = 49;
         }
 
         const limit = Math.max(0, s.length / 2 - FEED_BRIDGE_LENGTH_M);
@@ -634,6 +649,9 @@ function calculateDefaultLength(type: AntennaType, frequencyMHz: number): number
       // is applied separately in setAntennaType so the user can pick
       // either a stock whip length or the resonant length.
       return lambda * 0.25 * 0.95;
+    case 'efhw':
+      // Half-wave resonant length with the standard HF end-effect factor.
+      return lambda * 0.5 * 0.95;
     default:
       return halfWaveLength(frequencyMHz);
   }
@@ -760,6 +778,17 @@ export function buildWires(
       segments: state.segments,
       frequency: state.frequency,
       counterpoise: state.whipCounterpoise ?? false,
+    });
+  }
+
+  if (antennaType === 'efhw') {
+    return buildEfhwWires({
+      length: state.length,
+      height: h,
+      orientation: state.orientation,
+      wireRadius: state.wireRadius,
+      segments: state.segments,
+      frequency: state.frequency,
     });
   }
 
@@ -925,6 +954,9 @@ function buildExcitation(
   } else if (state.antennaType === 'vertical-whip') {
     // Base-fed monopole: excitation on the first (lowest) segment.
     return { wireTag: VERTICAL_WHIP_TAG, segment: 1 };
+  } else if (state.antennaType === 'efhw') {
+    // End-fed: excitation on the first (feed-end) segment.
+    return { wireTag: EFHW_TAG, segment: 1 };
   } else {
     const dipoleCentreSeg = Math.ceil(state.segments / 2);
     return { wireTag: DIPOLE_TAG, segment: dipoleCentreSeg };

--- a/tests/efhw.test.ts
+++ b/tests/efhw.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Tests for the End-Fed Half-Wave (EFHW) antenna implementation.
+ *
+ * Verifies:
+ *   - geometry builder produces the correct single wire
+ *   - excitation is placed on segment 1 (feed end)
+ *   - default state on type-switch (transformer on, 49:1 ratio)
+ *   - reference length equals ½λ × 0.95
+ *   - feedline is NOT supported (no feedline shield emitted)
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useAntennaStore, EFHW_TAG } from '../src/store/antennaStore';
+import { buildEfhwWires } from '../src/store/antennaGeometry';
+import { referenceLength } from '../src/physics/constants';
+import { selectSimulationInput } from '../src/store/antennaStore';
+
+describe('buildEfhwWires', () => {
+  it('returns a single wire with EFHW_TAG', () => {
+    const wires = buildEfhwWires({
+      length: 10,
+      height: 5,
+      orientation: 'EW',
+      wireRadius: 0.001,
+      segments: 21,
+      frequency: 14.15,
+    });
+    expect(wires).toHaveLength(1);
+    expect(wires[0]!.tag).toBe(EFHW_TAG);
+  });
+
+  it('feed end is at the origin, far end along the orientation vector', () => {
+    const wires = buildEfhwWires({
+      length: 10,
+      height: 5,
+      orientation: 'EW', // EW → dx=1, dy=0
+      wireRadius: 0.001,
+      segments: 21,
+      frequency: 14.15,
+    });
+    const wire = wires[0]!;
+    // Feed end at origin (x=0, y=0, z=height)
+    expect(wire.start[0]).toBeCloseTo(0);
+    expect(wire.start[1]).toBeCloseTo(0);
+    expect(wire.start[2]).toBeCloseTo(5);
+    // Far end displaced along E–W axis
+    expect(Math.abs(wire.end[0])).toBeCloseTo(10);
+    expect(wire.end[1]).toBeCloseTo(0);
+    expect(wire.end[2]).toBeCloseTo(5);
+  });
+
+  it('segments are at least MIN_SEGS_PER_LEG (9) even for a short wire', () => {
+    const wires = buildEfhwWires({
+      length: 0.5,
+      height: 5,
+      orientation: 'NS',
+      wireRadius: 0.001,
+      segments: 1,
+      frequency: 1.9,
+    });
+    expect(wires[0]!.segments).toBeGreaterThanOrEqual(9);
+  });
+
+  it('segment count scales with electrical length', () => {
+    // At 28 MHz the ½λ wire is short → fewer segments than at 3.5 MHz
+    const wiresHf = buildEfhwWires({
+      length: 5,
+      height: 5,
+      orientation: 'EW',
+      wireRadius: 0.001,
+      segments: 21,
+      frequency: 28,
+    });
+    const wiresLf = buildEfhwWires({
+      length: 40,
+      height: 5,
+      orientation: 'EW',
+      wireRadius: 0.001,
+      segments: 21,
+      frequency: 3.5,
+    });
+    expect(wiresLf[0]!.segments).toBeGreaterThanOrEqual(wiresHf[0]!.segments);
+  });
+});
+
+describe('referenceLength for efhw', () => {
+  it('equals ½λ × 0.95 at 14.15 MHz', () => {
+    const lambda = 299.792458 / 14.15;
+    const expected = lambda * 0.5 * 0.95;
+    expect(referenceLength('efhw', 14.15)).toBeCloseTo(expected, 5);
+  });
+
+  it('equals ½λ × 0.95 at 7.1 MHz', () => {
+    const lambda = 299.792458 / 7.1;
+    const expected = lambda * 0.5 * 0.95;
+    expect(referenceLength('efhw', 7.1)).toBeCloseTo(expected, 5);
+  });
+});
+
+describe('antennaStore EFHW type-switch', () => {
+  beforeEach(() => {
+    // Reset the store to a known state before each test
+    useAntennaStore.getState().setAntennaType('dipole');
+    useAntennaStore.getState().setFrequency(14.15);
+    useAntennaStore.getState().setTransformerEnabled(false);
+    useAntennaStore.getState().setTransformerRatio(1);
+  });
+
+  it('setAntennaType("efhw") sets transformerEnabled=true and transformerRatio=49', () => {
+    useAntennaStore.getState().setAntennaType('efhw');
+    const s = useAntennaStore.getState();
+    expect(s.antennaType).toBe('efhw');
+    expect(s.transformerEnabled).toBe(true);
+    expect(s.transformerRatio).toBe(49);
+  });
+
+  it('setAntennaType("efhw") sets terminatingResistor=0', () => {
+    // Start with a terminated antenna to verify it gets reset
+    useAntennaStore.getState().setAntennaType('sloping-v'); // sets R=300
+    useAntennaStore.getState().setAntennaType('efhw');
+    expect(useAntennaStore.getState().terminatingResistor).toBe(0);
+  });
+
+  it('setAntennaType("efhw") sets resonant default length ≈ ½λ × 0.95', () => {
+    useAntennaStore.getState().setAntennaType('efhw');
+    const s = useAntennaStore.getState();
+    const lambda = 299.792458 / s.frequency;
+    const expected = lambda * 0.5 * 0.95;
+    expect(s.length).toBeCloseTo(expected, 3);
+  });
+});
+
+describe('selectSimulationInput for EFHW', () => {
+  beforeEach(() => {
+    useAntennaStore.getState().setAntennaType('efhw');
+    useAntennaStore.getState().setFrequency(14.15);
+    useAntennaStore.getState().setHeight(10);
+  });
+
+  it('produces exactly one wire with EFHW_TAG', () => {
+    const input = selectSimulationInput(useAntennaStore.getState());
+    const efhwWires = input.wires.filter((w) => w.tag === EFHW_TAG);
+    expect(efhwWires).toHaveLength(1);
+  });
+
+  it('excitation is placed on EFHW_TAG segment 1', () => {
+    const input = selectSimulationInput(useAntennaStore.getState());
+    expect(input.excitation.wireTag).toBe(EFHW_TAG);
+    expect(input.excitation.segment).toBe(1);
+  });
+
+  it('does NOT produce a feedline shield wire (feedline not supported)', () => {
+    // Set a feedline to verify it is ignored for EFHW
+    useAntennaStore.getState().setFeedline('rg58');
+    useAntennaStore.getState().setFeedlineLength(10);
+    const input = selectSimulationInput(useAntennaStore.getState());
+    // FEEDLINE_SHIELD_TAG = 4 — should not appear in EFHW wires
+    const shieldWires = input.wires.filter((w) => w.tag === 4);
+    expect(shieldWires).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Implements the **End-Fed Half-Wave (EFHW)** from `docs/future-antenna-designs.md` as a fully modelled NEC-2 antenna type.

## What's new

### Physics model
- Single horizontal wire (`EFHW_TAG = 14`) fed at **segment 1** (the near/feed end)
- Feed impedance ~2500–5000 Ω at resonance — the characteristic high-Z end-fed signature
- Resonant reference length = ½λ × 0.95 (standard HF end-effect factor; current distribution is sinusoidal regardless of feed placement)
- Segment count scales with electrical length (≥ 20 seg/λ, minimum 9)

### Default behaviour on type-switch
| Parameter | Value | Rationale |
|---|---|---|
| `transformerEnabled` | `true` | Shows what the operator actually sees at the radio |
| `transformerRatio` | `49` | 49:1 unun (7:1 turns) → ~50 Ω match from ~2500 Ω feed |
| `terminatingResistor` | `0` | Not applicable |
| Feedline | not supported | EFHW uses end-fed topology, not the center-bridge feedline model |

When the transformer is on (default), `StatsReadout` divides the raw NEC impedance by 49 on the display side — the user sees the matched ~50 Ω rather than the multi-kΩ raw feedpoint.

### UI
- **"End-Fed Half-Wave (EFHW)"** added to the antenna type selector (positioned between Inverted V and Sloping V)
- Length label reads **"Wire length"** instead of the generic "Length"
- Orientation control and Transformer panel are both visible (correct for EFHW)
- Resonate button label: **½λ**

### Docs
- `docs/future-antenna-designs.md` — EFHW entry removed (now implemented)

## Tests
12 new unit tests in `tests/efhw.test.ts`:
- `buildEfhwWires` geometry: tag, feed-end position, segment floor, segment scaling
- `referenceLength('efhw', …)` at 14.15 MHz and 7.1 MHz
- Store type-switch: `transformerEnabled`, `transformerRatio`, `terminatingResistor`, default length
- `selectSimulationInput`: single EFHW wire, excitation on segment 1, no feedline shield

All 540 tests pass (528 existing + 12 new).

https://claude.ai/code/session_01JhUSXwtaufCb3jkLbHEhph

---
_Generated by [Claude Code](https://claude.ai/code/session_01JhUSXwtaufCb3jkLbHEhph)_