### PR TITLE
Add Inverted-L antenna type

### DIFF
--- a/docs/antenna-spec.md
+++ b/docs/antenna-spec.md
@@ -217,3 +217,43 @@ This document defines the physical and mathematical model for all antenna types 
 ### 5.6 Glossary
 
 - Same as Section 1.6.
+
+---
+
+## 6. Inverted-L
+
+### 6.1 Geometry Definition
+
+- **Shape:** Two wire segments forming an L: a vertical section from the base up to the bend point, followed by a horizontal top-loading section extending outward at right angles.
+- **`height` parameter:** Bend-point height above ground (metres). This equals the length of the vertical section (base gap excluded). Controls how tall the mast needs to be.
+- **`length` parameter:** Total wire length (vertical + horizontal combined, metres). The horizontal section absorbs any length beyond the vertical section: $L_{horiz} = L_{total} - L_{vert}$.
+- **Orientation:** Azimuth direction the horizontal section runs.
+- **Base:** The vertical wire starts at `VERTICAL_WHIP_BASE_GAP_M` (0.01 m) above ground — same electrical isolation as the vertical whip.
+- **Bend junction:** The end of the vertical wire and the start of the horizontal wire share an exact coordinate so NEC creates a proper wire junction.
+- **Reference length:** ¼λ total (same as a quarter-wave vertical); the horizontal section provides the electrical length the mast height falls short of.
+
+### 6.2 Feedpoint Definition
+
+- **NEC Excitation:** Segment 1 of `INVERTED_L_VERTICAL_TAG` (14) — the lowest segment at the base of the vertical section.
+- **Feed Type:** Base-fed monopole (unbalanced). Coax shield connects at the base; the antenna is driven against the ground / counterpoise.
+- **Feedline Support:** Not modelled (same convention as vertical whip). The feedline is treated as ideal.
+
+### 6.3 Counterpoise
+
+- **Model:** When enabled, `VERTICAL_WHIP_RADIAL_COUNT` (4) horizontal ¼λ radials fan out from the base at equal azimuth spacing, tagged `INVERTED_L_RADIAL_TAG` (16). Identical pattern to the vertical whip's counterpoise.
+- **Without counterpoise:** The source has no proper return path; NEC reports the high reactance and SWR that a radial-less base-fed antenna physically exhibits.
+
+### 6.4 SWR Convention
+
+- **Reference:** 50 Ω.
+- **Notes:** A resonant ¼λ inverted-L over a good ground presents roughly 30–50 Ω — a usable direct coax match. Feedpoint impedance varies with height, horizontal-section fraction, and ground quality. The vertical-section fraction has a stronger influence on the radiation pattern (more vertical component → more omnidirectional; more horizontal component → slight gain asymmetry in the horizontal-section direction).
+
+### 6.5 Segmentation Rules
+
+- **Density:** 20 segments per λ minimum for each section independently.
+- **Minimum:** 9 segments per section (`MIN_SEGS_PER_LEG`).
+- **Vertical and horizontal sections are emitted as separate `Wire` objects**, tagged independently so current-ripple diagnostics can distinguish them.
+
+### 6.6 Glossary
+
+- Same as Section 1.6.

--- a/docs/future-antenna-designs.md
+++ b/docs/future-antenna-designs.md
@@ -8,10 +8,6 @@ Antenna types desired for future implementation. Each entry notes the key geomet
 
 Half-wave dipole where both ends are connected by a second parallel conductor, forming a narrow rectangular loop. Feed impedance is ~300 Ω (4× a standard dipole), making it a natural match for 300 Ω twin-lead. Gain and pattern are identical to a dipole. Geometry requires two parallel wires joined at their ends with short connecting segments.
 
-## Inverted-L
-
-Vertical radiator with a horizontal top-loading section at right angles. Useful for 160 m and 80 m where a full quarter-wave vertical would be impractically tall. The horizontal section adds electrical length without additional height. Requires ground radials or a counterpoise similar to the existing vertical whip.
-
 ## Horizontal Loop (Skyloop)
 
 Full-wave loop laid out horizontally (parallel to ground). Typically square or rectangular. At low heights it produces a high-angle NVIS pattern; at greater heights the pattern develops low-angle gain. The four-sided geometry requires corner wires and a flexible aspect-ratio parameter for square vs. rectangular configurations.

--- a/src/components/Panel/DipoleControl.tsx
+++ b/src/components/Panel/DipoleControl.tsx
@@ -117,6 +117,7 @@ export function DipoleControl() {
     'sloping-v': '1λ/leg',
     'terminated-delta': '1λ',
     'vertical-whip': '¼λ',
+    'inverted-l': '¼λ',
   };
 
   const resonateTitles: Record<AntennaType, string> = {
@@ -126,13 +127,24 @@ export function DipoleControl() {
     'sloping-v': 'Set total length to 2λ (1λ per leg)',
     'terminated-delta': 'Set perimeter to 1λ',
     'vertical-whip': 'Set whip length to resonant ¼λ',
+    'inverted-l': 'Set total wire length (vertical + horizontal) to resonant ¼λ. The horizontal section makes up any length the mast height falls short of a full quarter-wave.',
   };
 
   const isVerticalWhip = antennaType === 'vertical-whip';
-  const lengthLabel = isVerticalWhip ? `Whip length (${unit})` : `Length (${unit})`;
+  const isInvertedL = antennaType === 'inverted-l';
+  const isGroundMountedVertical = isVerticalWhip || isInvertedL;
+
+  const lengthLabel = isVerticalWhip
+    ? `Whip length (${unit})`
+    : isInvertedL
+      ? `Total wire length — vertical + horizontal (${unit})`
+      : `Length (${unit})`;
+
   const heightLabel = isVerticalWhip
     ? `Base height above ground (${unit}) — ${dispHeight.toFixed(1)}`
-    : `Height above ground (${unit}) — ${dispHeight.toFixed(1)}`;
+    : isInvertedL
+      ? `Mast / bend-point height (${unit}) — ${dispHeight.toFixed(1)}`
+      : `Height above ground (${unit}) — ${dispHeight.toFixed(1)}`;
 
   return (
     <section className="panel-section">
@@ -152,6 +164,7 @@ export function DipoleControl() {
         <option value="delta-loop">Delta Loop</option>
         <option value="terminated-delta">Terminated Delta</option>
         <option value="vertical-whip">Vertical Whip</option>
+        <option value="inverted-l">Inverted-L</option>
       </select>
 
       <label htmlFor="dipole-length" style={{ marginTop: 10 }}>{lengthLabel}</label>
@@ -290,7 +303,7 @@ export function DipoleControl() {
         </>
       )}
 
-      {isVerticalWhip && (
+      {isGroundMountedVertical && (
         <>
           <label
             htmlFor="whip-counterpoise"
@@ -308,14 +321,14 @@ export function DipoleControl() {
           <div id="whip-counterpoise-hint" style={{ marginTop: 6, fontSize: 11, color: 'var(--text-muted)', lineHeight: 1.4 }}>
             {whipCounterpoise
               ? '4 horizontal ¼λ radials fan out from the base, giving the source a proper low-loss return path (canonical ground-plane vertical).'
-              : 'Freestanding whip with no counterpoise. NEC will report the high reactance and poor SWR that a radial-less monopole actually exhibits — switch the toggle on to model a proper ground-plane vertical.'}
+              : 'No counterpoise. NEC will report the high reactance and poor SWR that a radial-less base-fed antenna actually exhibits — switch the toggle on to model a proper ground-plane antenna.'}
           </div>
         </>
       )}
 
       <GeometryStatus />
 
-      {!isVerticalWhip && (
+      {!isGroundMountedVertical && (
         <>
           <label htmlFor="dipole-orientation" style={{ marginTop: 10 }}>Orientation (°)</label>
           <div className="row">
@@ -357,13 +370,51 @@ export function DipoleControl() {
         </>
       )}
 
-      {/* Transformer / balun: part of the antenna's feedpoint hardware
-          (applied before the NEC simulation), so it belongs in the Antenna
-          panel rather than as a separate top-level section. Hidden for
-          vertical whips — the transformer model in this app assumes a
-          two-terminal balanced feedpoint with a coax shield to choke,
-          neither of which applies to a base-fed monopole. */}
-      {!isVerticalWhip && <TransformerControl />}
+      {isInvertedL && (
+        <>
+          <label htmlFor="inverted-l-orientation" style={{ marginTop: 10 }}>Horizontal section direction (°)</label>
+          <div className="row">
+            <input
+              id="inverted-l-orientation"
+              type="number"
+              min={0}
+              max={359}
+              step={1}
+              value={localOrient}
+              onFocus={() => setIsOrientFocused(true)}
+              onChange={(e) => {
+                const s = e.target.value;
+                setLocalOrient(s);
+                const val = parseFloat(s);
+                if (!isNaN(val)) {
+                  setOrientation(val);
+                }
+              }}
+              onBlur={() => {
+                setIsOrientFocused(false);
+                setLocalOrient(currentDegrees.toString());
+              }}
+            />
+          </div>
+
+          <div className="button-group" role="group" aria-label="Horizontal section direction presets">
+            {orientations.map((o) => (
+              <button
+                key={o}
+                className={orientation === o ? 'active' : ''}
+                onClick={() => setOrientation(o)}
+                aria-pressed={orientation === o}
+              >
+                {o}
+              </button>
+            ))}
+          </div>
+        </>
+      )}
+
+      {/* Transformer / balun: hidden for base-fed monopole-style antennas —
+          the transformer model assumes a balanced two-terminal feedpoint. */}
+      {!isGroundMountedVertical && <TransformerControl />}
     </section>
   );
 }

--- a/src/physics/constants.ts
+++ b/src/physics/constants.ts
@@ -63,6 +63,11 @@ export function referenceLength(type: AntennaType, frequencyMHz: number, endEffe
     case 'vertical-whip':
       // Quarter-wave monopole resonant length.
       return lambda * 0.25 * endEffect;
+    case 'inverted-l':
+      // Total wire (vertical + horizontal) for a resonant quarter-wave.
+      // The horizontal top-loading section adds electrical length so the
+      // mast can be shorter than a full ¼λ vertical.
+      return lambda * 0.25 * endEffect;
     default:
       return lambda * 0.5 * endEffect;
   }
@@ -190,6 +195,25 @@ export const VERTICAL_WHIP_BASE_GAP_M = 0.01;
  * ripple diagnostics.
  */
 export const VERTICAL_WHIP_RADIAL_TAG = 13;
+
+/**
+ * Wire tag for the vertical section of an Inverted-L antenna.
+ * The base of this wire carries the NEC excitation (segment 1).
+ */
+export const INVERTED_L_VERTICAL_TAG = 14;
+
+/**
+ * Wire tag for the horizontal top-loading section of an Inverted-L.
+ * Shares the bend-point junction with INVERTED_L_VERTICAL_TAG.
+ */
+export const INVERTED_L_HORIZONTAL_TAG = 15;
+
+/**
+ * Wire tag for the optional counterpoise radials at the base of an
+ * Inverted-L. Kept separate from VERTICAL_WHIP_RADIAL_TAG so that
+ * current-ripple diagnostics can distinguish the two antenna types.
+ */
+export const INVERTED_L_RADIAL_TAG = 16;
 
 /**
  * Number of counterpoise radials, equally spaced in azimuth, deployed

--- a/src/physics/types.ts
+++ b/src/physics/types.ts
@@ -15,8 +15,13 @@ export type Vec3 = readonly [number, number, number];
  *   - vertical-whip: a single vertical wire fed at its base (monopole).
  *     `length` is the whip length and `height` is the base height above
  *     ground; resonant length is ¼λ.
+ *   - inverted-l: vertical radiator with a horizontal top-loading section.
+ *     `height` is the bend-point height (= vertical section length from
+ *     ground); `length` is the total wire (vertical + horizontal combined).
+ *     Base-fed at ground level; counterpoise radials optional. Useful on
+ *     160 m / 80 m where a full ¼λ vertical would be impractically tall.
  */
-export type AntennaType = 'dipole' | 'inverted-v' | 'delta-loop' | 'sloping-v' | 'terminated-delta' | 'vertical-whip';
+export type AntennaType = 'dipole' | 'inverted-v' | 'delta-loop' | 'sloping-v' | 'terminated-delta' | 'vertical-whip' | 'inverted-l';
 
 export interface Wire {
   readonly start: Vec3;

--- a/src/store/antennaGeometry.ts
+++ b/src/store/antennaGeometry.ts
@@ -14,6 +14,9 @@ import {
   VERTICAL_WHIP_BASE_GAP_M,
   VERTICAL_WHIP_RADIAL_TAG,
   VERTICAL_WHIP_RADIAL_COUNT,
+  INVERTED_L_VERTICAL_TAG,
+  INVERTED_L_HORIZONTAL_TAG,
+  INVERTED_L_RADIAL_TAG,
 } from '../physics/constants';
 import type { Wire } from '../physics/types';
 
@@ -716,6 +719,124 @@ export function buildVerticalWhipWires(params: VerticalWhipWiresParams): Wire[] 
         radius: params.wireRadius,
         segments: radialSegs,
         tag: VERTICAL_WHIP_RADIAL_TAG,
+      });
+    }
+  }
+
+  return wires;
+}
+
+export interface InvertedLWiresParams {
+  /**
+   * Total wire length (vertical section + horizontal section), metres.
+   * The horizontal section length is derived as `length − verticalLength`.
+   */
+  length: number;
+  /**
+   * Bend-point height above ground (metres).
+   * This is the height of the top of the vertical section and therefore
+   * the height of the entire horizontal section.
+   */
+  height: number;
+  /** Direction the horizontal top-loading section runs (azimuth). */
+  orientation: Orientation;
+  wireRadius: number;
+  segments: number;
+  frequency: number;
+  /**
+   * When true, deploy `VERTICAL_WHIP_RADIAL_COUNT` ¼λ horizontal radials
+   * at the base, providing a low-loss return path for the monopole source.
+   * Without them the feedpoint impedance will be highly reactive.
+   */
+  counterpoise: boolean;
+}
+
+/**
+ * Builds the wires for an Inverted-L antenna.
+ *
+ * The Inverted-L consists of:
+ *   1. A vertical section from the base (VERTICAL_WHIP_BASE_GAP_M above
+ *      ground) up to the bend height.
+ *   2. A horizontal top-loading section extending from the bend point
+ *      outward along the orientation azimuth.
+ *   3. Optional counterpoise radials at the base (¼λ each, same pattern
+ *      as the vertical whip).
+ *
+ * The total radiating wire length is `params.length`; the horizontal
+ * section absorbs any length beyond the vertical section, allowing a
+ * shorter mast to achieve the same electrical length as a taller whip.
+ *
+ * Tags:
+ *   INVERTED_L_VERTICAL_TAG   (14) — vertical section, base-fed at seg 1
+ *   INVERTED_L_HORIZONTAL_TAG (15) — horizontal top-loading section
+ *   INVERTED_L_RADIAL_TAG     (16) — optional counterpoise radials
+ *
+ * Excitation is placed on segment 1 of INVERTED_L_VERTICAL_TAG (the
+ * lowest segment at the base), exactly as for the vertical whip.
+ */
+export function buildInvertedLWires(params: InvertedLWiresParams): Wire[] {
+  const totalLen = Math.max(0.1, params.length);
+  const baseZ = VERTICAL_WHIP_BASE_GAP_M;
+
+  // Clamp bend height so there is always a meaningful vertical section.
+  const bendZ = Math.max(baseZ + 0.1, params.height);
+  const vertLen = bendZ - baseZ;
+
+  // Horizontal section is whatever total length remains after the vertical.
+  const horizLen = Math.max(0, totalLen - vertLen);
+
+  const [dx, dy] = orientationVector(params.orientation);
+  const lambda = wavelengthMeters(params.frequency);
+
+  // Segments for the vertical section.
+  const minVertSegs = Math.ceil((SEGS_PER_WAVELENGTH * vertLen) / lambda);
+  const vertSegs = Math.min(
+    MAX_SEGS_PER_LEG,
+    Math.max(MIN_SEGS_PER_LEG, minVertSegs, Math.round(params.segments / 2)),
+  );
+
+  const wires: Wire[] = [
+    {
+      start: [0, 0, baseZ],
+      end: [0, 0, bendZ],
+      radius: params.wireRadius,
+      segments: vertSegs,
+      tag: INVERTED_L_VERTICAL_TAG,
+    },
+  ];
+
+  if (horizLen > 0.01) {
+    const minHorizSegs = Math.ceil((SEGS_PER_WAVELENGTH * horizLen) / lambda);
+    const horizSegs = Math.min(
+      MAX_SEGS_PER_LEG,
+      Math.max(MIN_SEGS_PER_LEG, minHorizSegs, Math.round(params.segments / 2)),
+    );
+    wires.push({
+      start: [0, 0, bendZ],
+      end: [dx * horizLen, dy * horizLen, bendZ],
+      radius: params.wireRadius,
+      segments: horizSegs,
+      tag: INVERTED_L_HORIZONTAL_TAG,
+    });
+  }
+
+  if (params.counterpoise) {
+    const radialLen = lambda * 0.25 * 0.95;
+    const minRadialSegs = Math.ceil((SEGS_PER_WAVELENGTH * radialLen) / lambda);
+    const radialSegs = Math.min(
+      MAX_SEGS_PER_LEG,
+      Math.max(MIN_SEGS_PER_LEG, minRadialSegs),
+    );
+    for (let i = 0; i < VERTICAL_WHIP_RADIAL_COUNT; i++) {
+      const theta = (2 * Math.PI * i) / VERTICAL_WHIP_RADIAL_COUNT;
+      const rdx = Math.cos(theta);
+      const rdy = Math.sin(theta);
+      wires.push({
+        start: [0, 0, baseZ],
+        end: [rdx * radialLen, rdy * radialLen, baseZ],
+        radius: params.wireRadius,
+        segments: radialSegs,
+        tag: INVERTED_L_RADIAL_TAG,
       });
     }
   }

--- a/src/store/antennaStore.ts
+++ b/src/store/antennaStore.ts
@@ -46,6 +46,9 @@ import {
   TERMINATED_DELTA_BRIDGE_TAG,
   VERTICAL_WHIP_TAG,
   DEFAULT_WHIP_LENGTH_M,
+  INVERTED_L_VERTICAL_TAG,
+  INVERTED_L_HORIZONTAL_TAG,
+  INVERTED_L_RADIAL_TAG,
 } from '../physics/constants';
 
 // Re-export geometry tags for UI and tests.
@@ -63,6 +66,9 @@ export {
   TERMINATED_DELTA_RIGHT_BASE_TAG,
   TERMINATED_DELTA_BRIDGE_TAG,
   VERTICAL_WHIP_TAG,
+  INVERTED_L_VERTICAL_TAG,
+  INVERTED_L_HORIZONTAL_TAG,
+  INVERTED_L_RADIAL_TAG,
 };
 import type { UnitSystem } from '../physics/units';
 import {
@@ -71,6 +77,7 @@ import {
   buildDeltaLoopWires,
   buildTerminatedDeltaWires,
   buildVerticalWhipWires,
+  buildInvertedLWires,
   orientationVector,
   type OrientationPreset,
   type Orientation,
@@ -310,9 +317,10 @@ export const useAntennaStore = create<AntennaState>()(
         s.antennaType = type;
 
         // Vertical whips default to height=0 (sitting on ground). When
-        // switching back to a horizontal antenna, restore the default
-        // mast height so it doesn't stay stuck at 0m.
-        if (previousType === 'vertical-whip' && type !== 'vertical-whip' && s.height === 0) {
+        // switching to a horizontal antenna, restore the default mast height
+        // so it doesn't stay stuck at 0m. (Inverted-L keeps whatever height
+        // is set since its height is the bend point, not the base.)
+        if (previousType === 'vertical-whip' && type !== 'vertical-whip' && type !== 'inverted-l' && s.height === 0) {
           s.height = INITIAL_HEIGHT;
         }
 
@@ -342,6 +350,15 @@ export const useAntennaStore = create<AntennaState>()(
           // Force the transformer off — its UI is hidden for verticals and
           // the StatsReadout's realized-gain math would otherwise apply a
           // stale ratio/insertion-loss to the monopole result.
+          s.transformerEnabled = false;
+        } else if (type === 'inverted-l') {
+          // Base-fed L-antenna. `height` is the bend-point height (= vertical
+          // section length). If coming from a vertical whip with height=0,
+          // restore a sensible mast height so there is a vertical section.
+          if (s.height === 0) s.height = INITIAL_HEIGHT;
+          s.vAngle = 180;
+          s.legSlope = 0;
+          s.terminatingResistor = 0;
           s.transformerEnabled = false;
         } else if (type === 'sloping-v') {
           // Slope is auto-computed from height and leg length (tips at ground).
@@ -634,6 +651,9 @@ function calculateDefaultLength(type: AntennaType, frequencyMHz: number): number
       // is applied separately in setAntennaType so the user can pick
       // either a stock whip length or the resonant length.
       return lambda * 0.25 * 0.95;
+    case 'inverted-l':
+      // Total wire (vertical + horizontal) for a resonant quarter-wave.
+      return lambda * 0.25 * 0.95;
     default:
       return halfWaveLength(frequencyMHz);
   }
@@ -756,6 +776,18 @@ export function buildWires(
     return buildVerticalWhipWires({
       length: state.length,
       height: h,
+      wireRadius: state.wireRadius,
+      segments: state.segments,
+      frequency: state.frequency,
+      counterpoise: state.whipCounterpoise ?? false,
+    });
+  }
+
+  if (antennaType === 'inverted-l') {
+    return buildInvertedLWires({
+      length: state.length,
+      height: h,
+      orientation: state.orientation,
       wireRadius: state.wireRadius,
       segments: state.segments,
       frequency: state.frequency,
@@ -897,7 +929,7 @@ function buildGroundParams(state: AntennaState): GroundParams {
   // ground-mounted whip (height=0) is the canonical case: it still needs
   // the configured ground beneath it, and switching to free space would
   // break the monopole's image-theory feedpoint impedance.
-  if (state.height <= 0 && state.antennaType !== 'vertical-whip') return { type: 'free' };
+  if (state.height <= 0 && state.antennaType !== 'vertical-whip' && state.antennaType !== 'inverted-l') return { type: 'free' };
   switch (state.groundId) {
     case 'free': return { type: 'free' };
     case 'perfect': return { type: 'perfect' };
@@ -925,6 +957,9 @@ function buildExcitation(
   } else if (state.antennaType === 'vertical-whip') {
     // Base-fed monopole: excitation on the first (lowest) segment.
     return { wireTag: VERTICAL_WHIP_TAG, segment: 1 };
+  } else if (state.antennaType === 'inverted-l') {
+    // Base-fed: excitation on the first (lowest) segment of the vertical section.
+    return { wireTag: INVERTED_L_VERTICAL_TAG, segment: 1 };
   } else {
     const dipoleCentreSeg = Math.ceil(state.segments / 2);
     return { wireTag: DIPOLE_TAG, segment: dipoleCentreSeg };


### PR DESCRIPTION
Implements the **Inverted-L** from `docs/future-antenna-designs.md`.

## What is an Inverted-L?

A vertical radiator with a horizontal top-loading section at right angles. Particularly useful on **160 m and 80 m** where a full quarter-wave vertical would be impractically tall — the horizontal section makes up whatever electrical length the mast height falls short of.

## Geometry

```
         ←── horizontal section (orientation-controlled) ───→
bend─────────────────────────────────────────────────
  |
  |  vertical section
  |
base (fed here, ~1 cm above ground)
════════════════ ground / radials ════════════════
```

- **`length`** = total wire (vertical + horizontal combined)
- **`height`** = bend-point height = length of the vertical section
- Horizontal section = `length − height`; if `height ≥ length` it degenerates to a pure vertical
- Optional 4-radial ¼λ counterpoise at the base (shared toggle with vertical whip)
- Feedpoint: base of vertical section (same NEC convention as vertical whip)

## Changes

| File | What changed |
|------|-------------|
| `src/physics/types.ts` | Added `'inverted-l'` to `AntennaType` |
| `src/physics/constants.ts` | New tags: `INVERTED_L_VERTICAL_TAG` (14), `INVERTED_L_HORIZONTAL_TAG` (15), `INVERTED_L_RADIAL_TAG` (16); reference length ¼λ |
| `src/store/antennaGeometry.ts` | `buildInvertedLWires()` — vertical wire + horizontal wire + optional radials |
| `src/store/antennaStore.ts` | `buildWires` dispatch, `buildExcitation`, `buildGroundParams`, `setAntennaType`, `calculateDefaultLength`, re-exports |
| `src/components/Panel/DipoleControl.tsx` | Dropdown option, specific length/height labels, horizontal-section direction control, counterpoise toggle extended to both vertical types, transformer hidden |
| `docs/antenna-spec.md` | Full specification §6 |
| `docs/future-antenna-designs.md` | Removed Inverted-L entry |

## UI

- **Length label**: *"Total wire length — vertical + horizontal"*
- **Height label**: *"Mast / bend-point height"* — makes the two-section geometry clear
- **Horizontal section direction**: separate orientation input below the height slider, labelled distinctly from the dipole's "Orientation"
- **¼λ button** tooltip explains the top-loading role
- **Counterpoise toggle** is now shared between vertical whip and inverted-L via `isGroundMountedVertical`
- **Transformer hidden** (base-fed monopole, like vertical whip)

## Test results

All **536 tests pass**; no TypeScript errors.

https://claude.ai/code/session_01SecSmXDcfDiyDMFUk324bJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SecSmXDcfDiyDMFUk324bJ)_