### PR TITLE
Add Folded Dipole antenna type

### DIFF
--- a/docs/antenna-spec.md
+++ b/docs/antenna-spec.md
@@ -265,11 +265,9 @@ This document defines the physical and mathematical model for all antenna types 
 ### 7.1 Geometry Definition
 
 - **Shape:** Full-wave square loop in the vertical plane, fed at the centre of the bottom side.
-- **`height` parameter:** Height of the **top** of the loop above ground (metres) — same convention as the delta loop apex height.
+- **`height` parameter:** Height of the **feedpoint** (centre of the bottom side) above ground (metres). The loop always forms a true square (each side = P/4) extending upward from the feedpoint; the top of the loop sits at `height + P/4`. This is the same feedpoint-height convention used by every other antenna type.
 - **`length` parameter:** Total perimeter (metres). Reference length: 1λ.
-- **Square vs rectangle:** When the mast height ≥ P/4 + `SLOPING_V_MIN_TIP_Z_M` the loop is a true square (each side = P/4). When the mast is shorter, the loop flattens to a rectangle while preserving the full perimeter:
-  - `loop_height = min(P/4, height − SLOPING_V_MIN_TIP_Z_M)`
-  - `loop_width  = P/2 − loop_height`  (always ≥ loop_height)
+- **Shape:** Always a true square — each side = P/4. No rectangle-flattening.
 - **Orientation:** Azimuth the loop plane faces.
 - **Bottom wire:** Split at its centre by a `FEED_BRIDGE_LENGTH_M` feed bridge. The two half-wires (left and right) meet at the bridge.
 
@@ -297,8 +295,8 @@ This document defines the physical and mathematical model for all antenna types 
 
 ### 7.6 Gain
 
-- **Over dipole:** Approximately 1.5 dBd (~3.65 dBi) at 1λ perimeter over free space. Slightly less than the delta loop's gain on paper but with a more practical feedpoint impedance at the bottom of the loop.
-- **Pattern:** Broadside (perpendicular to the loop plane), vertically polarised, with low-angle radiation at typical heights.
+- **Pattern:** Broadside (perpendicular to the loop plane), vertically polarised. Gain over a dipole at the same feedpoint height depends heavily on height above ground; the theoretical free-space advantage of a full-wave loop over a dipole is small and varies with ground proximity.
+- **Note:** Do not compare gain numbers from a quad loop and a dipole unless both feedpoints are at the same height — the loop's top wire sits a full P/4 higher than the feedpoint, which can produce misleadingly high or low apparent gain depending on which height convention is assumed.
 
 ### 7.7 Glossary
 

--- a/docs/antenna-spec.md
+++ b/docs/antenna-spec.md
@@ -264,19 +264,19 @@ This document defines the physical and mathematical model for all antenna types 
 
 ### 7.1 Geometry Definition
 
-- **Shape:** Two parallel half-wave conductors joined at both ends, forming a narrow horizontal loop. The whole structure lies flat at a single height — every wire is at `z = height`, so it is fully buildable at a modest, user-controlled height (no part is forced higher).
+- **Shape:** Two parallel half-wave conductors joined at both ends, forming a narrow rectangular loop in the vertical plane. The bottom (fed) conductor sits at `z = height`; the top (un-fed) conductor sits at `z = height + aperture`. The connectors are short vertical wires at each end. The overall structure is fully buildable at a modest height — the top conductor only rises `aperture` (≤ 0.5 m) above the feedpoint, unlike a vertical loop.
 - **`length` parameter:** Each conductor's length (metres). Reference length: ½λ (0.475λ with end-effect) — same as a standard dipole; the fold does not change the resonant length.
-- **`foldedDipoleAperture` parameter:** Spacing between the two parallel conductors (metres). Default 0.3 m. Clamped to [0.02 m, `FOLDED_DIPOLE_MAX_APERTURE_M` = 0.5 m]. The upper cap keeps the antenna a genuine folded dipole and, crucially, within the spacing range where NEC's close-parallel-wire solution converges inside `MAX_SEGS_PER_LEG` (see §7.5).
-- **Orientation:** Azimuth the conductor axis runs. The aperture is taken in the horizontal direction perpendicular to the axis, so both conductors stay at the same height.
+- **`foldedDipoleAperture` parameter:** Vertical spacing between the two parallel conductors (metres). Default 0.3 m. Clamped to [0.02 m, `FOLDED_DIPOLE_MAX_APERTURE_M` = 0.5 m]. The upper cap keeps the antenna a genuine folded dipole and, crucially, within the spacing range where NEC's close-parallel-wire solution converges inside `MAX_SEGS_PER_LEG` (see §7.5).
+- **Orientation:** Azimuth the conductor axis runs. The aperture is in the vertical (Z) direction; changing the orientation rotates the axis in the horizontal plane but the top/bottom wire layout is preserved.
 - **Fed conductor:** Split at its centre by a `FEED_BRIDGE_LENGTH_M` feed bridge (the two halves carry `DIPOLE_LEFT_TAG` / `DIPOLE_RIGHT_TAG`, the same split-fed convention as the standard dipole).
-- **Min Height:** All wires at `z = height`; `height ≥ 0.1` m to avoid NEC `GE 1` instability.
+- **Min Height:** Bottom conductor at `z = height`; `height ≥ 0.1` m to avoid NEC `GE 1` instability. The top conductor is automatically at `z = height + aperture`.
 
 ### 7.2 Feedpoint Definition
 
 - **NEC Excitation:** Segment 1 of `FEED_BRIDGE_TAG` (3) at the centre of the lower conductor — handled by the existing `hasBridge` excitation path.
 - **Feed Type:** Single-segment voltage source on the bridge; balanced.
 - **Feedline Support:** Not currently modelled (the antenna is balanced and typically fed via 300 Ω twin-lead or a 4:1 balun). The transformer/balun post-processing control is available.
-- **Feedpoint Impedance:** Approximately 4× a plain dipole (~300 Ω) for equal-diameter conductors, largely independent of spacing. A 4:1 balun brings this to ~75 Ω; 300 Ω twin-lead matches it directly.
+- **Feedpoint Impedance:** Approximately 4× a plain dipole (~300 Ω) for equal-diameter conductors, largely independent of spacing. A 4:1 balun brings this to ~75 Ω; a 6:1 brings it to ~50 Ω for direct coax use. 300 Ω twin-lead matches it directly.
 
 ### 7.3 Termination Definition
 
@@ -287,7 +287,7 @@ This document defines the physical and mathematical model for all antenna types 
 ### 7.4 SWR Convention
 
 - **Reference:** 50 Ω.
-- **Statement:** Raw SWR against 50 Ω is high (~6:1) for the unterminated ~300 Ω feedpoint; a 4:1 balun or 300 Ω feed line is assumed in practice. The terminated variant shows a much flatter SWR-vs-frequency curve, reflecting the broadband impedance rather than improved efficiency.
+- **Statement:** Raw SWR against 50 Ω is high (~6:1) for the unterminated ~300 Ω feedpoint. A 6:1 impedance-transforming balun is **enabled by default** when this antenna type is selected, transforming the feedpoint to ~50 Ω and showing the characteristic flat broadband SWR curve. The terminated variant (TFD) shows an even flatter curve, reflecting the resistive termination rather than improved efficiency.
 
 ### 7.5 Segmentation Rules
 

--- a/docs/antenna-spec.md
+++ b/docs/antenna-spec.md
@@ -257,3 +257,49 @@ This document defines the physical and mathematical model for all antenna types 
 ### 6.6 Glossary
 
 - Same as Section 1.6.
+
+---
+
+## 7. Quad Loop
+
+### 7.1 Geometry Definition
+
+- **Shape:** Full-wave square loop in the vertical plane, fed at the centre of the bottom side.
+- **`height` parameter:** Height of the **top** of the loop above ground (metres) — same convention as the delta loop apex height.
+- **`length` parameter:** Total perimeter (metres). Reference length: 1λ.
+- **Square vs rectangle:** When the mast height ≥ P/4 + `SLOPING_V_MIN_TIP_Z_M` the loop is a true square (each side = P/4). When the mast is shorter, the loop flattens to a rectangle while preserving the full perimeter:
+  - `loop_height = min(P/4, height − SLOPING_V_MIN_TIP_Z_M)`
+  - `loop_width  = P/2 − loop_height`  (always ≥ loop_height)
+- **Orientation:** Azimuth the loop plane faces.
+- **Bottom wire:** Split at its centre by a `FEED_BRIDGE_LENGTH_M` feed bridge. The two half-wires (left and right) meet at the bridge.
+
+### 7.2 Feedpoint Definition
+
+- **NEC Excitation:** Segment 1 of `FEED_BRIDGE_TAG` (3) at the centre of the bottom side — same bridge convention as the split-dipole and delta loop with feedline.
+- **Feed Type:** Single-segment voltage source on the bridge; inherently balanced (the bridge is equidistant from both sides of the loop).
+- **Feedline Support:** Not currently modelled (feedpoint is at the bottom of the loop, not the top; adding a hanging shield wire would require a separate feedpoint-height computation).
+- **Feedpoint Impedance:** Approximately 100–140 Ω for a resonant 1λ side-fed square quad over real ground. A 2:1 balun or a short matching stub brings this to 50 Ω. Impedance varies with height above ground.
+
+### 7.3 Termination Definition
+
+- **Model:** None. The quad loop is a standing-wave resonant antenna.
+
+### 7.4 SWR Convention
+
+- **Reference:** 50 Ω.
+- **Statement:** Raw SWR will be approximately 2–3:1 at the 1λ resonant perimeter (due to the ~100–140 Ω feedpoint), improving toward 1:1 with a 2:1 impedance transformer or matching network.
+
+### 7.5 Segmentation Rules
+
+- **Density:** 20 segments per λ minimum per side.
+- **Minimum:** 9 segments per side (`MIN_SEGS_PER_LEG`).
+- **Wires:** 6 wires total — top, left, right, bottom-left half, bottom-right half, and the 1-segment feed bridge.
+
+### 7.6 Gain
+
+- **Over dipole:** Approximately 1.5 dBd (~3.65 dBi) at 1λ perimeter over free space. Slightly less than the delta loop's gain on paper but with a more practical feedpoint impedance at the bottom of the loop.
+- **Pattern:** Broadside (perpendicular to the loop plane), vertically polarised, with low-angle radiation at typical heights.
+
+### 7.7 Glossary
+
+- Same as Section 1.6.

--- a/docs/antenna-spec.md
+++ b/docs/antenna-spec.md
@@ -260,43 +260,47 @@ This document defines the physical and mathematical model for all antenna types 
 
 ---
 
-## 7. Quad Loop
+## 7. Folded Dipole
 
 ### 7.1 Geometry Definition
 
-- **Shape:** Full-wave square loop in the vertical plane, fed at the centre of the bottom side.
-- **`height` parameter:** Height of the **feedpoint** (centre of the bottom side) above ground (metres). The loop always forms a true square (each side = P/4) extending upward from the feedpoint; the top of the loop sits at `height + P/4`. This is the same feedpoint-height convention used by every other antenna type.
-- **`length` parameter:** Total perimeter (metres). Reference length: 1λ.
-- **Shape:** Always a true square — each side = P/4. No rectangle-flattening.
-- **Orientation:** Azimuth the loop plane faces.
-- **Bottom wire:** Split at its centre by a `FEED_BRIDGE_LENGTH_M` feed bridge. The two half-wires (left and right) meet at the bridge.
+- **Shape:** Two parallel half-wave conductors joined at both ends, forming a narrow horizontal loop. The whole structure lies flat at a single height — every wire is at `z = height`, so it is fully buildable at a modest, user-controlled height (no part is forced higher).
+- **`length` parameter:** Each conductor's length (metres). Reference length: ½λ (0.475λ with end-effect) — same as a standard dipole; the fold does not change the resonant length.
+- **`foldedDipoleAperture` parameter:** Spacing between the two parallel conductors (metres). Default 0.3 m. Clamped to [0.02 m, `FOLDED_DIPOLE_MAX_APERTURE_M` = 0.5 m]. The upper cap keeps the antenna a genuine folded dipole and, crucially, within the spacing range where NEC's close-parallel-wire solution converges inside `MAX_SEGS_PER_LEG` (see §7.5).
+- **Orientation:** Azimuth the conductor axis runs. The aperture is taken in the horizontal direction perpendicular to the axis, so both conductors stay at the same height.
+- **Fed conductor:** Split at its centre by a `FEED_BRIDGE_LENGTH_M` feed bridge (the two halves carry `DIPOLE_LEFT_TAG` / `DIPOLE_RIGHT_TAG`, the same split-fed convention as the standard dipole).
+- **Min Height:** All wires at `z = height`; `height ≥ 0.1` m to avoid NEC `GE 1` instability.
 
 ### 7.2 Feedpoint Definition
 
-- **NEC Excitation:** Segment 1 of `FEED_BRIDGE_TAG` (3) at the centre of the bottom side — same bridge convention as the split-dipole and delta loop with feedline.
-- **Feed Type:** Single-segment voltage source on the bridge; inherently balanced (the bridge is equidistant from both sides of the loop).
-- **Feedline Support:** Not currently modelled (feedpoint is at the bottom of the loop, not the top; adding a hanging shield wire would require a separate feedpoint-height computation).
-- **Feedpoint Impedance:** Approximately 100–140 Ω for a resonant 1λ side-fed square quad over real ground. A 2:1 balun or a short matching stub brings this to 50 Ω. Impedance varies with height above ground.
+- **NEC Excitation:** Segment 1 of `FEED_BRIDGE_TAG` (3) at the centre of the lower conductor — handled by the existing `hasBridge` excitation path.
+- **Feed Type:** Single-segment voltage source on the bridge; balanced.
+- **Feedline Support:** Not currently modelled (the antenna is balanced and typically fed via 300 Ω twin-lead or a 4:1 balun). The transformer/balun post-processing control is available.
+- **Feedpoint Impedance:** Approximately 4× a plain dipole (~300 Ω) for equal-diameter conductors, largely independent of spacing. A 4:1 balun brings this to ~75 Ω; 300 Ω twin-lead matches it directly.
 
 ### 7.3 Termination Definition
 
-- **Model:** None. The quad loop is a standing-wave resonant antenna.
+- **Topology:** Optional. A single `LD 4` resistor at the **centre segment** of the conductor opposite the feed (`FOLDED_DIPOLE_OPPOSITE_TAG`). The opposite conductor is emitted with an **odd** segment count so its centre segment is exactly at the midpoint — no extra wire is needed.
+- **Unterminated (`terminatingResistor = 0`):** A classic folded dipole — ~300 Ω, narrowband, dipole gain and pattern.
+- **Terminated (`terminatingResistor > 0`):** A terminated folded dipole (TFD). The resistor flattens SWR across a wide frequency range at the cost of efficiency (roughly half the power is dissipated). Typical value ~390–600 Ω. This is the straight-conductor cousin of the T2FD modelled under §5 as a terminated delta.
 
 ### 7.4 SWR Convention
 
 - **Reference:** 50 Ω.
-- **Statement:** Raw SWR will be approximately 2–3:1 at the 1λ resonant perimeter (due to the ~100–140 Ω feedpoint), improving toward 1:1 with a 2:1 impedance transformer or matching network.
+- **Statement:** Raw SWR against 50 Ω is high (~6:1) for the unterminated ~300 Ω feedpoint; a 4:1 balun or 300 Ω feed line is assumed in practice. The terminated variant shows a much flatter SWR-vs-frequency curve, reflecting the broadband impedance rather than improved efficiency.
 
 ### 7.5 Segmentation Rules
 
-- **Density:** 20 segments per λ minimum per side.
-- **Minimum:** 9 segments per side (`MIN_SEGS_PER_LEG`).
-- **Wires:** 6 wires total — top, left, right, bottom-left half, bottom-right half, and the 1-segment feed bridge.
+- **Target segment length:** `min(λ / 20, aperture / 2)`. NEC's thin-wire kernel loses accuracy for closely-spaced parallel wires once the segment length grows much larger than the wire separation; tying the segment length to half the aperture is the empirical point at which the free-space gain converges to the dipole value. All segment counts derive from this single target length, capped at `MAX_SEGS_PER_LEG` (100). This is also why the aperture is capped at 0.5 m — wider spacings would need more than 100 segments to converge.
+- **Minimum:** 9 segments (`MIN_SEGS_PER_LEG`) per fed half-conductor and for the opposite conductor.
+- **Alignment:** The opposite conductor uses an **odd** number of segments to give a precise centre for the termination resistor. The fed conductor is split into two halves around the 1-segment feed bridge.
+- **Wires:** 6 wires total — fed-conductor left half, feed bridge, fed-conductor right half, opposite conductor, and the two end connectors across the aperture (shared `FOLDED_DIPOLE_CONNECTOR_TAG`).
 
 ### 7.6 Gain
 
-- **Pattern:** Broadside (perpendicular to the loop plane), vertically polarised. Gain over a dipole at the same feedpoint height depends heavily on height above ground; the theoretical free-space advantage of a full-wave loop over a dipole is small and varies with ground proximity.
-- **Note:** Do not compare gain numbers from a quad loop and a dipole unless both feedpoints are at the same height — the loop's top wire sits a full P/4 higher than the feedpoint, which can produce misleadingly high or low apparent gain depending on which height convention is assumed.
+- **Unterminated:** Identical to a standard dipole (~2.15 dBi in free space) at narrow apertures. The fold is an impedance transformation, not a gain mechanism.
+- **Wide aperture:** As the spacing grows toward a notable fraction of a wavelength, the two in-phase conductors begin to act as a broadside two-element array and the pattern departs from a simple dipole.
+- **Terminated:** Lower than a plain dipole — the terminating resistor dissipates a substantial fraction of the input power (the broadband-vs-efficiency trade).
 
 ### 7.7 Glossary
 

--- a/docs/future-antenna-designs.md
+++ b/docs/future-antenna-designs.md
@@ -4,10 +4,6 @@ Antenna types desired for future implementation. Each entry notes the key geomet
 
 ---
 
-## Folded Dipole
-
-Half-wave dipole where both ends are connected by a second parallel conductor, forming a narrow rectangular loop. Feed impedance is ~300 Ω (4× a standard dipole), making it a natural match for 300 Ω twin-lead. Gain and pattern are identical to a dipole. Geometry requires two parallel wires joined at their ends with short connecting segments.
-
 ## Horizontal Loop (Skyloop)
 
 Full-wave loop laid out horizontally (parallel to ground). Typically square or rectangular. At low heights it produces a high-angle NVIS pattern; at greater heights the pattern develops low-angle gain. The four-sided geometry requires corner wires and a flexible aspect-ratio parameter for square vs. rectangular configurations.

--- a/docs/future-antenna-designs.md
+++ b/docs/future-antenna-designs.md
@@ -12,10 +12,6 @@ Half-wave dipole where both ends are connected by a second parallel conductor, f
 
 Full-wave loop laid out horizontally (parallel to ground). Typically square or rectangular. At low heights it produces a high-angle NVIS pattern; at greater heights the pattern develops low-angle gain. The four-sided geometry requires corner wires and a flexible aspect-ratio parameter for square vs. rectangular configurations.
 
-## Quad Loop
-
-Square loop with roughly 1λ perimeter, fed at the centre of one side or at a corner. Produces slightly more gain than a dipole (~1.5 dBd) and a lower feed impedance when corner-fed (~50–100 Ω). Geometry is a four-sided variant of the existing delta loop builder using a square rather than triangular shape.
-
 ## Lazy-H / Collinear Stack
 
 Two half-wave dipoles stacked vertically and fed in phase via a half-wave phasing stub. Adds approximately 3 dB of broadside gain over a single dipole by narrowing the elevation pattern. Requires a stacking height parameter and a phasing line modelled as a transmission line (TL card) between the two driven elements.

--- a/src/components/Panel/DipoleControl.tsx
+++ b/src/components/Panel/DipoleControl.tsx
@@ -134,7 +134,7 @@ export function DipoleControl() {
     'terminated-delta': 'Set perimeter to 1λ',
     'vertical-whip': 'Set whip length to resonant ¼λ',
     'inverted-l': 'Set total wire length (vertical + horizontal) to resonant ¼λ. The horizontal section makes up any length the mast height falls short of a full quarter-wave.',
-    'folded-dipole': 'Set each conductor to a resonant ½λ. Feedpoint is ~4× a plain dipole (~300 Ω) — a natural match for 300 Ω twin-lead or a 4:1 balun to 75 Ω. Same gain and pattern as a dipole when unterminated.',
+    'folded-dipole': 'Set each conductor to a resonant ½λ. Raw feedpoint ~300 Ω (~4× a plain dipole). A 6:1 impedance-transforming balun is enabled by default, which transforms this to ~50 Ω and reveals the characteristic flat broadband SWR curve the folded dipole is known for. Same gain and pattern as a plain dipole when unterminated.',
   };
 
   const isVerticalWhip = antennaType === 'vertical-whip';
@@ -155,7 +155,9 @@ export function DipoleControl() {
     ? `Base height above ground (${unit}) — ${dispHeight.toFixed(1)}`
     : isInvertedL
       ? `Mast / bend-point height (${unit}) — ${dispHeight.toFixed(1)}`
-      : `Height above ground (${unit}) — ${dispHeight.toFixed(1)}`;
+      : isFoldedDipole
+        ? `Bottom conductor height / feedpoint (${unit}) — ${dispHeight.toFixed(1)}`
+        : `Height above ground (${unit}) — ${dispHeight.toFixed(1)}`;
 
   const dispAperture = toDisplayLength(foldedDipoleAperture, units);
   const minApertureDisp = toDisplayLength(0.02, units);
@@ -294,7 +296,7 @@ export function DipoleControl() {
             }}
           />
           <div id="folded-dipole-aperture-hint" style={{ marginTop: 6, fontSize: 11, color: 'var(--text-muted)', lineHeight: 1.4 }}>
-            Spacing between the two parallel conductors. For equal-diameter wires the feedpoint stays ~4× a plain dipole (~300 Ω) regardless of spacing; wider spacing mainly broadens the impedance bandwidth. Capped at {maxApertureDisp.toFixed(2)} {unit} — beyond a realistic folded-dipole spacing the structure morphs toward a loop and no longer solves reliably as two close parallel wires.
+            Vertical spacing between the bottom (fed) and top (un-fed) conductors. The fed conductor is at the antenna height; the top conductor is aperture above it. For equal-diameter wires the feedpoint stays ~4× a plain dipole (~300 Ω) regardless of spacing; wider spacing mainly broadens the impedance bandwidth. Capped at {maxApertureDisp.toFixed(2)} {unit} — beyond a realistic folded-dipole spacing the structure morphs toward a loop and no longer solves reliably as two close parallel wires.
           </div>
         </>
       )}

--- a/src/components/Panel/DipoleControl.tsx
+++ b/src/components/Panel/DipoleControl.tsx
@@ -129,7 +129,7 @@ export function DipoleControl() {
     'terminated-delta': 'Set perimeter to 1λ',
     'vertical-whip': 'Set whip length to resonant ¼λ',
     'inverted-l': 'Set total wire length (vertical + horizontal) to resonant ¼λ. The horizontal section makes up any length the mast height falls short of a full quarter-wave.',
-    'quad-loop': 'Set perimeter to 1λ (resonant quad loop). Side-fed impedance ~100–140 Ω; a 2:1 balun or ATU brings it to 50 Ω. ~1.5 dBd gain over a dipole. Slightly more gain than the delta loop with a lower feedpoint.',
+    'quad-loop': 'Set perimeter to 1λ (resonant quad loop). Side-fed impedance ~100–140 Ω; a 2:1 balun or ATU brings it to 50 Ω.',
   };
 
   const isVerticalWhip = antennaType === 'vertical-whip';
@@ -142,11 +142,15 @@ export function DipoleControl() {
       ? `Total wire length — vertical + horizontal (${unit})`
       : `Length (${unit})`;
 
+  const isQuadLoop = antennaType === 'quad-loop';
+
   const heightLabel = isVerticalWhip
     ? `Base height above ground (${unit}) — ${dispHeight.toFixed(1)}`
     : isInvertedL
       ? `Mast / bend-point height (${unit}) — ${dispHeight.toFixed(1)}`
-      : `Height above ground (${unit}) — ${dispHeight.toFixed(1)}`;
+      : isQuadLoop
+        ? `Feedpoint height — bottom of loop (${unit}) — ${dispHeight.toFixed(1)}`
+        : `Height above ground (${unit}) — ${dispHeight.toFixed(1)}`;
 
   return (
     <section className="panel-section">

--- a/src/components/Panel/DipoleControl.tsx
+++ b/src/components/Panel/DipoleControl.tsx
@@ -118,6 +118,7 @@ export function DipoleControl() {
     'terminated-delta': '1λ',
     'vertical-whip': '¼λ',
     'inverted-l': '¼λ',
+    'quad-loop': '1λ',
   };
 
   const resonateTitles: Record<AntennaType, string> = {
@@ -128,6 +129,7 @@ export function DipoleControl() {
     'terminated-delta': 'Set perimeter to 1λ',
     'vertical-whip': 'Set whip length to resonant ¼λ',
     'inverted-l': 'Set total wire length (vertical + horizontal) to resonant ¼λ. The horizontal section makes up any length the mast height falls short of a full quarter-wave.',
+    'quad-loop': 'Set perimeter to 1λ (resonant quad loop). Side-fed impedance ~100–140 Ω; a 2:1 balun or ATU brings it to 50 Ω. ~1.5 dBd gain over a dipole. Slightly more gain than the delta loop with a lower feedpoint.',
   };
 
   const isVerticalWhip = antennaType === 'vertical-whip';
@@ -165,6 +167,7 @@ export function DipoleControl() {
         <option value="terminated-delta">Terminated Delta</option>
         <option value="vertical-whip">Vertical Whip</option>
         <option value="inverted-l">Inverted-L</option>
+        <option value="quad-loop">Quad Loop</option>
       </select>
 
       <label htmlFor="dipole-length" style={{ marginTop: 10 }}>{lengthLabel}</label>

--- a/src/components/Panel/DipoleControl.tsx
+++ b/src/components/Panel/DipoleControl.tsx
@@ -11,6 +11,7 @@ import {
   type OrientationPreset,
   type AntennaType,
 } from '../../store/antennaStore';
+import { FOLDED_DIPOLE_MAX_APERTURE_M } from '../../physics/constants';
 import { TransformerControl } from './TransformerControl';
 
 export function DipoleControl() {
@@ -26,6 +27,7 @@ export function DipoleControl() {
     frequency,
     orientation,
     vAngle,
+    foldedDipoleAperture,
     terminatingResistor,
     whipCounterpoise,
     setAntennaType,
@@ -35,6 +37,7 @@ export function DipoleControl() {
     setHeight,
     setOrientation,
     setVAngle,
+    setFoldedDipoleAperture,
     setTerminatingResistor,
     setWhipCounterpoise,
   } = useAntennaStore(useShallow((s) => ({
@@ -45,6 +48,7 @@ export function DipoleControl() {
     frequency: s.frequency,
     orientation: s.orientation,
     vAngle: s.vAngle,
+    foldedDipoleAperture: s.foldedDipoleAperture,
     terminatingResistor: s.terminatingResistor,
     whipCounterpoise: s.whipCounterpoise,
     setAntennaType: s.setAntennaType,
@@ -54,6 +58,7 @@ export function DipoleControl() {
     setHeight: s.setHeight,
     setOrientation: s.setOrientation,
     setVAngle: s.setVAngle,
+    setFoldedDipoleAperture: s.setFoldedDipoleAperture,
     setTerminatingResistor: s.setTerminatingResistor,
     setWhipCounterpoise: s.setWhipCounterpoise,
   })));
@@ -118,7 +123,7 @@ export function DipoleControl() {
     'terminated-delta': '1λ',
     'vertical-whip': '¼λ',
     'inverted-l': '¼λ',
-    'quad-loop': '1λ',
+    'folded-dipole': '½λ',
   };
 
   const resonateTitles: Record<AntennaType, string> = {
@@ -129,28 +134,32 @@ export function DipoleControl() {
     'terminated-delta': 'Set perimeter to 1λ',
     'vertical-whip': 'Set whip length to resonant ¼λ',
     'inverted-l': 'Set total wire length (vertical + horizontal) to resonant ¼λ. The horizontal section makes up any length the mast height falls short of a full quarter-wave.',
-    'quad-loop': 'Set perimeter to 1λ (resonant quad loop). Side-fed impedance ~100–140 Ω; a 2:1 balun or ATU brings it to 50 Ω.',
+    'folded-dipole': 'Set each conductor to a resonant ½λ. Feedpoint is ~4× a plain dipole (~300 Ω) — a natural match for 300 Ω twin-lead or a 4:1 balun to 75 Ω. Same gain and pattern as a dipole when unterminated.',
   };
 
   const isVerticalWhip = antennaType === 'vertical-whip';
   const isInvertedL = antennaType === 'inverted-l';
   const isGroundMountedVertical = isVerticalWhip || isInvertedL;
 
+  const isFoldedDipole = antennaType === 'folded-dipole';
+
   const lengthLabel = isVerticalWhip
     ? `Whip length (${unit})`
     : isInvertedL
       ? `Total wire length — vertical + horizontal (${unit})`
-      : `Length (${unit})`;
-
-  const isQuadLoop = antennaType === 'quad-loop';
+      : isFoldedDipole
+        ? `Conductor length — ½λ each (${unit})`
+        : `Length (${unit})`;
 
   const heightLabel = isVerticalWhip
     ? `Base height above ground (${unit}) — ${dispHeight.toFixed(1)}`
     : isInvertedL
       ? `Mast / bend-point height (${unit}) — ${dispHeight.toFixed(1)}`
-      : isQuadLoop
-        ? `Feedpoint height — bottom of loop (${unit}) — ${dispHeight.toFixed(1)}`
-        : `Height above ground (${unit}) — ${dispHeight.toFixed(1)}`;
+      : `Height above ground (${unit}) — ${dispHeight.toFixed(1)}`;
+
+  const dispAperture = toDisplayLength(foldedDipoleAperture, units);
+  const minApertureDisp = toDisplayLength(0.02, units);
+  const maxApertureDisp = toDisplayLength(FOLDED_DIPOLE_MAX_APERTURE_M, units);
 
   return (
     <section className="panel-section">
@@ -171,7 +180,7 @@ export function DipoleControl() {
         <option value="terminated-delta">Terminated Delta</option>
         <option value="vertical-whip">Vertical Whip</option>
         <option value="inverted-l">Inverted-L</option>
-        <option value="quad-loop">Quad Loop</option>
+        <option value="folded-dipole">Folded Dipole</option>
       </select>
 
       <label htmlFor="dipole-length" style={{ marginTop: 10 }}>{lengthLabel}</label>
@@ -265,7 +274,32 @@ export function DipoleControl() {
         </>
       )}
 
-      {(antennaType === 'sloping-v' || antennaType === 'terminated-delta') && (
+      {isFoldedDipole && (
+        <>
+          <label htmlFor="folded-dipole-aperture" style={{ marginTop: 10 }}>
+            Conductor spacing / aperture ({unit}) — {dispAperture.toFixed(2)}
+          </label>
+          <input
+            id="folded-dipole-aperture"
+            type="range"
+            min={minApertureDisp}
+            max={maxApertureDisp}
+            step={units === 'metric' ? 0.01 : 0.05}
+            value={dispAperture}
+            aria-label="Folded dipole conductor spacing"
+            aria-describedby="folded-dipole-aperture-hint"
+            onChange={(e) => {
+              const val = parseFloat(e.target.value);
+              if (!isNaN(val)) setFoldedDipoleAperture(fromDisplayLength(val, units));
+            }}
+          />
+          <div id="folded-dipole-aperture-hint" style={{ marginTop: 6, fontSize: 11, color: 'var(--text-muted)', lineHeight: 1.4 }}>
+            Spacing between the two parallel conductors. For equal-diameter wires the feedpoint stays ~4× a plain dipole (~300 Ω) regardless of spacing; wider spacing mainly broadens the impedance bandwidth. Capped at {maxApertureDisp.toFixed(2)} {unit} — beyond a realistic folded-dipole spacing the structure morphs toward a loop and no longer solves reliably as two close parallel wires.
+          </div>
+        </>
+      )}
+
+      {(antennaType === 'sloping-v' || antennaType === 'terminated-delta' || antennaType === 'folded-dipole') && (
         <>
           <label htmlFor="terminating-resistor" style={{ marginTop: 10 }}>
             Termination resistance (Ω)
@@ -302,10 +336,14 @@ export function DipoleControl() {
           </div>
           <div id="terminating-resistor-hint" style={{ marginTop: 6, fontSize: 11, color: 'var(--text-muted)', lineHeight: 1.4 }}>
             {terminatingResistor === 0
-              ? 'Unterminated: travelling wave reflects, creating a standing-wave pattern. Use this mode to check whether the antenna structure resonates at the design frequency.'
+              ? antennaType === 'folded-dipole'
+                ? 'Unterminated: a classic folded dipole — ~300 Ω feedpoint, narrowband, same gain and pattern as a plain dipole. Add a resistor to model a broadband terminated folded dipole (TFD).'
+                : 'Unterminated: travelling wave reflects, creating a standing-wave pattern. Use this mode to check whether the antenna structure resonates at the design frequency.'
               : antennaType === 'sloping-v'
                 ? `${terminatingResistor} Ω resistors at each tip (to ground). Click Off to remove termination and inspect resonance. Affects gain, directivity, front/back ratio, feedpoint impedance, realized gain, and termination loss. Lower SWR alone does not indicate the best design point.`
-                : `${terminatingResistor} Ω resistors at each inner half-base end (to ground via short stubs). Click Off to remove termination and inspect resonance. Affects gain, directivity, front/back ratio, feedpoint impedance, realized gain, and termination loss. Lower SWR alone does not indicate the best design point.`}
+                : antennaType === 'folded-dipole'
+                  ? `${terminatingResistor} Ω resistor at the centre of the conductor opposite the feed — a terminated folded dipole (TFD). Flattens SWR across a wide frequency range at the cost of efficiency (roughly half the power is dissipated in the resistor). A typical TFD value is ~390–600 Ω. Click Off for a plain folded dipole.`
+                  : `${terminatingResistor} Ω resistors at each inner half-base end (to ground via short stubs). Click Off to remove termination and inspect resonance. Affects gain, directivity, front/back ratio, feedpoint impedance, realized gain, and termination loss. Lower SWR alone does not indicate the best design point.`}
           </div>
         </>
       )}

--- a/src/components/Scene/useDipoleGeometry.ts
+++ b/src/components/Scene/useDipoleGeometry.ts
@@ -48,10 +48,12 @@ export function useDipoleGeometry({
     vAngle,
     legSlope,
     frequency,
+    foldedDipoleAperture,
   } = useAntennaStore(useShallow((s) => ({
     vAngle: s.vAngle,
     legSlope: s.legSlope,
     frequency: s.frequency,
+    foldedDipoleAperture: s.foldedDipoleAperture,
   })));
 
   const rendered = useMemo(() => {
@@ -69,6 +71,7 @@ export function useDipoleGeometry({
       legSlope,
       frequency,
       whipCounterpoise,
+      foldedDipoleAperture,
     });
 
     return wires.map((w, idx) => {
@@ -100,7 +103,7 @@ export function useDipoleGeometry({
         isBridge,
       };
     }).filter((x): x is NonNullable<typeof x> => x !== null);
-  }, [type, length, height, orientation, wireRadius, segments, feedlineId, feedlineLength, feedlineOffset, vAngle, legSlope, frequency, whipCounterpoise]);
+  }, [type, length, height, orientation, wireRadius, segments, feedlineId, feedlineLength, feedlineOffset, vAngle, legSlope, frequency, whipCounterpoise, foldedDipoleAperture]);
 
   const { shield, feedpoint } = useMemo(() => {
     const isDelta = type === 'delta-loop' || type === 'terminated-delta';

--- a/src/physics/constants.ts
+++ b/src/physics/constants.ts
@@ -68,11 +68,11 @@ export function referenceLength(type: AntennaType, frequencyMHz: number, endEffe
       // The horizontal top-loading section adds electrical length so the
       // mast can be shorter than a full ¼λ vertical.
       return lambda * 0.25 * endEffect;
-    case 'quad-loop':
-      // Full-wave perimeter. Quad loops resonate at approximately 1λ
-      // perimeter (slightly less in practice; 1λ is the canonical starting
-      // point, same convention as the delta loop).
-      return lambda * 1.0 * endEffect;
+    case 'folded-dipole':
+      // Each conductor is a resonant half-wave, same as a standard dipole.
+      // The fold (the second parallel conductor) raises the feedpoint
+      // impedance ~4× but does not change the resonant length.
+      return lambda * 0.5 * endEffect;
     default:
       return lambda * 0.5 * endEffect;
   }
@@ -221,23 +221,40 @@ export const INVERTED_L_HORIZONTAL_TAG = 15;
 export const INVERTED_L_RADIAL_TAG = 16;
 
 /**
- * Wire tags for the Quad Loop antenna (full-wave square loop, side-fed).
+ * Wire tags for the Folded Dipole antenna.
  *
- * The loop is divided into five segments: top side, left side, right side,
- * and the two halves of the bottom side that meet at the feed bridge.
- * The feed bridge (FEED_BRIDGE_TAG = 3) sits at the centre of the bottom.
+ * Two parallel half-wave conductors joined at both ends form a narrow loop.
+ * The lower conductor is fed at its centre (split into DIPOLE_LEFT_TAG /
+ * DIPOLE_RIGHT_TAG halves around the FEED_BRIDGE_TAG = 3 source bridge, the
+ * same split-fed convention as the standard dipole). The upper conductor is
+ * continuous (FOLDED_DIPOLE_OPPOSITE_TAG); in a *terminated* folded dipole
+ * (TFD) a resistor sits at the centre segment of that conductor. Two short
+ * end-connector wires across the aperture share FOLDED_DIPOLE_CONNECTOR_TAG.
  *
- *   QUAD_LOOP_TOP_TAG          (17) — top horizontal wire
- *   QUAD_LOOP_LEFT_TAG         (18) — left vertical wire (bottom → top)
- *   QUAD_LOOP_RIGHT_TAG        (19) — right vertical wire (top → bottom)
- *   QUAD_LOOP_BOTTOM_LEFT_TAG  (20) — left half of bottom wire
- *   QUAD_LOOP_BOTTOM_RIGHT_TAG (21) — right half of bottom wire
+ *   FOLDED_DIPOLE_OPPOSITE_TAG  (17) — un-fed parallel conductor
+ *   FOLDED_DIPOLE_CONNECTOR_TAG (18) — both end connectors across the aperture
  */
-export const QUAD_LOOP_TOP_TAG = 17;
-export const QUAD_LOOP_LEFT_TAG = 18;
-export const QUAD_LOOP_RIGHT_TAG = 19;
-export const QUAD_LOOP_BOTTOM_LEFT_TAG = 20;
-export const QUAD_LOOP_BOTTOM_RIGHT_TAG = 21;
+export const FOLDED_DIPOLE_OPPOSITE_TAG = 17;
+export const FOLDED_DIPOLE_CONNECTOR_TAG = 18;
+
+/**
+ * Default conductor spacing (aperture) of the folded dipole, metres.
+ * 0.3 m is a typical wide-spaced HF folded-dipole gap (e.g. window-line
+ * spreaders). For equal-diameter conductors the feedpoint stays ~4× a plain
+ * dipole (~300 Ω) regardless of spacing; the spacing mainly trades off
+ * bandwidth and the onset of array-like pattern effects at large apertures.
+ */
+export const FOLDED_DIPOLE_DEFAULT_APERTURE_M = 0.3;
+
+/**
+ * Maximum folded-dipole conductor spacing, metres. Two long, closely-spaced
+ * parallel wires converge slowly in NEC's thin-wire kernel: the segment length
+ * must shrink with the spacing, and beyond ~0.5 m the structure would need
+ * more than `MAX_SEGS_PER_LEG` segments to solve accurately (and is morphing
+ * toward a loop rather than a folded dipole). 0.5 m comfortably covers every
+ * realistic folded-dipole spacing across the HF range.
+ */
+export const FOLDED_DIPOLE_MAX_APERTURE_M = 0.5;
 
 /**
  * Number of counterpoise radials, equally spaced in azimuth, deployed

--- a/src/physics/constants.ts
+++ b/src/physics/constants.ts
@@ -68,6 +68,11 @@ export function referenceLength(type: AntennaType, frequencyMHz: number, endEffe
       // The horizontal top-loading section adds electrical length so the
       // mast can be shorter than a full ¼λ vertical.
       return lambda * 0.25 * endEffect;
+    case 'quad-loop':
+      // Full-wave perimeter. Quad loops resonate at approximately 1λ
+      // perimeter (slightly less in practice; 1λ is the canonical starting
+      // point, same convention as the delta loop).
+      return lambda * 1.0 * endEffect;
     default:
       return lambda * 0.5 * endEffect;
   }
@@ -214,6 +219,25 @@ export const INVERTED_L_HORIZONTAL_TAG = 15;
  * current-ripple diagnostics can distinguish the two antenna types.
  */
 export const INVERTED_L_RADIAL_TAG = 16;
+
+/**
+ * Wire tags for the Quad Loop antenna (full-wave square loop, side-fed).
+ *
+ * The loop is divided into five segments: top side, left side, right side,
+ * and the two halves of the bottom side that meet at the feed bridge.
+ * The feed bridge (FEED_BRIDGE_TAG = 3) sits at the centre of the bottom.
+ *
+ *   QUAD_LOOP_TOP_TAG          (17) — top horizontal wire
+ *   QUAD_LOOP_LEFT_TAG         (18) — left vertical wire (bottom → top)
+ *   QUAD_LOOP_RIGHT_TAG        (19) — right vertical wire (top → bottom)
+ *   QUAD_LOOP_BOTTOM_LEFT_TAG  (20) — left half of bottom wire
+ *   QUAD_LOOP_BOTTOM_RIGHT_TAG (21) — right half of bottom wire
+ */
+export const QUAD_LOOP_TOP_TAG = 17;
+export const QUAD_LOOP_LEFT_TAG = 18;
+export const QUAD_LOOP_RIGHT_TAG = 19;
+export const QUAD_LOOP_BOTTOM_LEFT_TAG = 20;
+export const QUAD_LOOP_BOTTOM_RIGHT_TAG = 21;
 
 /**
  * Number of counterpoise radials, equally spaced in azimuth, deployed

--- a/src/physics/types.ts
+++ b/src/physics/types.ts
@@ -20,8 +20,13 @@ export type Vec3 = readonly [number, number, number];
  *     ground); `length` is the total wire (vertical + horizontal combined).
  *     Base-fed at ground level; counterpoise radials optional. Useful on
  *     160 m / 80 m where a full ¼λ vertical would be impractically tall.
+ *   - quad-loop: full-wave square loop in the vertical plane, fed at the
+ *     centre of the bottom side. `height` is the height of the top of the
+ *     loop; `length` is the perimeter (reference: 1λ). The loop shape is
+ *     square when the mast is tall enough; it flattens to a rectangle
+ *     (wider than tall, perimeter preserved) when the mast is too short.
  */
-export type AntennaType = 'dipole' | 'inverted-v' | 'delta-loop' | 'sloping-v' | 'terminated-delta' | 'vertical-whip' | 'inverted-l';
+export type AntennaType = 'dipole' | 'inverted-v' | 'delta-loop' | 'sloping-v' | 'terminated-delta' | 'vertical-whip' | 'inverted-l' | 'quad-loop';
 
 export interface Wire {
   readonly start: Vec3;

--- a/src/physics/types.ts
+++ b/src/physics/types.ts
@@ -20,13 +20,14 @@ export type Vec3 = readonly [number, number, number];
  *     ground); `length` is the total wire (vertical + horizontal combined).
  *     Base-fed at ground level; counterpoise radials optional. Useful on
  *     160 m / 80 m where a full ¼λ vertical would be impractically tall.
- *   - quad-loop: full-wave square loop in the vertical plane, fed at the
- *     centre of the bottom side. `height` is the height of the top of the
- *     loop; `length` is the perimeter (reference: 1λ). The loop shape is
- *     square when the mast is tall enough; it flattens to a rectangle
- *     (wider than tall, perimeter preserved) when the mast is too short.
+ *   - folded-dipole: two parallel half-wave conductors joined at both ends,
+ *     forming a narrow horizontal loop at a single height. `length` is each
+ *     conductor's length (≈½λ resonant); `foldedDipoleAperture` is the
+ *     spacing between the two conductors. Fed at the centre of the lower
+ *     conductor (~300 Ω). An optional terminating resistor at the centre of
+ *     the upper conductor turns it into a broadband terminated folded dipole.
  */
-export type AntennaType = 'dipole' | 'inverted-v' | 'delta-loop' | 'sloping-v' | 'terminated-delta' | 'vertical-whip' | 'inverted-l' | 'quad-loop';
+export type AntennaType = 'dipole' | 'inverted-v' | 'delta-loop' | 'sloping-v' | 'terminated-delta' | 'vertical-whip' | 'inverted-l' | 'folded-dipole';
 
 export interface Wire {
   readonly start: Vec3;

--- a/src/store/antennaGeometry.ts
+++ b/src/store/antennaGeometry.ts
@@ -17,11 +17,8 @@ import {
   INVERTED_L_VERTICAL_TAG,
   INVERTED_L_HORIZONTAL_TAG,
   INVERTED_L_RADIAL_TAG,
-  QUAD_LOOP_TOP_TAG,
-  QUAD_LOOP_LEFT_TAG,
-  QUAD_LOOP_RIGHT_TAG,
-  QUAD_LOOP_BOTTOM_LEFT_TAG,
-  QUAD_LOOP_BOTTOM_RIGHT_TAG,
+  FOLDED_DIPOLE_OPPOSITE_TAG,
+  FOLDED_DIPOLE_CONNECTOR_TAG,
 } from '../physics/constants';
 import type { Wire } from '../physics/types';
 
@@ -849,24 +846,14 @@ export function buildInvertedLWires(params: InvertedLWiresParams): Wire[] {
   return wires;
 }
 
-export interface QuadLoopWiresParams {
-  /** Total perimeter, metres. */
+export interface FoldedDipoleWiresParams {
+  /** Each conductor's length, metres (≈½λ resonant). */
   length: number;
-  /**
-   * Height of the **feedpoint** (centre of the bottom side) above ground,
-   * metres. The loop is always a true square: each side = P/4. The loop
-   * extends upward and sideways symmetrically from the feedpoint, so the
-   * top of the loop sits at `height + P/4`.
-   *
-   * This is the same convention used by every other antenna type — the
-   * `height` slider always moves the feedpoint, not the top of the
-   * structure.
-   */
+  /** Height of the (planar, horizontal) antenna above ground, metres. */
   height: number;
-  /**
-   * Azimuth the loop faces (the plane of the loop is perpendicular to the
-   * ground and aligned along this direction).
-   */
+  /** Spacing between the two parallel conductors, metres. */
+  aperture: number;
+  /** Azimuth the conductor axis runs. */
   orientation: Orientation;
   wireRadius: number;
   segments: number;
@@ -874,116 +861,138 @@ export interface QuadLoopWiresParams {
 }
 
 /**
- * Builds the wires for a Quad Loop antenna (full-wave square loop,
- * centre-of-bottom-side fed).
+ * Builds the wires for a Folded Dipole antenna.
  *
- * The loop lies in a vertical plane whose orientation matches
- * `params.orientation`. `params.height` is the **feedpoint height**
- * (centre of the bottom side) — the same convention used by the dipole,
- * inverted-V, delta loop, etc. The loop always forms a true square: each
- * side = P/4. The top sits at `height + P/4`.
+ * Two parallel conductors of length `length` run along the orientation axis,
+ * separated by `aperture` in the horizontal direction perpendicular to the
+ * axis, and joined at both ends by short connector wires. The whole structure
+ * lies flat at a single height `h` — every wire is at z = h, so the antenna
+ * is fully buildable at a modest, user-controlled height (no part is forced
+ * higher, unlike a vertical loop).
  *
- * The bottom side is split at its centre by a short FEED_BRIDGE_TAG segment
- * (identical convention to the delta loop apex bridge). Excitation lands on
- * segment 1 of the bridge — the existing buildExcitation `hasBridge` path
- * handles this automatically.
+ * The lower (fed) conductor is split at its centre around a FEED_BRIDGE_TAG
+ * source bridge — the same split-fed convention as the standard dipole, so
+ * the existing buildExcitation `hasBridge` path drives it automatically. The
+ * upper conductor is a single continuous wire with an odd segment count; a
+ * terminating resistor (when fitted) lands on its exact centre segment via
+ * buildTerminationElements, turning the antenna into a broadband TFD.
  *
  * Tags:
- *   QUAD_LOOP_TOP_TAG          (17) — top horizontal wire
- *   QUAD_LOOP_LEFT_TAG         (18) — left vertical wire (bottom-left → top-left)
- *   QUAD_LOOP_RIGHT_TAG        (19) — right vertical wire (top-right → bottom-right)
- *   QUAD_LOOP_BOTTOM_LEFT_TAG  (20) — left half of bottom (bottom-left → bridge-left)
- *   QUAD_LOOP_BOTTOM_RIGHT_TAG (21) — right half of bottom (bridge-right → bottom-right)
- *   FEED_BRIDGE_TAG             (3) — 1-segment source bridge at bottom centre
+ *   DIPOLE_LEFT_TAG             (1)  — fed conductor, left half (left → bridge)
+ *   DIPOLE_RIGHT_TAG            (2)  — fed conductor, right half (bridge → right)
+ *   FEED_BRIDGE_TAG            (3)  — 1-segment source bridge at the centre
+ *   FOLDED_DIPOLE_OPPOSITE_TAG  (17) — un-fed parallel conductor (left → right)
+ *   FOLDED_DIPOLE_CONNECTOR_TAG (18) — both end connectors across the aperture
  */
-export function buildQuadLoopWires(params: QuadLoopWiresParams): Wire[] {
-  const perimeter = params.length;
+export function buildFoldedDipoleWires(params: FoldedDipoleWiresParams): Wire[] {
   const h = params.height;
-  const [dx, dy] = orientationVector(params.orientation);
-
-  // height is the feedpoint (bottom-centre) height.
-  // The loop is always a true square: side = P/4.
-  const sideLen = perimeter / 4;
-  const bottomZ = Math.max(SLOPING_V_MIN_TIP_Z_M, h);
-  const topZ = bottomZ + sideLen;
-
-  // Half the bottom-side width = half a side length.
-  const halfWidth = sideLen / 2;
-
+  const half = Math.max(0.1, params.length) / 2;
+  const halfAp = Math.max(0.025, params.aperture / 2);
   const bridgeHalf = FEED_BRIDGE_LENGTH_M / 2;
 
-  const topLeft:     [number, number, number] = [-halfWidth * dx, -halfWidth * dy, topZ];
-  const topRight:    [number, number, number] = [ halfWidth * dx,  halfWidth * dy, topZ];
-  const bottomLeft:  [number, number, number] = [-halfWidth * dx, -halfWidth * dy, bottomZ];
-  const bottomRight: [number, number, number] = [ halfWidth * dx,  halfWidth * dy, bottomZ];
-  const centerLeft:  [number, number, number] = [-bridgeHalf * dx, -bridgeHalf * dy, bottomZ];
-  const centerRight: [number, number, number] = [ bridgeHalf * dx,  bridgeHalf * dy, bottomZ];
+  const [dx, dy] = orientationVector(params.orientation);
+  const [px, py] = [-dy, dx];
+  const cleanZero = (v: number): number => (v === 0 ? 0 : v);
+
+  // axis = distance along the conductor axis; perp = offset across the aperture.
+  const pt = (axis: number, perp: number): [number, number, number] => [
+    cleanZero(axis * dx + perp * px),
+    cleanZero(axis * dy + perp * py),
+    h,
+  ];
 
   const lambda = wavelengthMeters(params.frequency);
-  const userSegsPerSide = Math.round(params.segments / 4);
 
-  // All four sides are the same length (true square), so one segment count
-  // covers the top wire, the two side wires, and each bottom half.
-  const minSideSegs = Math.ceil((SEGS_PER_WAVELENGTH * sideLen) / lambda);
-  const topSegs = Math.min(MAX_SEGS_PER_LEG, Math.max(MIN_SEGS_PER_LEG, minSideSegs, userSegsPerSide));
+  // Target segment length. NEC's thin-wire kernel loses accuracy for closely
+  // spaced parallel wires once the segment length grows much larger than the
+  // wire separation, so the folded dipole must segment finely enough that each
+  // segment is no longer than ~half the aperture (empirically the point where
+  // the free-space gain converges to the dipole value). We take the smaller of
+  // the usual density target (λ / SEGS_PER_WAVELENGTH) and half the aperture,
+  // then derive all segment counts from that single target length. This also
+  // keeps the corner junction segments (conductor vs. connector) close in
+  // length. The aperture is capped (see the store) so this stays within
+  // MAX_SEGS_PER_LEG across the HF range.
+  const aperture = halfAp * 2;
+  const targetSegLen = Math.max(1e-3, Math.min(lambda / SEGS_PER_WAVELENGTH, halfAp));
 
-  // Left / right vertical wires (same length as top).
-  const sideSegs = topSegs;
+  const segsForLen = (len: number, userFloor: number): number =>
+    Math.min(
+      MAX_SEGS_PER_LEG,
+      Math.max(MIN_SEGS_PER_LEG, Math.ceil(len / targetSegLen), userFloor),
+    );
 
-  // Each bottom half (from corner to bridge edge).
-  // halfWidth = sideLen/2, so halfBottomLen ≈ sideLen/2 (minus the tiny bridge half).
-  const halfBottomLen = Math.max(0.01, halfWidth - bridgeHalf);
-  const minHalfBottomSegs = Math.ceil((SEGS_PER_WAVELENGTH * halfBottomLen) / lambda);
-  const halfBottomSegs = Math.min(MAX_SEGS_PER_LEG, Math.max(MIN_SEGS_PER_LEG, minHalfBottomSegs, Math.round(userSegsPerSide / 2)));
+  // Each half of the fed conductor (corner → feed bridge edge).
+  const halfCondLen = Math.max(0.01, half - bridgeHalf);
+  const halfSegs = segsForLen(halfCondLen, Math.round(params.segments / 2));
+
+  // Opposite conductor: force an odd segment count so the centre segment
+  // (which carries the optional terminating resistor) is exactly at midpoint.
+  const rawOppSegs = segsForLen(params.length, params.segments);
+  const oppSegs = rawOppSegs % 2 === 0 ? rawOppSegs + 1 : rawOppSegs;
+
+  // End connectors span the aperture, segmented at the same target length so
+  // their segments match the adjacent conductor segments at the corners.
+  const connSegs = Math.max(1, Math.min(MAX_SEGS_PER_LEG, Math.ceil(aperture / targetSegLen)));
+
+  const fedPerp = -halfAp;
+  const oppPerp = halfAp;
+
+  const leftFed = pt(-half, fedPerp);
+  const rightFed = pt(half, fedPerp);
+  const bridgeLeft = pt(-bridgeHalf, fedPerp);
+  const bridgeRight = pt(bridgeHalf, fedPerp);
+  const leftOpp = pt(-half, oppPerp);
+  const rightOpp = pt(half, oppPerp);
 
   return [
-    // Top wire — left corner to right corner.
+    // Fed conductor — left half (left end → bridge).
     {
-      start: topLeft,
-      end: topRight,
+      start: leftFed,
+      end: bridgeLeft,
       radius: params.wireRadius,
-      segments: topSegs,
-      tag: QUAD_LOOP_TOP_TAG,
+      segments: halfSegs,
+      tag: DIPOLE_LEFT_TAG,
     },
-    // Left vertical wire — bottom-left corner up to top-left corner.
+    // Feed bridge at the centre of the fed conductor.
     {
-      start: bottomLeft,
-      end: topLeft,
-      radius: params.wireRadius,
-      segments: sideSegs,
-      tag: QUAD_LOOP_LEFT_TAG,
-    },
-    // Right vertical wire — top-right corner down to bottom-right corner.
-    {
-      start: topRight,
-      end: bottomRight,
-      radius: params.wireRadius,
-      segments: sideSegs,
-      tag: QUAD_LOOP_RIGHT_TAG,
-    },
-    // Left half of bottom wire — bottom-left corner to bridge-left.
-    {
-      start: bottomLeft,
-      end: centerLeft,
-      radius: params.wireRadius,
-      segments: halfBottomSegs,
-      tag: QUAD_LOOP_BOTTOM_LEFT_TAG,
-    },
-    // Right half of bottom wire — bridge-right to bottom-right corner.
-    {
-      start: centerRight,
-      end: bottomRight,
-      radius: params.wireRadius,
-      segments: halfBottomSegs,
-      tag: QUAD_LOOP_BOTTOM_RIGHT_TAG,
-    },
-    // Feed bridge at the centre of the bottom side.
-    {
-      start: centerLeft,
-      end: centerRight,
+      start: bridgeLeft,
+      end: bridgeRight,
       radius: params.wireRadius,
       segments: 1,
       tag: FEED_BRIDGE_TAG,
+    },
+    // Fed conductor — right half (bridge → right end).
+    {
+      start: bridgeRight,
+      end: rightFed,
+      radius: params.wireRadius,
+      segments: halfSegs,
+      tag: DIPOLE_RIGHT_TAG,
+    },
+    // Opposite (un-fed) conductor — continuous wire; resistor on centre seg.
+    {
+      start: leftOpp,
+      end: rightOpp,
+      radius: params.wireRadius,
+      segments: oppSegs,
+      tag: FOLDED_DIPOLE_OPPOSITE_TAG,
+    },
+    // Left end connector across the aperture.
+    {
+      start: leftFed,
+      end: leftOpp,
+      radius: params.wireRadius,
+      segments: connSegs,
+      tag: FOLDED_DIPOLE_CONNECTOR_TAG,
+    },
+    // Right end connector across the aperture.
+    {
+      start: rightFed,
+      end: rightOpp,
+      radius: params.wireRadius,
+      segments: connSegs,
+      tag: FOLDED_DIPOLE_CONNECTOR_TAG,
     },
   ];
 }

--- a/src/store/antennaGeometry.ts
+++ b/src/store/antennaGeometry.ts
@@ -852,7 +852,16 @@ export function buildInvertedLWires(params: InvertedLWiresParams): Wire[] {
 export interface QuadLoopWiresParams {
   /** Total perimeter, metres. */
   length: number;
-  /** Height of the top of the loop above ground, metres. */
+  /**
+   * Height of the **feedpoint** (centre of the bottom side) above ground,
+   * metres. The loop is always a true square: each side = P/4. The loop
+   * extends upward and sideways symmetrically from the feedpoint, so the
+   * top of the loop sits at `height + P/4`.
+   *
+   * This is the same convention used by every other antenna type — the
+   * `height` slider always moves the feedpoint, not the top of the
+   * structure.
+   */
   height: number;
   /**
    * Azimuth the loop faces (the plane of the loop is perpendicular to the
@@ -869,17 +878,10 @@ export interface QuadLoopWiresParams {
  * centre-of-bottom-side fed).
  *
  * The loop lies in a vertical plane whose orientation matches
- * `params.orientation`. The top of the loop sits at `params.height`.
- *
- * Shape:
- *   - When the mast is tall enough (height ≥ P/4 + SLOPING_V_MIN_TIP_Z_M),
- *     the loop is square: each side = P/4.
- *   - When the mast is shorter, the loop flattens to a rectangle while
- *     preserving the full perimeter:
- *       loop_height = min(P/4, height − SLOPING_V_MIN_TIP_Z_M)
- *       loop_width  = P/2 − loop_height
- *     (loop_width ≥ P/4 always, so the rectangle is always wider than tall
- *     or exactly square.)
+ * `params.orientation`. `params.height` is the **feedpoint height**
+ * (centre of the bottom side) — the same convention used by the dipole,
+ * inverted-V, delta loop, etc. The loop always forms a true square: each
+ * side = P/4. The top sits at `height + P/4`.
  *
  * The bottom side is split at its centre by a short FEED_BRIDGE_TAG segment
  * (identical convention to the delta loop apex bridge). Excitation lands on
@@ -899,22 +901,19 @@ export function buildQuadLoopWires(params: QuadLoopWiresParams): Wire[] {
   const h = params.height;
   const [dx, dy] = orientationVector(params.orientation);
 
-  // Maximum available loop height given the mast height.
-  const maxAvailable = Math.max(0.01, h - SLOPING_V_MIN_TIP_Z_M);
-  const squareSide = perimeter / 4;
-  const loopHeight = Math.min(squareSide, maxAvailable);
+  // height is the feedpoint (bottom-centre) height.
+  // The loop is always a true square: side = P/4.
+  const sideLen = perimeter / 4;
+  const bottomZ = Math.max(SLOPING_V_MIN_TIP_Z_M, h);
+  const topZ = bottomZ + sideLen;
 
-  // Preserve perimeter: width = P/2 − height.
-  // For a true square loopHeight = loopWidth = P/4;
-  // when constrained the loop is wider than tall.
-  const loopWidth = perimeter / 2 - loopHeight;
-  const halfWidth = loopWidth / 2;
-  const bottomZ = h - loopHeight;
+  // Half the bottom-side width = half a side length.
+  const halfWidth = sideLen / 2;
 
   const bridgeHalf = FEED_BRIDGE_LENGTH_M / 2;
 
-  const topLeft:     [number, number, number] = [-halfWidth * dx, -halfWidth * dy, h];
-  const topRight:    [number, number, number] = [ halfWidth * dx,  halfWidth * dy, h];
+  const topLeft:     [number, number, number] = [-halfWidth * dx, -halfWidth * dy, topZ];
+  const topRight:    [number, number, number] = [ halfWidth * dx,  halfWidth * dy, topZ];
   const bottomLeft:  [number, number, number] = [-halfWidth * dx, -halfWidth * dy, bottomZ];
   const bottomRight: [number, number, number] = [ halfWidth * dx,  halfWidth * dy, bottomZ];
   const centerLeft:  [number, number, number] = [-bridgeHalf * dx, -bridgeHalf * dy, bottomZ];
@@ -923,15 +922,16 @@ export function buildQuadLoopWires(params: QuadLoopWiresParams): Wire[] {
   const lambda = wavelengthMeters(params.frequency);
   const userSegsPerSide = Math.round(params.segments / 4);
 
-  // Top wire (full width).
-  const minTopSegs = Math.ceil((SEGS_PER_WAVELENGTH * loopWidth) / lambda);
-  const topSegs = Math.min(MAX_SEGS_PER_LEG, Math.max(MIN_SEGS_PER_LEG, minTopSegs, userSegsPerSide));
+  // All four sides are the same length (true square), so one segment count
+  // covers the top wire, the two side wires, and each bottom half.
+  const minSideSegs = Math.ceil((SEGS_PER_WAVELENGTH * sideLen) / lambda);
+  const topSegs = Math.min(MAX_SEGS_PER_LEG, Math.max(MIN_SEGS_PER_LEG, minSideSegs, userSegsPerSide));
 
-  // Left / right vertical wires.
-  const minSideSegs = Math.ceil((SEGS_PER_WAVELENGTH * loopHeight) / lambda);
-  const sideSegs = Math.min(MAX_SEGS_PER_LEG, Math.max(MIN_SEGS_PER_LEG, minSideSegs, userSegsPerSide));
+  // Left / right vertical wires (same length as top).
+  const sideSegs = topSegs;
 
   // Each bottom half (from corner to bridge edge).
+  // halfWidth = sideLen/2, so halfBottomLen ≈ sideLen/2 (minus the tiny bridge half).
   const halfBottomLen = Math.max(0.01, halfWidth - bridgeHalf);
   const minHalfBottomSegs = Math.ceil((SEGS_PER_WAVELENGTH * halfBottomLen) / lambda);
   const halfBottomSegs = Math.min(MAX_SEGS_PER_LEG, Math.max(MIN_SEGS_PER_LEG, minHalfBottomSegs, Math.round(userSegsPerSide / 2)));

--- a/src/store/antennaGeometry.ts
+++ b/src/store/antennaGeometry.ts
@@ -17,6 +17,11 @@ import {
   INVERTED_L_VERTICAL_TAG,
   INVERTED_L_HORIZONTAL_TAG,
   INVERTED_L_RADIAL_TAG,
+  QUAD_LOOP_TOP_TAG,
+  QUAD_LOOP_LEFT_TAG,
+  QUAD_LOOP_RIGHT_TAG,
+  QUAD_LOOP_BOTTOM_LEFT_TAG,
+  QUAD_LOOP_BOTTOM_RIGHT_TAG,
 } from '../physics/constants';
 import type { Wire } from '../physics/types';
 
@@ -842,4 +847,143 @@ export function buildInvertedLWires(params: InvertedLWiresParams): Wire[] {
   }
 
   return wires;
+}
+
+export interface QuadLoopWiresParams {
+  /** Total perimeter, metres. */
+  length: number;
+  /** Height of the top of the loop above ground, metres. */
+  height: number;
+  /**
+   * Azimuth the loop faces (the plane of the loop is perpendicular to the
+   * ground and aligned along this direction).
+   */
+  orientation: Orientation;
+  wireRadius: number;
+  segments: number;
+  frequency: number;
+}
+
+/**
+ * Builds the wires for a Quad Loop antenna (full-wave square loop,
+ * centre-of-bottom-side fed).
+ *
+ * The loop lies in a vertical plane whose orientation matches
+ * `params.orientation`. The top of the loop sits at `params.height`.
+ *
+ * Shape:
+ *   - When the mast is tall enough (height ≥ P/4 + SLOPING_V_MIN_TIP_Z_M),
+ *     the loop is square: each side = P/4.
+ *   - When the mast is shorter, the loop flattens to a rectangle while
+ *     preserving the full perimeter:
+ *       loop_height = min(P/4, height − SLOPING_V_MIN_TIP_Z_M)
+ *       loop_width  = P/2 − loop_height
+ *     (loop_width ≥ P/4 always, so the rectangle is always wider than tall
+ *     or exactly square.)
+ *
+ * The bottom side is split at its centre by a short FEED_BRIDGE_TAG segment
+ * (identical convention to the delta loop apex bridge). Excitation lands on
+ * segment 1 of the bridge — the existing buildExcitation `hasBridge` path
+ * handles this automatically.
+ *
+ * Tags:
+ *   QUAD_LOOP_TOP_TAG          (17) — top horizontal wire
+ *   QUAD_LOOP_LEFT_TAG         (18) — left vertical wire (bottom-left → top-left)
+ *   QUAD_LOOP_RIGHT_TAG        (19) — right vertical wire (top-right → bottom-right)
+ *   QUAD_LOOP_BOTTOM_LEFT_TAG  (20) — left half of bottom (bottom-left → bridge-left)
+ *   QUAD_LOOP_BOTTOM_RIGHT_TAG (21) — right half of bottom (bridge-right → bottom-right)
+ *   FEED_BRIDGE_TAG             (3) — 1-segment source bridge at bottom centre
+ */
+export function buildQuadLoopWires(params: QuadLoopWiresParams): Wire[] {
+  const perimeter = params.length;
+  const h = params.height;
+  const [dx, dy] = orientationVector(params.orientation);
+
+  // Maximum available loop height given the mast height.
+  const maxAvailable = Math.max(0.01, h - SLOPING_V_MIN_TIP_Z_M);
+  const squareSide = perimeter / 4;
+  const loopHeight = Math.min(squareSide, maxAvailable);
+
+  // Preserve perimeter: width = P/2 − height.
+  // For a true square loopHeight = loopWidth = P/4;
+  // when constrained the loop is wider than tall.
+  const loopWidth = perimeter / 2 - loopHeight;
+  const halfWidth = loopWidth / 2;
+  const bottomZ = h - loopHeight;
+
+  const bridgeHalf = FEED_BRIDGE_LENGTH_M / 2;
+
+  const topLeft:     [number, number, number] = [-halfWidth * dx, -halfWidth * dy, h];
+  const topRight:    [number, number, number] = [ halfWidth * dx,  halfWidth * dy, h];
+  const bottomLeft:  [number, number, number] = [-halfWidth * dx, -halfWidth * dy, bottomZ];
+  const bottomRight: [number, number, number] = [ halfWidth * dx,  halfWidth * dy, bottomZ];
+  const centerLeft:  [number, number, number] = [-bridgeHalf * dx, -bridgeHalf * dy, bottomZ];
+  const centerRight: [number, number, number] = [ bridgeHalf * dx,  bridgeHalf * dy, bottomZ];
+
+  const lambda = wavelengthMeters(params.frequency);
+  const userSegsPerSide = Math.round(params.segments / 4);
+
+  // Top wire (full width).
+  const minTopSegs = Math.ceil((SEGS_PER_WAVELENGTH * loopWidth) / lambda);
+  const topSegs = Math.min(MAX_SEGS_PER_LEG, Math.max(MIN_SEGS_PER_LEG, minTopSegs, userSegsPerSide));
+
+  // Left / right vertical wires.
+  const minSideSegs = Math.ceil((SEGS_PER_WAVELENGTH * loopHeight) / lambda);
+  const sideSegs = Math.min(MAX_SEGS_PER_LEG, Math.max(MIN_SEGS_PER_LEG, minSideSegs, userSegsPerSide));
+
+  // Each bottom half (from corner to bridge edge).
+  const halfBottomLen = Math.max(0.01, halfWidth - bridgeHalf);
+  const minHalfBottomSegs = Math.ceil((SEGS_PER_WAVELENGTH * halfBottomLen) / lambda);
+  const halfBottomSegs = Math.min(MAX_SEGS_PER_LEG, Math.max(MIN_SEGS_PER_LEG, minHalfBottomSegs, Math.round(userSegsPerSide / 2)));
+
+  return [
+    // Top wire — left corner to right corner.
+    {
+      start: topLeft,
+      end: topRight,
+      radius: params.wireRadius,
+      segments: topSegs,
+      tag: QUAD_LOOP_TOP_TAG,
+    },
+    // Left vertical wire — bottom-left corner up to top-left corner.
+    {
+      start: bottomLeft,
+      end: topLeft,
+      radius: params.wireRadius,
+      segments: sideSegs,
+      tag: QUAD_LOOP_LEFT_TAG,
+    },
+    // Right vertical wire — top-right corner down to bottom-right corner.
+    {
+      start: topRight,
+      end: bottomRight,
+      radius: params.wireRadius,
+      segments: sideSegs,
+      tag: QUAD_LOOP_RIGHT_TAG,
+    },
+    // Left half of bottom wire — bottom-left corner to bridge-left.
+    {
+      start: bottomLeft,
+      end: centerLeft,
+      radius: params.wireRadius,
+      segments: halfBottomSegs,
+      tag: QUAD_LOOP_BOTTOM_LEFT_TAG,
+    },
+    // Right half of bottom wire — bridge-right to bottom-right corner.
+    {
+      start: centerRight,
+      end: bottomRight,
+      radius: params.wireRadius,
+      segments: halfBottomSegs,
+      tag: QUAD_LOOP_BOTTOM_RIGHT_TAG,
+    },
+    // Feed bridge at the centre of the bottom side.
+    {
+      start: centerLeft,
+      end: centerRight,
+      radius: params.wireRadius,
+      segments: 1,
+      tag: FEED_BRIDGE_TAG,
+    },
+  ];
 }

--- a/src/store/antennaGeometry.ts
+++ b/src/store/antennaGeometry.ts
@@ -864,41 +864,44 @@ export interface FoldedDipoleWiresParams {
  * Builds the wires for a Folded Dipole antenna.
  *
  * Two parallel conductors of length `length` run along the orientation axis,
- * separated by `aperture` in the horizontal direction perpendicular to the
- * axis, and joined at both ends by short connector wires. The whole structure
- * lies flat at a single height `h` — every wire is at z = h, so the antenna
- * is fully buildable at a modest, user-controlled height (no part is forced
- * higher, unlike a vertical loop).
+ * separated vertically by `aperture`: the fed (bottom) conductor sits at
+ * z = height and the un-fed (top) conductor sits at z = height + aperture.
+ * Short vertical connector wires join both ends, completing the folded loop.
+ * The structure is fully buildable at a modest height — the top conductor only
+ * rises `aperture` (≤ 0.5 m) above the feedpoint height, unlike a vertical loop.
  *
- * The lower (fed) conductor is split at its centre around a FEED_BRIDGE_TAG
+ * The bottom (fed) conductor is split at its centre around a FEED_BRIDGE_TAG
  * source bridge — the same split-fed convention as the standard dipole, so
  * the existing buildExcitation `hasBridge` path drives it automatically. The
- * upper conductor is a single continuous wire with an odd segment count; a
+ * top conductor is a single continuous wire with an odd segment count; a
  * terminating resistor (when fitted) lands on its exact centre segment via
  * buildTerminationElements, turning the antenna into a broadband TFD.
  *
  * Tags:
- *   DIPOLE_LEFT_TAG             (1)  — fed conductor, left half (left → bridge)
- *   DIPOLE_RIGHT_TAG            (2)  — fed conductor, right half (bridge → right)
+ *   DIPOLE_LEFT_TAG             (1)  — fed (bottom) conductor, left half (left → bridge)
+ *   DIPOLE_RIGHT_TAG            (2)  — fed (bottom) conductor, right half (bridge → right)
  *   FEED_BRIDGE_TAG            (3)  — 1-segment source bridge at the centre
- *   FOLDED_DIPOLE_OPPOSITE_TAG  (17) — un-fed parallel conductor (left → right)
- *   FOLDED_DIPOLE_CONNECTOR_TAG (18) — both end connectors across the aperture
+ *   FOLDED_DIPOLE_OPPOSITE_TAG  (17) — un-fed (top) conductor (left → right)
+ *   FOLDED_DIPOLE_CONNECTOR_TAG (18) — both end connectors (vertical, bottom → top)
  */
 export function buildFoldedDipoleWires(params: FoldedDipoleWiresParams): Wire[] {
   const h = params.height;
   const half = Math.max(0.1, params.length) / 2;
-  const halfAp = Math.max(0.025, params.aperture / 2);
+  const aperture = Math.max(0.02, params.aperture);
   const bridgeHalf = FEED_BRIDGE_LENGTH_M / 2;
 
   const [dx, dy] = orientationVector(params.orientation);
-  const [px, py] = [-dy, dx];
   const cleanZero = (v: number): number => (v === 0 ? 0 : v);
 
-  // axis = distance along the conductor axis; perp = offset across the aperture.
-  const pt = (axis: number, perp: number): [number, number, number] => [
-    cleanZero(axis * dx + perp * px),
-    cleanZero(axis * dy + perp * py),
-    h,
+  // Bottom (fed) conductor at z = h; top (opposite) conductor at z = h + aperture.
+  const zBottom = h;
+  const zTop = h + aperture;
+
+  // axis = signed distance along the orientation direction from the antenna centre.
+  const pt = (axis: number, z: number): [number, number, number] => [
+    cleanZero(axis * dx),
+    cleanZero(axis * dy),
+    z,
   ];
 
   const lambda = wavelengthMeters(params.frequency);
@@ -913,8 +916,7 @@ export function buildFoldedDipoleWires(params: FoldedDipoleWiresParams): Wire[] 
   // keeps the corner junction segments (conductor vs. connector) close in
   // length. The aperture is capped (see the store) so this stays within
   // MAX_SEGS_PER_LEG across the HF range.
-  const aperture = halfAp * 2;
-  const targetSegLen = Math.max(1e-3, Math.min(lambda / SEGS_PER_WAVELENGTH, halfAp));
+  const targetSegLen = Math.max(1e-3, Math.min(lambda / SEGS_PER_WAVELENGTH, aperture / 2));
 
   const segsForLen = (len: number, userFloor: number): number =>
     Math.min(
@@ -931,19 +933,16 @@ export function buildFoldedDipoleWires(params: FoldedDipoleWiresParams): Wire[] 
   const rawOppSegs = segsForLen(params.length, params.segments);
   const oppSegs = rawOppSegs % 2 === 0 ? rawOppSegs + 1 : rawOppSegs;
 
-  // End connectors span the aperture, segmented at the same target length so
-  // their segments match the adjacent conductor segments at the corners.
+  // End connectors span the aperture vertically, segmented at the same target
+  // length so their segments match the adjacent conductor segments at the corners.
   const connSegs = Math.max(1, Math.min(MAX_SEGS_PER_LEG, Math.ceil(aperture / targetSegLen)));
 
-  const fedPerp = -halfAp;
-  const oppPerp = halfAp;
-
-  const leftFed = pt(-half, fedPerp);
-  const rightFed = pt(half, fedPerp);
-  const bridgeLeft = pt(-bridgeHalf, fedPerp);
-  const bridgeRight = pt(bridgeHalf, fedPerp);
-  const leftOpp = pt(-half, oppPerp);
-  const rightOpp = pt(half, oppPerp);
+  const leftFed = pt(-half, zBottom);
+  const rightFed = pt(half, zBottom);
+  const bridgeLeft = pt(-bridgeHalf, zBottom);
+  const bridgeRight = pt(bridgeHalf, zBottom);
+  const leftOpp = pt(-half, zTop);
+  const rightOpp = pt(half, zTop);
 
   return [
     // Fed conductor — left half (left end → bridge).

--- a/src/store/antennaStore.ts
+++ b/src/store/antennaStore.ts
@@ -49,11 +49,10 @@ import {
   INVERTED_L_VERTICAL_TAG,
   INVERTED_L_HORIZONTAL_TAG,
   INVERTED_L_RADIAL_TAG,
-  QUAD_LOOP_TOP_TAG,
-  QUAD_LOOP_LEFT_TAG,
-  QUAD_LOOP_RIGHT_TAG,
-  QUAD_LOOP_BOTTOM_LEFT_TAG,
-  QUAD_LOOP_BOTTOM_RIGHT_TAG,
+  FOLDED_DIPOLE_OPPOSITE_TAG,
+  FOLDED_DIPOLE_CONNECTOR_TAG,
+  FOLDED_DIPOLE_DEFAULT_APERTURE_M,
+  FOLDED_DIPOLE_MAX_APERTURE_M,
 } from '../physics/constants';
 
 // Re-export geometry tags for UI and tests.
@@ -74,11 +73,8 @@ export {
   INVERTED_L_VERTICAL_TAG,
   INVERTED_L_HORIZONTAL_TAG,
   INVERTED_L_RADIAL_TAG,
-  QUAD_LOOP_TOP_TAG,
-  QUAD_LOOP_LEFT_TAG,
-  QUAD_LOOP_RIGHT_TAG,
-  QUAD_LOOP_BOTTOM_LEFT_TAG,
-  QUAD_LOOP_BOTTOM_RIGHT_TAG,
+  FOLDED_DIPOLE_OPPOSITE_TAG,
+  FOLDED_DIPOLE_CONNECTOR_TAG,
 };
 import type { UnitSystem } from '../physics/units';
 import {
@@ -88,7 +84,7 @@ import {
   buildTerminatedDeltaWires,
   buildVerticalWhipWires,
   buildInvertedLWires,
-  buildQuadLoopWires,
+  buildFoldedDipoleWires,
   orientationVector,
   type OrientationPreset,
   type Orientation,
@@ -114,6 +110,7 @@ export interface ComparisonSnapshot {
   readonly segments: number;
   readonly vAngle: number;
   readonly legSlope: number;
+  readonly foldedDipoleAperture: number;
   readonly groundId: string;
   readonly groundSigma: number;
   readonly groundEpsilon: number;
@@ -147,6 +144,13 @@ export interface AntennaState {
    * the horizontal, degrees (0..90).
    */
   legSlope: number;
+
+  /**
+   * Folded-dipole only: spacing between the two parallel conductors
+   * (metres). Larger apertures widen impedance bandwidth and eventually
+   * introduce array-like pattern effects. Ignored for other antenna types.
+   */
+  foldedDipoleAperture: number;
 
   /**
    * Far-end terminating resistor (ohms).
@@ -227,6 +231,7 @@ export interface AntennaState {
   setOrientation(o: Orientation): void;
   setVAngle(deg: number): void;
   setLegSlope(deg: number): void;
+  setFoldedDipoleAperture(meters: number): void;
   setTerminatingResistor(ohms: number): void;
   setWhipCounterpoise(enabled: boolean): void;
   setWireRadius(meters: number): void;
@@ -285,6 +290,7 @@ export const useAntennaStore = create<AntennaState>()(
       segments: 21,
       vAngle: 180,
       legSlope: 0,
+      foldedDipoleAperture: FOLDED_DIPOLE_DEFAULT_APERTURE_M,
       terminatingResistor: 0,
       whipCounterpoise: false,
 
@@ -371,13 +377,13 @@ export const useAntennaStore = create<AntennaState>()(
           s.legSlope = 0;
           s.terminatingResistor = 0;
           s.transformerEnabled = false;
-        } else if (type === 'quad-loop') {
-          // Full-wave square loop. `height` = feedpoint height (centre of the
-          // bottom side). The loop extends upward as a true square from there.
+        } else if (type === 'folded-dipole') {
+          // Two parallel half-wave conductors at a single height. Plain
+          // (unterminated) by default — ~300 Ω, dipole-like pattern. A
+          // non-zero terminating resistor makes it a broadband TFD.
           s.vAngle = 180;
           s.legSlope = 0;
           s.terminatingResistor = 0;
-          s.transformerEnabled = false;
         } else if (type === 'sloping-v') {
           // Slope is auto-computed from height and leg length (tips at ground).
           // V-angle snaps to the value giving maximum forward gain; the user
@@ -472,6 +478,16 @@ export const useAntennaStore = create<AntennaState>()(
       setLegSlope: (deg) => set((s) => {
         if (!Number.isFinite(deg)) return;
         s.legSlope = Math.max(0, Math.min(90, deg));
+      }),
+      setFoldedDipoleAperture: (meters) => set((s) => {
+        if (!Number.isFinite(meters)) return;
+        // Clamp to [2 cm, FOLDED_DIPOLE_MAX_APERTURE_M]. The upper bound keeps
+        // the antenna in the genuine folded-dipole regime (a realistic
+        // conductor spacing) and, crucially, in the range where NEC's
+        // close-parallel-wire solution converges within MAX_SEGS_PER_LEG.
+        // Beyond that the structure morphs toward a loop and would need
+        // impractically fine segmentation to solve accurately.
+        s.foldedDipoleAperture = Math.max(0.02, Math.min(FOLDED_DIPOLE_MAX_APERTURE_M, meters));
       }),
       setTerminatingResistor: (ohms) => set((s) => {
         if (!Number.isFinite(ohms)) return;
@@ -672,9 +688,9 @@ function calculateDefaultLength(type: AntennaType, frequencyMHz: number): number
     case 'inverted-l':
       // Total wire (vertical + horizontal) for a resonant quarter-wave.
       return lambda * 0.25 * 0.95;
-    case 'quad-loop':
-      // 1λ perimeter (same convention as the delta loop).
-      return lambda * 1.0;
+    case 'folded-dipole':
+      // Each conductor is a resonant half-wave (same as a standard dipole).
+      return halfWaveLength(frequencyMHz);
     default:
       return halfWaveLength(frequencyMHz);
   }
@@ -715,7 +731,7 @@ export function computeEffectiveSlope(
 
 export function buildWires(
   state: Pick<AntennaState, 'antennaType' | 'length' | 'height' | 'orientation' | 'wireRadius' | 'segments' | 'frequency' | 'vAngle' | 'legSlope'> &
-    Partial<Pick<AntennaState, 'feedlineId' | 'feedlineLength' | 'feedlineOffset' | 'whipCounterpoise'>>,
+    Partial<Pick<AntennaState, 'feedlineId' | 'feedlineLength' | 'feedlineOffset' | 'whipCounterpoise' | 'foldedDipoleAperture'>>,
 ): Wire[] {
   const antennaType = state.antennaType;
   const half = state.length / 2;
@@ -816,10 +832,11 @@ export function buildWires(
     });
   }
 
-  if (antennaType === 'quad-loop') {
-    return buildQuadLoopWires({
+  if (antennaType === 'folded-dipole') {
+    return buildFoldedDipoleWires({
       length: state.length,
       height: h,
+      aperture: state.foldedDipoleAperture ?? FOLDED_DIPOLE_DEFAULT_APERTURE_M,
       orientation: state.orientation,
       wireRadius: state.wireRadius,
       segments: state.segments,
@@ -1159,6 +1176,19 @@ function buildTerminationElements(state: AntennaState, wires: Wire[]) {
     );
   }
 
+  if (state.antennaType === 'folded-dipole' && state.terminatingResistor > 0) {
+    const R = state.terminatingResistor;
+    // Terminated folded dipole (TFD): the resistor sits at the centre of the
+    // conductor opposite the feed. The opposite conductor is emitted with an
+    // odd segment count, so its centre segment is exactly at the midpoint —
+    // no extra wire needed, just an LD-4 load on that one segment.
+    const opposite = wires.find((w) => w.tag === FOLDED_DIPOLE_OPPOSITE_TAG)!;
+    const centreSeg = Math.ceil(opposite.segments / 2);
+    loads.push(
+      { type: 4, wireTag: FOLDED_DIPOLE_OPPOSITE_TAG, segmentStart: centreSeg, segmentEnd: centreSeg, param1: R, param2: 0 },
+    );
+  }
+
   return { extraWires, loads };
 }
 
@@ -1206,6 +1236,7 @@ function createComparisonSnapshot(state: AntennaState): ComparisonSnapshot | nul
     segments: state.segments,
     vAngle: state.vAngle,
     legSlope: state.legSlope,
+    foldedDipoleAperture: state.foldedDipoleAperture,
     groundId: state.groundId,
     groundSigma: state.groundSigma,
     groundEpsilon: state.groundEpsilon,

--- a/src/store/antennaStore.ts
+++ b/src/store/antennaStore.ts
@@ -49,6 +49,11 @@ import {
   INVERTED_L_VERTICAL_TAG,
   INVERTED_L_HORIZONTAL_TAG,
   INVERTED_L_RADIAL_TAG,
+  QUAD_LOOP_TOP_TAG,
+  QUAD_LOOP_LEFT_TAG,
+  QUAD_LOOP_RIGHT_TAG,
+  QUAD_LOOP_BOTTOM_LEFT_TAG,
+  QUAD_LOOP_BOTTOM_RIGHT_TAG,
 } from '../physics/constants';
 
 // Re-export geometry tags for UI and tests.
@@ -69,6 +74,11 @@ export {
   INVERTED_L_VERTICAL_TAG,
   INVERTED_L_HORIZONTAL_TAG,
   INVERTED_L_RADIAL_TAG,
+  QUAD_LOOP_TOP_TAG,
+  QUAD_LOOP_LEFT_TAG,
+  QUAD_LOOP_RIGHT_TAG,
+  QUAD_LOOP_BOTTOM_LEFT_TAG,
+  QUAD_LOOP_BOTTOM_RIGHT_TAG,
 };
 import type { UnitSystem } from '../physics/units';
 import {
@@ -78,6 +88,7 @@ import {
   buildTerminatedDeltaWires,
   buildVerticalWhipWires,
   buildInvertedLWires,
+  buildQuadLoopWires,
   orientationVector,
   type OrientationPreset,
   type Orientation,
@@ -356,6 +367,13 @@ export const useAntennaStore = create<AntennaState>()(
           // section length). If coming from a vertical whip with height=0,
           // restore a sensible mast height so there is a vertical section.
           if (s.height === 0) s.height = INITIAL_HEIGHT;
+          s.vAngle = 180;
+          s.legSlope = 0;
+          s.terminatingResistor = 0;
+          s.transformerEnabled = false;
+        } else if (type === 'quad-loop') {
+          // Full-wave square loop. `height` = top of the loop; the loop hangs
+          // downward from there. Feedpoint at centre of the bottom side.
           s.vAngle = 180;
           s.legSlope = 0;
           s.terminatingResistor = 0;
@@ -654,6 +672,9 @@ function calculateDefaultLength(type: AntennaType, frequencyMHz: number): number
     case 'inverted-l':
       // Total wire (vertical + horizontal) for a resonant quarter-wave.
       return lambda * 0.25 * 0.95;
+    case 'quad-loop':
+      // 1λ perimeter (same convention as the delta loop).
+      return lambda * 1.0;
     default:
       return halfWaveLength(frequencyMHz);
   }
@@ -792,6 +813,17 @@ export function buildWires(
       segments: state.segments,
       frequency: state.frequency,
       counterpoise: state.whipCounterpoise ?? false,
+    });
+  }
+
+  if (antennaType === 'quad-loop') {
+    return buildQuadLoopWires({
+      length: state.length,
+      height: h,
+      orientation: state.orientation,
+      wireRadius: state.wireRadius,
+      segments: state.segments,
+      frequency: state.frequency,
     });
   }
 

--- a/src/store/antennaStore.ts
+++ b/src/store/antennaStore.ts
@@ -372,8 +372,8 @@ export const useAntennaStore = create<AntennaState>()(
           s.terminatingResistor = 0;
           s.transformerEnabled = false;
         } else if (type === 'quad-loop') {
-          // Full-wave square loop. `height` = top of the loop; the loop hangs
-          // downward from there. Feedpoint at centre of the bottom side.
+          // Full-wave square loop. `height` = feedpoint height (centre of the
+          // bottom side). The loop extends upward as a true square from there.
           s.vAngle = 180;
           s.legSlope = 0;
           s.terminatingResistor = 0;

--- a/src/store/antennaStore.ts
+++ b/src/store/antennaStore.ts
@@ -378,12 +378,17 @@ export const useAntennaStore = create<AntennaState>()(
           s.terminatingResistor = 0;
           s.transformerEnabled = false;
         } else if (type === 'folded-dipole') {
-          // Two parallel half-wave conductors at a single height. Plain
-          // (unterminated) by default — ~300 Ω, dipole-like pattern. A
-          // non-zero terminating resistor makes it a broadband TFD.
+          // Two parallel half-wave conductors separated vertically by the
+          // aperture. Plain (unterminated) by default — ~300 Ω, dipole-like
+          // pattern. A non-zero terminating resistor makes it a broadband TFD.
+          // The raw ~300 Ω feedpoint is ~6× the 50 Ω coax reference; enable a
+          // 6:1 impedance-transforming balun by default so the SWR sweep shows
+          // the characteristic flat broadband curve the antenna is known for.
           s.vAngle = 180;
           s.legSlope = 0;
           s.terminatingResistor = 0;
+          s.transformerEnabled = true;
+          s.transformerRatio = 6;
         } else if (type === 'sloping-v') {
           // Slope is auto-computed from height and leg length (tips at ground).
           // V-angle snaps to the value giving maximum forward gain; the user

--- a/tests/foldedDipole.integration.test.ts
+++ b/tests/foldedDipole.integration.test.ts
@@ -1,0 +1,67 @@
+// Integration test: a folded dipole built through selectSimulationInput and
+// solved by the real NEC-2 Wasm engine. Guards two physics claims:
+//   1. An unterminated folded dipole presents ~4× a plain dipole (~300 Ω) and
+//      radiates like a dipole (~2 dBi in free space).
+//   2. Adding a terminating resistor (TFD) dissipates power — gain drops and
+//      the feedpoint impedance changes.
+
+import { describe, expect, it, beforeAll } from 'vitest';
+import { Nec2Engine } from '../src/physics/nec2Engine';
+import { useAntennaStore, selectSimulationInput, type AntennaState } from '../src/store/antennaStore';
+import { halfWaveLength } from '../src/physics/constants';
+import { pathToFileURL } from 'node:url';
+import { resolve } from 'node:path';
+
+const wasmUrl = pathToFileURL(resolve(process.cwd(), 'public/')).href + '/';
+
+const FREQ = 7.1;
+
+function foldedState(overrides: Partial<AntennaState>): AntennaState {
+  return {
+    ...useAntennaStore.getState(),
+    antennaType: 'folded-dipole',
+    length: halfWaveLength(FREQ),
+    height: 10,
+    frequency: FREQ,
+    orientation: 'EW',
+    groundId: 'free',
+    foldedDipoleAperture: 0.3,
+    terminatingResistor: 0,
+    transformerEnabled: false,
+    ...overrides,
+  } as AntennaState;
+}
+
+describe('Folded dipole (real Wasm)', () => {
+  let engine: Nec2Engine;
+
+  beforeAll(async () => {
+    engine = new Nec2Engine({ baseUrl: wasmUrl });
+    await engine.init();
+  }, 30_000);
+
+  it('unterminated: ~4× dipole feedpoint (~300 Ω) and dipole-like gain in free space', async () => {
+    const r = await engine.simulate(selectSimulationInput(foldedState({})));
+
+    expect(Number.isFinite(r.maxGainDbi)).toBe(true);
+    // Free-space dipole gain ~2.15 dBi; the fold does not change the pattern.
+    expect(r.maxGainDbi).toBeGreaterThan(1.8);
+    expect(r.maxGainDbi).toBeLessThan(2.8);
+    // Feedpoint is the folded dipole's hallmark ~4× a plain dipole (~300 Ω).
+    expect(r.impedance.R).toBeGreaterThan(200);
+    expect(r.impedance.R).toBeLessThan(400);
+  }, 30_000);
+
+  it('terminated (TFD): resistor lowers gain and shifts the feedpoint impedance', async () => {
+    const unterminated = await engine.simulate(selectSimulationInput(foldedState({})));
+    const terminated = await engine.simulate(
+      selectSimulationInput(foldedState({ terminatingResistor: 600 })),
+    );
+
+    expect(Number.isFinite(terminated.maxGainDbi)).toBe(true);
+    // The resistor dissipates a substantial fraction of the input power.
+    expect(terminated.maxGainDbi).toBeLessThan(unterminated.maxGainDbi);
+    // Termination measurably changes the feedpoint impedance.
+    expect(Math.abs(terminated.impedance.R - unterminated.impedance.R)).toBeGreaterThan(2);
+  }, 30_000);
+});

--- a/tests/foldedDipole.test.ts
+++ b/tests/foldedDipole.test.ts
@@ -43,20 +43,37 @@ describe('folded dipole geometry', () => {
     expect(tags.filter((t) => t === FOLDED_DIPOLE_CONNECTOR_TAG)).toHaveLength(2);
   });
 
-  it('keeps every wire at the single antenna height (planar, horizontal)', () => {
+  it('places the fed (bottom) conductor at height and the opposite (top) conductor at height + aperture', () => {
     const wires = foldedDipoleWires({ height: 12 });
-    for (const w of wires) {
+    // Fed conductor wires (left half, bridge, right half) must be at z = 12.
+    const fedTags = new Set([DIPOLE_LEFT_TAG, DIPOLE_RIGHT_TAG, FEED_BRIDGE_TAG]);
+    for (const w of wires.filter((w) => fedTags.has(w.tag))) {
       expect(w.start[2]).toBeCloseTo(12, 9);
       expect(w.end[2]).toBeCloseTo(12, 9);
     }
+    // Opposite (top) conductor must be at z = 12 + aperture.
+    const opp = wires.find((w) => w.tag === FOLDED_DIPOLE_OPPOSITE_TAG)!;
+    expect(opp.start[2]).toBeCloseTo(12 + APERTURE, 9);
+    expect(opp.end[2]).toBeCloseTo(12 + APERTURE, 9);
+    // Connectors must span from z = 12 (bottom) to z = 12 + aperture (top).
+    const connectors = wires.filter((w) => w.tag === FOLDED_DIPOLE_CONNECTOR_TAG);
+    for (const c of connectors) {
+      const zLow = Math.min(c.start[2], c.end[2]);
+      const zHigh = Math.max(c.start[2], c.end[2]);
+      expect(zLow).toBeCloseTo(12, 9);
+      expect(zHigh).toBeCloseTo(12 + APERTURE, 9);
+    }
   });
 
-  it('separates the two conductors by exactly the aperture', () => {
+  it('separates the two conductors vertically by exactly the aperture', () => {
     const wires = foldedDipoleWires();
     const fed = wires.find((w) => w.tag === DIPOLE_LEFT_TAG)!;
     const opp = wires.find((w) => w.tag === FOLDED_DIPOLE_OPPOSITE_TAG)!;
-    // EW orientation → conductors offset along the y-axis.
-    expect(Math.abs(opp.start[1] - fed.start[1])).toBeCloseTo(APERTURE, 9);
+    // Vertical separation — top conductor is aperture above the bottom conductor.
+    expect(opp.start[2] - fed.start[2]).toBeCloseTo(APERTURE, 9);
+    // No horizontal offset between conductors for vertical aperture.
+    expect(opp.start[0]).toBeCloseTo(fed.start[0], 9);
+    expect(opp.start[1]).toBeCloseTo(fed.start[1], 9);
   });
 
   it('gives the opposite conductor an odd segment count (precise centre for the resistor)', () => {

--- a/tests/foldedDipole.test.ts
+++ b/tests/foldedDipole.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+import {
+  useAntennaStore,
+  buildWires,
+  selectSimulationInput,
+  DIPOLE_LEFT_TAG,
+  DIPOLE_RIGHT_TAG,
+  FEED_BRIDGE_TAG,
+  FOLDED_DIPOLE_OPPOSITE_TAG,
+  FOLDED_DIPOLE_CONNECTOR_TAG,
+  type AntennaState,
+} from '../src/store/antennaStore';
+
+const FREQ = 7.1;
+const APERTURE = 0.5;
+
+function foldedDipoleWires(overrides: Partial<Parameters<typeof buildWires>[0]> = {}) {
+  return buildWires({
+    antennaType: 'folded-dipole',
+    length: 20,
+    height: 10,
+    orientation: 'EW',
+    wireRadius: 0.001,
+    segments: 21,
+    frequency: FREQ,
+    vAngle: 180,
+    legSlope: 0,
+    foldedDipoleAperture: APERTURE,
+    ...overrides,
+  });
+}
+
+describe('folded dipole geometry', () => {
+  it('emits the six expected wires with the correct tags', () => {
+    const wires = foldedDipoleWires();
+    expect(wires).toHaveLength(6);
+    const tags = wires.map((w) => w.tag);
+    expect(tags).toContain(DIPOLE_LEFT_TAG);
+    expect(tags).toContain(DIPOLE_RIGHT_TAG);
+    expect(tags).toContain(FEED_BRIDGE_TAG);
+    expect(tags).toContain(FOLDED_DIPOLE_OPPOSITE_TAG);
+    // Two connectors share the connector tag.
+    expect(tags.filter((t) => t === FOLDED_DIPOLE_CONNECTOR_TAG)).toHaveLength(2);
+  });
+
+  it('keeps every wire at the single antenna height (planar, horizontal)', () => {
+    const wires = foldedDipoleWires({ height: 12 });
+    for (const w of wires) {
+      expect(w.start[2]).toBeCloseTo(12, 9);
+      expect(w.end[2]).toBeCloseTo(12, 9);
+    }
+  });
+
+  it('separates the two conductors by exactly the aperture', () => {
+    const wires = foldedDipoleWires();
+    const fed = wires.find((w) => w.tag === DIPOLE_LEFT_TAG)!;
+    const opp = wires.find((w) => w.tag === FOLDED_DIPOLE_OPPOSITE_TAG)!;
+    // EW orientation → conductors offset along the y-axis.
+    expect(Math.abs(opp.start[1] - fed.start[1])).toBeCloseTo(APERTURE, 9);
+  });
+
+  it('gives the opposite conductor an odd segment count (precise centre for the resistor)', () => {
+    const wires = foldedDipoleWires();
+    const opp = wires.find((w) => w.tag === FOLDED_DIPOLE_OPPOSITE_TAG)!;
+    expect(opp.segments % 2).toBe(1);
+  });
+
+  it('forms a closed loop — connector endpoints coincide with both conductors', () => {
+    const wires = foldedDipoleWires();
+    const left = wires.find((w) => w.tag === DIPOLE_LEFT_TAG)!;
+    const opp = wires.find((w) => w.tag === FOLDED_DIPOLE_OPPOSITE_TAG)!;
+    const connectors = wires.filter((w) => w.tag === FOLDED_DIPOLE_CONNECTOR_TAG);
+    // One connector must touch the fed conductor's left end and the opposite
+    // conductor's matching end.
+    const touchesFedLeft = connectors.some(
+      (c) => c.start.every((v, i) => Math.abs(v - left.start[i]) < 1e-9),
+    );
+    const touchesOppLeft = connectors.some(
+      (c) => c.end.every((v, i) => Math.abs(v - opp.start[i]) < 1e-9),
+    );
+    expect(touchesFedLeft).toBe(true);
+    expect(touchesOppLeft).toBe(true);
+  });
+});
+
+describe('folded dipole excitation and termination', () => {
+  function fullState(overrides: Partial<AntennaState>): AntennaState {
+    return {
+      ...useAntennaStore.getState(),
+      antennaType: 'folded-dipole',
+      length: 20,
+      height: 10,
+      frequency: FREQ,
+      orientation: 'EW',
+      foldedDipoleAperture: APERTURE,
+      terminatingResistor: 0,
+      ...overrides,
+    } as AntennaState;
+  }
+
+  it('feeds the bridge at the centre of the lower conductor', () => {
+    const input = selectSimulationInput(fullState({}));
+    expect(input.excitation).toEqual({ wireTag: FEED_BRIDGE_TAG, segment: 1 });
+  });
+
+  it('adds no termination load when unterminated', () => {
+    const input = selectSimulationInput(fullState({ terminatingResistor: 0 }));
+    const oppLoads = (input.loads ?? []).filter((l) => l.wireTag === FOLDED_DIPOLE_OPPOSITE_TAG);
+    expect(oppLoads).toHaveLength(0);
+  });
+
+  it('places one LD-4 resistor on the opposite conductor centre when terminated', () => {
+    const state = fullState({ terminatingResistor: 600 });
+    const input = selectSimulationInput(state);
+    const oppLoads = (input.loads ?? []).filter((l) => l.wireTag === FOLDED_DIPOLE_OPPOSITE_TAG);
+    expect(oppLoads).toHaveLength(1);
+
+    const wires = buildWires(state);
+    const opp = wires.find((w) => w.tag === FOLDED_DIPOLE_OPPOSITE_TAG)!;
+    const centre = Math.ceil(opp.segments / 2);
+    expect(oppLoads[0]).toMatchObject({
+      type: 4,
+      segmentStart: centre,
+      segmentEnd: centre,
+      param1: 600,
+    });
+  });
+});


### PR DESCRIPTION
Adds the **Folded Dipole** from `docs/future-antenna-designs.md`. (This PR previously implemented a Quad Loop; that was dropped because it required the top of the loop ~λ/4 above the feedpoint, which isn't practical for the masts this tool targets.)

## What is a Folded Dipole?

Two parallel half-wave conductors joined at both ends, forming a narrow vertical loop. The **bottom (fed) conductor** sits at the antenna height; the **top (un-fed) conductor** is `aperture` metres above it. Short vertical connectors join the ends.

```
 ┌──────────────────────────────┐   opposite conductor  ← z = height + aperture
 │                              │     (optional resistor at centre for TFD)
 └────────────┤feed├────────────┘   fed conductor       ← z = height
              ↕ aperture (vertical spacing, default 0.3 m)
```

- **`length`** = each conductor's length (≈½λ resonant, same as a dipole — the fold doesn't change resonant length).
- **Aperture** (vertical spacing between conductors) is adjustable, default 0.3 m, capped at 0.5 m. The top conductor only rises ≤ 0.5 m above the feedpoint, so the antenna remains fully buildable at modest heights.
- **Feedpoint** ≈ 4× a plain dipole (~300 Ω). A **6:1 impedance-transforming balun is enabled by default**, transforming this to ~50 Ω for direct coax connection and showing the characteristic flat broadband SWR curve.
- **Gain/pattern** identical to a dipole when unterminated.

## Is there a resistor? (yes — optionally)

A plain folded dipole has no resistor. The **terminated folded dipole (TFD)** places a resistor at the centre of the conductor opposite the feed, which broadbands the SWR at the cost of efficiency (≈ half the power is dissipated). This is exposed via the existing terminating-resistor control: `0` = classic folded dipole, `> 0` = broadband TFD.

## NEC modelling note

Two long, closely-spaced parallel wires converge slowly in NEC's thin-wire kernel. Segmentation is tied to **half the aperture** (the empirical point where the free-space gain converges to the dipole value), and the aperture is capped at 0.5 m so this stays within `MAX_SEGS_PER_LEG`. Verified across 40/20/10 m: gain 1.9–2.6 dBi (dipole-like) and R ≈ 270–335 Ω (≈4× a dipole).

## Changes

| File | What changed |
|------|-------------|
| `src/physics/types.ts` | `'quad-loop'` → `'folded-dipole'` in `AntennaType` |
| `src/physics/constants.ts` | Folded-dipole tags (17–18), `referenceLength` (½λ), default/max aperture constants |
| `src/store/antennaGeometry.ts` | `buildFoldedDipoleWires()` — 6 wires, **vertical aperture** (bottom fed at z=height, top opposite at z=height+aperture), aperture-tied segmentation |
| `src/store/antennaStore.ts` | `foldedDipoleAperture` state + setter; **`transformerEnabled=true, transformerRatio=6` on type switch** so SWR sweep shows broadband curve by default; TFD resistor placement; comparison snapshot |
| `src/components/Panel/DipoleControl.tsx` | Dropdown option, `½λ` preset (updated tooltip explaining default 6:1 balun), aperture slider (updated hint: "vertical spacing"), height label updated to "Bottom conductor height / feedpoint", TFD resistor control + hints |
| `src/components/Scene/useDipoleGeometry.ts` | Pass aperture through to the 3D geometry |
| `docs/antenna-spec.md` | §7 rewritten as Folded Dipole with vertical aperture geometry and default balun SWR convention |
| `docs/future-antenna-designs.md` | Removed Folded Dipole entry |
| `tests/foldedDipole*.test.ts` | New geometry/store unit tests (updated for vertical aperture) + real-Wasm integration test |

## Test results

All **546 tests pass** (536 + 10 new); type-check, lint, and production build clean.

https://claude.ai/code/session_01SecSmXDcfDiyDMFUk324bJ