### PR TITLE
SWR chart: hide raw curve when balun active; post-balun bandwidth stats

### DIFF
--- a/src/components/Charts/SWRChart.tsx
+++ b/src/components/Charts/SWRChart.tsx
@@ -94,7 +94,10 @@ export function SWRChart() {
     [comparisonActive, frequency, reference, sweep]
   );
 
-  const stats = useMemo(() => computeStats(sweep), [sweep]);
+  const stats = useMemo(
+    () => computeStats({ sweep, transformerInDisplay, transformerRatio }),
+    [sweep, transformerInDisplay, transformerRatio],
+  );
 
   const yMax = useMemo(
     () =>
@@ -119,9 +122,8 @@ export function SWRChart() {
         chartText,
         chartGrid,
         comparisonActive,
-        transformerEnabled,
       }),
-    [accent, chartGrid, chartText, comparisonActive, transformerEnabled, frequency, xBounds, yMax, stats]
+    [accent, chartGrid, chartText, comparisonActive, frequency, xBounds, yMax, stats]
   );
 
   if (!result || sweep.length === 0) {

--- a/src/components/Charts/swrChartUtils.ts
+++ b/src/components/Charts/swrChartUtils.ts
@@ -53,37 +53,38 @@ export function computeChartData({
     });
   }
 
-  const rawLabel = comparisonActive
-    ? (transformerInDisplay ? 'Current (raw)' : 'Current')
-    : (transformerInDisplay ? 'Raw (vs 50 Ω)' : 'SWR (vs 50 Ω)');
-
-  datasets.push({
-    label: rawLabel,
-    data: sweep.map((point) => ({ x: point.frequencyMHz, y: point.swr })),
-    borderColor: accent,
-    backgroundColor: currentFill,
-    fill: false,
-    tension: 0.18,
-    pointRadius: 0,
-    pointHoverRadius: 3,
-    pointBackgroundColor: accent,
-  });
-
+  // When the balun/transformer is active, show ONLY the post-balun curve.
+  // The raw curve is suppressed — it can always be recovered by disabling
+  // the balun, and including both makes the post-balun curve unreadably
+  // compressed on the y-axis.
   if (transformerInDisplay) {
+    const label = comparisonActive ? `Current (after ${transformerRatio}:1)` : 'SWR (vs 50 Ω)';
     datasets.push({
-      label: `After ${transformerRatio}:1 xfmr`,
+      label,
       data: sweep.map((point) => ({
         x: point.frequencyMHz,
         y: computeSwr({ R: point.R / transformerRatio, X: point.X / transformerRatio }),
       })),
-      borderColor: 'rgba(80, 200, 120, 0.9)',
-      backgroundColor: 'rgba(80, 200, 120, 0.1)',
+      borderColor: accent,
+      backgroundColor: currentFill,
       fill: false,
       tension: 0.18,
       pointRadius: 0,
       pointHoverRadius: 3,
-      pointBackgroundColor: '#50c878',
-      borderDash: [6, 3],
+      pointBackgroundColor: accent,
+    });
+  } else {
+    const rawLabel = comparisonActive ? 'Current' : 'SWR (vs 50 Ω)';
+    datasets.push({
+      label: rawLabel,
+      data: sweep.map((point) => ({ x: point.frequencyMHz, y: point.swr })),
+      borderColor: accent,
+      backgroundColor: currentFill,
+      fill: false,
+      tension: 0.18,
+      pointRadius: 0,
+      pointHoverRadius: 3,
+      pointBackgroundColor: accent,
     });
   }
 
@@ -131,32 +132,54 @@ export interface SWRStats {
   highClipped: boolean;
 }
 
-export function computeStats(sweep: readonly SweepPoint[]): SWRStats | null {
+export interface ComputeStatsArgs {
+  sweep: readonly SweepPoint[];
+  /** When true, evaluate min SWR and 2:1 bandwidth on the post-balun impedance. */
+  transformerInDisplay?: boolean;
+  transformerRatio?: number;
+}
+
+export function computeStats({
+  sweep,
+  transformerInDisplay = false,
+  transformerRatio = 1,
+}: ComputeStatsArgs): SWRStats | null {
   if (sweep.length === 0) return null;
+
+  // Effective SWR after the optional transformer.
+  const effectiveSwr = (pt: SweepPoint): number =>
+    transformerInDisplay
+      ? computeSwr({ R: pt.R / transformerRatio, X: pt.X / transformerRatio })
+      : pt.swr;
+
   let minSWR = Infinity;
   let minFreq = 0;
   for (const pt of sweep) {
-    if (pt.swr < minSWR) {
-      minSWR = pt.swr;
+    const s = effectiveSwr(pt);
+    if (s < minSWR) {
+      minSWR = s;
       minFreq = pt.frequencyMHz;
     }
   }
+
   let fLow: number | null = null;
   let fHigh: number | null = null;
   for (let i = 0; i < sweep.length - 1; i++) {
     const p1 = sweep[i];
     const p2 = sweep[i + 1];
-    if (p1.swr >= 2 && p2.swr <= 2) {
-      const t = (2 - p1.swr) / (p2.swr - p1.swr);
+    const s1 = effectiveSwr(p1);
+    const s2 = effectiveSwr(p2);
+    if (s1 >= 2 && s2 <= 2) {
+      const t = (2 - s1) / (s2 - s1);
       fLow = p1.frequencyMHz + t * (p2.frequencyMHz - p1.frequencyMHz);
-    } else if (p1.swr <= 2 && p2.swr >= 2) {
-      const t = (2 - p1.swr) / (p2.swr - p1.swr);
+    } else if (s1 <= 2 && s2 >= 2) {
+      const t = (2 - s1) / (s2 - s1);
       fHigh = p1.frequencyMHz + t * (p2.frequencyMHz - p1.frequencyMHz);
     }
   }
 
-  const lowClipped = fLow === null && sweep[0].swr <= 2;
-  const highClipped = fHigh === null && sweep[sweep.length - 1].swr <= 2;
+  const lowClipped = fLow === null && effectiveSwr(sweep[0]) <= 2;
+  const highClipped = fHigh === null && effectiveSwr(sweep[sweep.length - 1]) <= 2;
 
   if (lowClipped) fLow = sweep[0].frequencyMHz;
   if (highClipped) fHigh = sweep[sweep.length - 1].frequencyMHz;
@@ -187,14 +210,18 @@ export function computeYMax({
   let anyBelow2 = false;
 
   for (let i = 0; i < sweep.length; i++) {
-    const v = sweep[i].swr;
-    if (v > maxVal) maxVal = v;
-    if (v <= 2) anyBelow2 = true;
-
+    // When the transformer is active we only render the post-balun curve,
+    // so only consider those values for the y-axis range. Including the raw
+    // SWR (which can be ~6:1 for a folded dipole) would compress the
+    // post-balun curve to an unreadable sliver at the bottom of the chart.
     if (transformerInDisplay) {
       const v2 = computeSwr({ R: sweep[i].R / transformerRatio, X: sweep[i].X / transformerRatio });
       if (v2 > maxVal) maxVal = v2;
       if (v2 <= 2) anyBelow2 = true;
+    } else {
+      const v = sweep[i].swr;
+      if (v > maxVal) maxVal = v;
+      if (v <= 2) anyBelow2 = true;
     }
   }
 
@@ -224,7 +251,6 @@ export interface ComputeOptionsArgs {
   chartText: string;
   chartGrid: string;
   comparisonActive: boolean;
-  transformerEnabled: boolean;
 }
 
 export function computeOptions({
@@ -236,7 +262,6 @@ export function computeOptions({
   chartText,
   chartGrid,
   comparisonActive,
-  transformerEnabled,
 }: ComputeOptionsArgs): ChartOptions<'line'> {
   const annotations: Record<string, AnnotationOptions> = {
     swr2: {
@@ -315,7 +340,11 @@ export function computeOptions({
     },
     plugins: {
       legend: {
-        display: comparisonActive || transformerEnabled,
+        // Show the legend only when multiple curves coexist: comparison mode
+        // has two curves (reference + current). When the transformer is active
+        // outside comparison mode there is only one curve (post-balun), so the
+        // legend would just repeat the axis title and is suppressed.
+        display: comparisonActive,
         labels: { color: chartText },
       },
       annotation: {


### PR DESCRIPTION
## Problem

When a balun/transformer is enabled (e.g. the default 6:1 for the folded dipole), the chart showed **both** the raw pre-balun SWR curve (~6:1) and the post-balun curve (~1:1). The raw curve dominated the y-axis scale, compressing the post-balun curve into an unreadable sliver at the bottom. The "2:1 BW" bandwidth stat was also computed from the raw (pre-balun) SWR, which is meaningless when the whole point of the balun is to match to 50 Ω.

## Fix

**When the balun/transformer is active:**

- **Raw curve suppressed** — only the post-balun SWR curve is shown. The raw curve is trivially recoverable by disabling the balun in the transformer control.
- **y-axis scaled to post-balun values** — the chart uses the full height for the curve you actually care about.
- **Min SWR and 2:1 bandwidth computed from post-balun impedance** — the bandwidth readout now shows the usable bandwidth behind the balun.
- **Legend hidden** — with only one curve there's nothing to label; suppressing the legend reclaims vertical space.

**In comparison mode** the reference curve (always raw) is preserved alongside the post-balun current curve, and the legend is shown so both datasets are identifiable.

## Files changed

| File | Change |
|------|--------|
| `src/components/Charts/swrChartUtils.ts` | `computeChartData`: emit only post-balun curve when transformer active; `computeStats`: accept transformer params, evaluate min/bandwidth on post-balun SWR; `computeYMax`: scale to post-balun values only; `computeOptions`: remove `transformerEnabled` param (legend now keyed to `comparisonActive` only) |
| `src/components/Charts/SWRChart.tsx` | Pass `transformerInDisplay`/`transformerRatio` to `computeStats`; remove `transformerEnabled` from `computeOptions` call |

All 546 tests pass; type-check clean.

https://claude.ai/code/session_01SecSmXDcfDiyDMFUk324bJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SecSmXDcfDiyDMFUk324bJ)_