### PR TITLE
⚡ Bolt: Optimize wire tip lookups in store

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -134,3 +134,8 @@
 
 **Learning:** When checking string membership against a static, known list of options, defining an array inline and using `.includes()` requires reallocation on every execution and runs in $O(N)$ time. By extracting the static array into a module-scoped `Set`, we avoid memory reallocation and change the check to $O(1)$ time, yielding a measurable performance boost.
 **Action:** Always extract static membership checks (like enum-like string arrays) into a module-scoped `Set` and use `Set.has()` in frequently-executed render paths or hot loops.
+
+## 2025-05-18 - Loop Fusions and Array Find optimizations
+
+**Learning:** Finding individual wires in an array generated from Three.js vectors inside `antennaStore.ts` using `.find` or `.filter` requires multiple $O(N)$ allocations and passes over the array.
+**Action:** Replace multiple separate `.find` and `.filter` calls on array elements with a single `for` loop that stores the specific matches by evaluating all cases and executing early `break` statements. This removes functional allocation overhead inside hot store selectors.

--- a/src/store/antennaStore.ts
+++ b/src/store/antennaStore.ts
@@ -1121,10 +1121,15 @@ function buildTerminationElements(state: AntennaState, wires: Wire[]) {
     // sharing the leg's tag. By convention `buildSlopingVWires` emits the
     // LEFT leg tip→apex (so the first sub-wire's `.start` is the tip) and
     // the RIGHT leg apex→tip (so the last sub-wire's `.end` is the tip).
-    const leftLegWires  = wires.filter((w) => w.tag === DIPOLE_LEFT_TAG);
-    const rightLegWires = wires.filter((w) => w.tag === DIPOLE_RIGHT_TAG);
-    const leftTip  = leftLegWires[0]!.start;
-    const rightTip = rightLegWires[rightLegWires.length - 1]!.end;
+    let firstLeft: Wire | undefined;
+    let lastRight: Wire | undefined;
+    for (let i = 0; i < wires.length; i++) {
+      const w = wires[i];
+      if (w.tag === DIPOLE_LEFT_TAG && !firstLeft) firstLeft = w;
+      if (w.tag === DIPOLE_RIGHT_TAG) lastRight = w;
+    }
+    const leftTip  = firstLeft!.start;
+    const rightTip = lastRight!.end;
 
     extraWires.push(
       {
@@ -1164,10 +1169,16 @@ function buildTerminationElements(state: AntennaState, wires: Wire[]) {
     // centreRight → rightCorner so the inner end is the wire's `.start`.
     // The bridge runs leftInner → rightInner, joining the two halves
     // electrically through the resistor.
-    const leftHalfBase  = wires.find((w) => w.tag === TERMINATED_DELTA_LEFT_BASE_TAG)!;
-    const rightHalfBase = wires.find((w) => w.tag === TERMINATED_DELTA_RIGHT_BASE_TAG)!;
-    const leftInner  = leftHalfBase.end;
-    const rightInner = rightHalfBase.start;
+    let leftHalfBase: Wire | undefined;
+    let rightHalfBase: Wire | undefined;
+    for (let i = 0; i < wires.length; i++) {
+      const w = wires[i];
+      if (w.tag === TERMINATED_DELTA_LEFT_BASE_TAG) leftHalfBase = w;
+      else if (w.tag === TERMINATED_DELTA_RIGHT_BASE_TAG) rightHalfBase = w;
+      if (leftHalfBase && rightHalfBase) break;
+    }
+    const leftInner  = leftHalfBase!.end;
+    const rightInner = rightHalfBase!.start;
 
     extraWires.push({
       start: leftInner,

--- a/src/store/antennaStore.ts
+++ b/src/store/antennaStore.ts
@@ -1173,8 +1173,8 @@ function buildTerminationElements(state: AntennaState, wires: Wire[]) {
     let rightHalfBase: Wire | undefined;
     for (let i = 0; i < wires.length; i++) {
       const w = wires[i];
-      if (w.tag === TERMINATED_DELTA_LEFT_BASE_TAG) leftHalfBase = w;
-      else if (w.tag === TERMINATED_DELTA_RIGHT_BASE_TAG) rightHalfBase = w;
+      if (w.tag === TERMINATED_DELTA_LEFT_BASE_TAG && !leftHalfBase) leftHalfBase = w;
+      else if (w.tag === TERMINATED_DELTA_RIGHT_BASE_TAG && !rightHalfBase) rightHalfBase = w;
       if (leftHalfBase && rightHalfBase) break;
     }
     const leftInner  = leftHalfBase!.end;


### PR DESCRIPTION
💡 **What:** Replaced inefficient `.filter()` and `.find()` chained method calls used to locate wire tips (`sloping-v`) and base tags (`TERMINATED_DELTA_LEFT_BASE_TAG`, etc.) with single-pass `for` loops and early `break` statements in `antennaStore.ts`.
🎯 **Why:** To reduce intermediate array allocations, memory footprint, and multiple loop iterations when re-evaluating antenna geometries from the Zustand store.
📊 **Impact:** Reduces redundant $O(N)$ array operations to a single $O(N)$ pass, slightly improving geometry recalculation speed and lowering GC overhead.
🔬 **Measurement:** Code logic and geometry validity has been fully tested and confirmed via the suite. Test timings are identical or slightly improved.

---
*PR created automatically by Jules for task [11357516047494711226](https://jules.google.com/task/11357516047494711226) started by @2fst4u*