### PR TITLE
📚 Archivist: Update README to reflect newly added antenna topologies

### DIFF
--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -37,3 +37,8 @@
 
 **Learning:** The "V-Beam" terminology was previously added to the "Sloping V" documentation to clarify that they use the same geometry function. However, the user clarified that V-beam antennas are not actually used anymore in the project.
 **Action:** All references to "V-Beam" have been entirely removed from the documentation (`docs/antenna-model-spec.md`, `docs/antenna-spec.md`) and the codebase (`src/store/antennaGeometry.ts`) to avoid confusion and properly reflect the current state of the application.
+
+## 2025-05-25 - README Scope Completeness
+
+**Learning:** The `README.md` file's "Current scope" list was missing several antenna topologies (`vertical whips`, `inverted-Ls`, and `folded dipoles`) that are fully implemented in the engine (`src/physics/types.ts` `AntennaType`) and documented in `docs/antenna-spec.md`. The README capabilities summary frequently drifts from active implementations.
+**Action:** Updated `README.md` to perfectly match the `AntennaType` definitions to accurately represent the application's capabilities.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A 3D, responsive, physics-accurate visualiser for HF antenna radiation patterns,
 
 While this repository is fully open source and developers are welcome to fork or clone it to run locally, the primary way to use the application is via the hosted URL at **[www.gain.observer](https://www.gain.observer/)**.
 
-Current scope (Phase 1): horizontal dipoles, inverted Vs, sloping Vs, delta loops, and terminated delta loops, 1.8–30 MHz, real-ground support, offset feed points, feedlines & baluns, comparison mode, SWR/polar cut charts, dark/light theming, metric/imperial toggle.
+Current scope (Phase 1): horizontal dipoles, inverted Vs, sloping Vs, delta loops, terminated delta loops, vertical whips, inverted-Ls, and folded dipoles, 1.8–30 MHz, real-ground support, offset feed points, feedlines & baluns, comparison mode, SWR/polar cut charts, dark/light theming, metric/imperial toggle.
 
 ## Stack
 


### PR DESCRIPTION
💡 Problem: The `README.md` file's "Current scope" list was missing several antenna topologies (`vertical whips`, `inverted-Ls`, and `folded dipoles`) that are fully implemented in the engine (`src/physics/types.ts` `AntennaType`) and documented in `docs/antenna-spec.md`. The README capabilities summary frequently drifts from active implementations.
🎯 Fix: Updated `README.md` to perfectly match the `AntennaType` definitions to accurately represent the application's capabilities. Also updated the `.jules/archivist.md` journal.
🧪 Verification: Formatted via `prettier` and validated tests via `npm run test` and `npm run lint`.
🔎 Scope: Strictly constrained to documentation changes (`README.md` and `.jules/archivist.md`). No application behavior or logic has been modified.

---
*PR created automatically by Jules for task [1048773746075879067](https://jules.google.com/task/1048773746075879067) started by @2fst4u*