### PR TITLE
📚 Archivist: Update README scope to include all supported antennas

### DIFF
--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -37,3 +37,7 @@
 
 **Learning:** The "V-Beam" terminology was previously added to the "Sloping V" documentation to clarify that they use the same geometry function. However, the user clarified that V-beam antennas are not actually used anymore in the project.
 **Action:** All references to "V-Beam" have been entirely removed from the documentation (`docs/antenna-model-spec.md`, `docs/antenna-spec.md`) and the codebase (`src/store/antennaGeometry.ts`) to avoid confusion and properly reflect the current state of the application.
+
+## 2025-05-26 - README phase 1 scope is outdated
+**Learning:** The `README.md` listed phase 1 scope and did not include `vertical-whip`, `inverted-l`, and `folded-dipole` which are supported in `AntennaType` type now.
+**Action:** Always verify `AntennaType` against `README.md` or other files that hardcode supported types.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A 3D, responsive, physics-accurate visualiser for HF antenna radiation patterns,
 
 While this repository is fully open source and developers are welcome to fork or clone it to run locally, the primary way to use the application is via the hosted URL at **[www.gain.observer](https://www.gain.observer/)**.
 
-Current scope (Phase 1): horizontal dipoles, inverted Vs, sloping Vs, delta loops, and terminated delta loops, 1.8–30 MHz, real-ground support, offset feed points, feedlines & baluns, comparison mode, SWR/polar cut charts, dark/light theming, metric/imperial toggle.
+Current scope (Phase 1): horizontal dipoles, inverted Vs, sloping Vs, delta loops, terminated delta loops, vertical whips, inverted Ls, and folded dipoles, 1.8–30 MHz, real-ground support, offset feed points, feedlines & baluns, comparison mode, SWR/polar cut charts, dark/light theming, metric/imperial toggle.
 
 ## Stack
 


### PR DESCRIPTION
💡 Problem: The `README.md` listed its "Current scope (Phase 1)" antennas but did not include `vertical-whip`, `inverted-l`, and `folded-dipole`, which are supported in the codebase.
🎯 Fix: Appended `vertical whips`, `inverted Ls`, and `folded dipoles` to the phase 1 scope list in `README.md`.
🧪 Verification: Read the updated README file, and ensured `npm run lint` and `npm run test` passed. Also correctly appended learnings to `.jules/archivist.md` instead of overwriting it.
🔎 Scope: Only modified `README.md` and `.jules/archivist.md`.

---
*PR created automatically by Jules for task [1613243743108293010](https://jules.google.com/task/1613243743108293010) started by @2fst4u*