### PR TITLE
🎨 Palette: Add ARIA labels to dynamic range inputs

### DIFF
--- a/src/components/Panel/DipoleControl.tsx
+++ b/src/components/Panel/DipoleControl.tsx
@@ -258,6 +258,7 @@ export function DipoleControl() {
         max={maxHeight}
         step={units === 'metric' ? 0.5 : 1}
         value={dispHeight}
+        aria-label={isVerticalWhip ? 'Base height above ground' : isInvertedL ? 'Mast / bend-point height' : isFoldedDipole ? 'Bottom conductor height / feedpoint' : 'Height above ground'}
         onChange={(e) => {
           const val = parseFloat(e.target.value);
           if (!isNaN(val)) setHeight(fromDisplayLength(val, units));

--- a/src/components/Panel/DisplayControl.tsx
+++ b/src/components/Panel/DisplayControl.tsx
@@ -58,6 +58,7 @@ export function DisplayControl() {
         id="dynamic-range"
         type="range" min={10} max={50} step={1}
         value={dbRange}
+        aria-label="Dynamic range in dB"
         onChange={(e) => setDbRange(parseInt(e.target.value, 10))}
       />
 
@@ -66,6 +67,7 @@ export function DisplayControl() {
         id="color-max"
         type="range" min={-20} max={30} step={1}
         value={colorMaxDb}
+        aria-label="Color max in dBi"
         onChange={(e) => setColorMaxDb(parseInt(e.target.value, 10))}
       />
 
@@ -74,6 +76,7 @@ export function DisplayControl() {
         id="pattern-scale"
         type="range" min={0.3} max={3} step={0.1}
         value={patternScale}
+        aria-label="Pattern scale multiplier"
         onChange={(e) => setPatternScale(parseFloat(e.target.value))}
       />
 

--- a/src/components/Panel/FeedlineControl.tsx
+++ b/src/components/Panel/FeedlineControl.tsx
@@ -134,6 +134,7 @@ export function FeedlineControl() {
                   max={dispOffsetLimit}
                   step={units === 'metric' ? 0.05 : 0.25}
                   value={dispOffset}
+                  aria-label="Feedline attachment offset"
                   aria-describedby="feedline-offset-hint"
                   onChange={(e) => {
                     const val = parseFloat(e.target.value);


### PR DESCRIPTION
Added clean `aria-label` values to all range sliders (`type="range"`) that previously relied on visual labels containing dynamic, interpolated state values. This improves the screen reader experience by eliminating redundant, duplicate announcements of the slider's value.

---
*PR created automatically by Jules for task [9412116179780707086](https://jules.google.com/task/9412116179780707086) started by @2fst4u*