### PR TITLE
📚 Archivist: Update antenna-model-spec to include missing antenna topologies

### DIFF
--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -41,3 +41,7 @@
 ## 2025-05-26 - README phase 1 scope is outdated
 **Learning:** The `README.md` listed phase 1 scope and did not include `vertical-whip`, `inverted-l`, and `folded-dipole` which are supported in `AntennaType` type now.
 **Action:** Always verify `AntennaType` against `README.md` or other files that hardcode supported types.
+
+## 2025-05-27 - Antenna Model Spec Drift
+**Learning:** `docs/antenna-model-spec.md` drifted and omitted several supported antenna types (Vertical Whip, Inverted-L, Folded Dipole) under "2. Antenna Type Definitions". These types were already documented in the codebase, `README.md`, and `docs/antenna-spec.md`, leading to an incomplete representation of the physics model.
+**Action:** The missing topologies (Vertical Whip, Inverted-L, Folded Dipole) were added to `docs/antenna-model-spec.md` to accurately match reality.

--- a/docs/antenna-model-spec.md
+++ b/docs/antenna-model-spec.md
@@ -70,6 +70,30 @@ We use the standard NEC-2 Cartesian coordinate system:
 - **Feedpoint**: The apex.
 - **Termination Support**: A single resistor across the base-centre gap (not two resistors to ground). Designed for broadband flat impedance, not directionality — the antenna remains roughly broadside-bidirectional, like a delta loop but aperiodic.
 
+### 2.6 Vertical Whip
+
+- **Structure**: A single vertical wire extending upwards from the base.
+- **Length**: The length of the vertical wire.
+- **Height**: The height of the base above ground (typically 0).
+- **Feedpoint**: Base-fed.
+- **Balanced**: No (unbalanced, driven against ground or radials).
+
+### 2.7 Inverted-L
+
+- **Structure**: A vertical wire section from the base up to a bend point, followed by a horizontal top-loading section.
+- **Length**: Total wire length (vertical + horizontal combined).
+- **Height**: The bend-point height above ground.
+- **Feedpoint**: Base-fed on the vertical section.
+- **Balanced**: No.
+
+### 2.8 Folded Dipole
+
+- **Structure**: Two parallel half-wave conductors joined at both ends, forming a narrow rectangular loop.
+- **Length**: The length of each conductor.
+- **Height**: The height of the bottom fed conductor.
+- **Feedpoint**: Center-fed on the bottom conductor.
+- **Balanced**: Yes.
+
 ---
 
 ## 3. "Terminated" Antennas


### PR DESCRIPTION
💡 Problem: The `docs/antenna-model-spec.md` document had drifted and omitted definitions for `Vertical Whip`, `Inverted-L`, and `Folded Dipole` topologies under the "Antenna Type Definitions" section, despite these being fully supported and implemented in the codebase.
🎯 Fix: Added the missing topologies to `docs/antenna-model-spec.md` with structured definitions matching the existing document style, and recorded a critical learning entry in the `.jules/archivist.md` journal.
🧪 Verification: Verified changes via `npm run lint`, `npm run build`, and `npm run test`.
🔎 Scope: Only documentation (`docs/antenna-model-spec.md`) and the journal (`.jules/archivist.md`) were updated. No application logic was modified.

---
*PR created automatically by Jules for task [2804730090227501505](https://jules.google.com/task/2804730090227501505) started by @2fst4u*