### PR TITLE
🔭 Scout: Upgrade fragments to semantic sections in StatsReadout

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -27,3 +27,7 @@
 
 **Learning:** When generating a plan as Scout, do not include conditional logic or exploratory tasks in the final execution plan. Also ensure that testing and linting steps are explicitly listed before the pre-commit step, and that the pre-commit step itself strictly follows the required format.
 **Action:** Always fully explore the codebase first, identify the specific DOM element and file to edit, and then formulate a plan with exact steps, including a dedicated test/lint verification step before the pre-commit step.
+## 2024-05-27 - Upgrading Fragments to Semantic Sections
+
+**Learning:** When React components return fragments (`<>...</>`) containing headings (like `<h3>`), these structures are rendered as "div soup" or flat content blocks in the DOM, which obscures the document outline for search engines and screen readers.
+**Action:** When a fragment conceptually represents a distinct section of content with a heading, upgrade the fragment to a `<section>` tag and use `aria-labelledby` linked to the heading's `id`. This provides clear semantic landmarks without altering visual styling.

--- a/src/components/Panel/StatsReadout.tsx
+++ b/src/components/Panel/StatsReadout.tsx
@@ -167,9 +167,10 @@ function ComparisonStats({
   reference: NonNullable<ReturnType<typeof useAntennaStore.getState>['comparisonReference']>['result'];
 }) {
   return (
-    <>
+    /* SEO: Upgrade fragment to semantic section tag for document outline */
+    <section aria-labelledby="comparison-stats-heading">
       <hr style={{ border: 0, borderTop: '1px solid var(--border)', margin: '8px 0' }} />
-      <h3 style={{ fontSize: 11, margin: 0, color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: 6 }}>
+      <h3 id="comparison-stats-heading" style={{ fontSize: 11, margin: 0, color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: 6 }}>
         Versus reference
       </h3>
       <div className="stat">
@@ -192,7 +193,7 @@ function ComparisonStats({
         <span className="stat-label">X delta</span>
         <span className="stat-value">{formatSigned(current.impedance.X - reference.impedance.X, 1)} Ω</span>
       </div>
-    </>
+    </section>
   );
 }
 
@@ -234,9 +235,10 @@ function TerminationSection({ diagnostics }: { diagnostics: TerminationDiagnosti
   if (!hasContent) return null;
 
   return (
-    <>
+    /* SEO: Upgrade fragment to semantic section tag for document outline */
+    <section aria-labelledby="termination-effectiveness-heading">
       <hr style={{ border: 0, borderTop: '1px solid var(--border)', margin: '8px 0' }} />
-      <h3 style={{ fontSize: 11, margin: 0, color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: 6 }}>
+      <h3 id="termination-effectiveness-heading" style={{ fontSize: 11, margin: 0, color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: 6 }}>
         Termination effectiveness
       </h3>
       {legRipples.map((r) => (
@@ -273,7 +275,7 @@ function TerminationSection({ diagnostics }: { diagnostics: TerminationDiagnosti
         <strong>Note:</strong> Termination reduces reflections along the antenna wire.
         It does not guarantee a 50 Ω feedpoint impedance.
       </div>
-    </>
+    </section>
   );
 }
 


### PR DESCRIPTION
💡 What: Upgraded the React fragments (`<>...</>`) in the `ComparisonStats` and `TerminationSection` components to semantic `<section>` tags, and explicitly linked them to their internal `<h3>` headings using `id` and `aria-labelledby` attributes.

🎯 Why: To provide clear semantic landmarks and improve the document outline for search engine crawlers and screen readers, transforming flat "div soup" into properly structured content regions.

📊 Value: Improves document structure and accessibility, making it easier for crawlers to understand the relationships between different data blocks in the results panel.

🔬 Measurement: Inspect the DOM output in the browser to verify that the `ComparisonStats` and `TerminationSection` blocks are wrapped in `<section>` tags with valid `aria-labelledby` attributes pointing to their respective `<h3>` IDs.

---
*PR created automatically by Jules for task [2103173610682200993](https://jules.google.com/task/2103173610682200993) started by @2fst4u*