### PR TITLE
📚 Archivist: Fix terminology for terminated delta in README

### DIFF
--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -45,3 +45,6 @@
 ## 2025-05-27 - Antenna Model Spec Drift
 **Learning:** `docs/antenna-model-spec.md` drifted and omitted several supported antenna types (Vertical Whip, Inverted-L, Folded Dipole) under "2. Antenna Type Definitions". These types were already documented in the codebase, `README.md`, and `docs/antenna-spec.md`, leading to an incomplete representation of the physics model.
 **Action:** The missing topologies (Vertical Whip, Inverted-L, Folded Dipole) were added to `docs/antenna-model-spec.md` to accurately match reality.
+## 2024-05-28 - Syncing terminology
+**Learning:** The README.md still refers to "terminated delta loops", but in the app and the `antenna-spec.md` they are referred to as `Terminated Delta`.
+**Action:** Need to update README.md to be more precise about the actual application state.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A 3D, responsive, physics-accurate visualiser for HF antenna radiation patterns,
 
 While this repository is fully open source and developers are welcome to fork or clone it to run locally, the primary way to use the application is via the hosted URL at **[www.gain.observer](https://www.gain.observer/)**.
 
-Current scope (Phase 1): horizontal dipoles, inverted Vs, sloping Vs, delta loops, terminated delta loops, vertical whips, inverted Ls, and folded dipoles, 1.8–30 MHz, real-ground support, offset feed points, feedlines & baluns, comparison mode, SWR/polar cut charts, dark/light theming, metric/imperial toggle.
+Current scope (Phase 1): horizontal dipoles, inverted Vs, sloping Vs, delta loops, terminated deltas, vertical whips, inverted Ls, and folded dipoles, 1.8–30 MHz, real-ground support, offset feed points, feedlines & baluns, comparison mode, SWR/polar cut charts, dark/light theming, metric/imperial toggle.
 
 ## Stack
 


### PR DESCRIPTION
💡 Problem: The README referred to "terminated delta loops", but everywhere else in the repo (e.g. `docs/antenna-spec.md`) and the app UI it is specifically referred to as a "terminated delta" to emphasize its distinction from a simple loop.
🎯 Fix: Changed "terminated delta loops" to "terminated deltas" in the `README.md` file. Added a journal entry to `.jules/archivist.md`.
🧪 Verification: Read the README file and tested the app.
🔎 Scope: Only modified the `README.md` documentation file, no code changes.

---
*PR created automatically by Jules for task [11389592500636993681](https://jules.google.com/task/11389592500636993681) started by @2fst4u*