### PR TITLE
🔭 Scout: [SEO improvement] Add semantic attributes to AntennaScene Canvas

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -31,3 +31,6 @@
 
 **Learning:** When React components return fragments (`<>...</>`) containing headings (like `<h3>`), these structures are rendered as "div soup" or flat content blocks in the DOM, which obscures the document outline for search engines and screen readers.
 **Action:** When a fragment conceptually represents a distinct section of content with a heading, upgrade the fragment to a `<section>` tag and use `aria-labelledby` linked to the heading's `id`. This provides clear semantic landmarks without altering visual styling.
+## 2024-05-28 - React Three Fiber `<Canvas>` SEO
+**Learning:** The R3F `<Canvas>` component renders an opaque WebGL context that is inherently invisible to search engines and screen readers.
+**Action:** Apply `role="img"` and a descriptive `aria-label` directly to the `<Canvas>` element to provide semantic context.

--- a/src/components/Scene/AntennaScene.tsx
+++ b/src/components/Scene/AntennaScene.tsx
@@ -77,11 +77,15 @@ export function AntennaScene({ snapshot = null }: AntennaSceneProps) {
 
   return (
     <Canvas
+      role="img"
+      aria-label="Interactive 3D visualization of the HF antenna radiation pattern"
       camera={{ position: [18, 12, 22], fov: 45, near: 0.1, far: 1000 }}
       dpr={[1, 2]}
       gl={{ antialias: true, alpha: false }}
       style={{ background: 'var(--bg-canvas)' }}
     >
+      {/* SEO: R3F Canvas renders a WebGL node which is invisible to search engines.
+          Adding role="img" and an aria-label provides critical context. */}
       <color attach="background" args={[THEME_COLORS[theme].background]} />
       <ambientLight intensity={0.35} />
       <directionalLight position={[15, 25, 10]} intensity={1.15} castShadow />


### PR DESCRIPTION
💡 What: Added `role="img"` and `aria-label="Interactive 3D visualization of the HF antenna radiation pattern"` to the `<Canvas>` component in `src/components/Scene/AntennaScene.tsx`.
🎯 Why: `<canvas>` tags are opaque to search engine crawlers, treating the interactive visualization as an empty box.
📊 Value: Search engines and screen readers can now understand that this section of the UI is an interactive 3D visualization, providing important semantic context for indexing.
🔬 Measurement: Verify by inspecting the rendered `<canvas>` wrapper `div` in the DOM, confirming the `role="img"` and `aria-label` attributes are correctly attached.

---
*PR created automatically by Jules for task [9101361990221235102](https://jules.google.com/task/9101361990221235102) started by @2fst4u*