### PR TITLE
fix: correct physics errors in referenceLength for loop and traveling-wave antennas

### DIFF
--- a/src/physics/constants.ts
+++ b/src/physics/constants.ts
@@ -36,12 +36,17 @@ export function halfWaveLength(frequencyMHz: number, endEffect = 0.95): number {
  * Topology-aware reference length (metres).
  *
  *   - dipole: 0.475λ total (0.5λ × 0.95 end-effect).
- *   - inverted-v: 0.485λ total (0.5λ × 0.97 end-effect) per spec.
- *   - delta-loop: 1λ perimeter.
- *   - sloping-v: 2λ total (1λ per leg).
- *   - terminated-delta: 1λ perimeter (same triangle as delta-loop).
+ *   - inverted-v: 0.485λ total (0.5λ × 0.97). Slightly more wire than a flat
+ *     dipole: the V geometry reduces the effective horizontal current
+ *     component, so extra wire restores the resonant frequency.
+ *   - delta-loop: 1.02λ perimeter (ARRL formula: 1005/f ft; no end-effect
+ *     correction — loops have no free ends).
+ *   - sloping-v: 2λ total (1λ per leg). Traveling-wave antenna; no
+ *     end-effect correction applies.
+ *   - terminated-delta: 1.02λ perimeter (same triangle as delta-loop).
  *
- * Applies the standard HF end-effect factor k ~ 0.95 where noted.
+ * Applies the standard HF end-effect factor k ~ 0.95 only to resonant
+ * half-wave elements (dipole variants, quarter-wave monopoles).
  */
 export function referenceLength(type: AntennaType, frequencyMHz: number, endEffect = 0.95): number {
   const lambda = wavelengthMeters(frequencyMHz);
@@ -49,17 +54,21 @@ export function referenceLength(type: AntennaType, frequencyMHz: number, endEffe
     case 'dipole':
       return lambda * 0.5 * endEffect;
     case 'inverted-v':
-      // Slightly higher end-effect than a dipole due to the V geometry.
+      // The V geometry reduces the effective horizontal current component;
+      // slightly more wire than a flat dipole is needed to restore resonance.
       return lambda * 0.5 * 0.97;
     case 'delta-loop':
-      return lambda * 1.0 * endEffect;
+      // Full-wave loop: no free ends, so end-effect does not apply.
+      // ARRL formula (1005/f MHz ft) gives ≈1.02λ for thin wire at HF.
+      return lambda * 1.02;
     case 'sloping-v':
-      return lambda * 2.0 * endEffect;
+      // Traveling-wave V antenna: 1λ per leg. End-effect correction does not
+      // apply to non-resonant traveling-wave structures.
+      return lambda * 2.0;
     case 'terminated-delta':
-      // Same physical perimeter as a delta loop. Resonance is irrelevant in
-      // a true terminated configuration (the wave is absorbed before it can
-      // reflect), but 1λ is the canonical starting point.
-      return lambda * 1.0 * endEffect;
+      // Same perimeter as delta-loop. Resonance is irrelevant in a true
+      // terminated configuration, but 1.02λ is the canonical starting point.
+      return lambda * 1.02;
     case 'vertical-whip':
       // Quarter-wave monopole resonant length.
       return lambda * 0.25 * endEffect;

--- a/tests/constants.test.ts
+++ b/tests/constants.test.ts
@@ -3,9 +3,12 @@ import {
   FEEDLINE_PRESETS,
   feedlineLossDb,
   findFeedlinePreset,
+  findGroundPreset,
   halfWaveLength,
+  referenceLength,
   HF_BAND_PRESETS,
 } from '../src/physics/constants';
+import { type AntennaType } from '../src/physics/types';
 
 describe('physics constants and helpers', () => {
   it('halfWaveLength accounts for end effect', () => {
@@ -20,6 +23,65 @@ describe('physics constants and helpers', () => {
     expect(names).toContain('40m');
     expect(names).toContain('20m');
     expect(names).toContain('10m');
+  });
+});
+
+describe('referenceLength', () => {
+  // λ at 14.150 MHz (20m band) = 299.792458 / 14.150 ≈ 21.187 m
+  const lambda = 299.792458 / 14.150;
+
+  it('dipole: 0.5λ × end-effect (default 0.95)', () => {
+    expect(referenceLength('dipole', 14.150)).toBeCloseTo(lambda * 0.5 * 0.95, 4);
+  });
+
+  it('dipole: custom end-effect overrides default', () => {
+    expect(referenceLength('dipole', 14.150, 1.0)).toBeCloseTo(lambda * 0.5, 4);
+  });
+
+  it('inverted-v: slightly longer than flat dipole (0.5λ × 0.97)', () => {
+    expect(referenceLength('inverted-v', 14.150)).toBeCloseTo(lambda * 0.5 * 0.97, 4);
+  });
+
+  it('delta-loop: 1.02λ perimeter (no end-effect correction for loops)', () => {
+    expect(referenceLength('delta-loop', 14.150)).toBeCloseTo(lambda * 1.02, 4);
+  });
+
+  it('terminated-delta: 1.02λ perimeter, same as delta-loop', () => {
+    expect(referenceLength('terminated-delta', 14.150)).toBeCloseTo(lambda * 1.02, 4);
+  });
+
+  it('sloping-v: 2λ total (1λ per leg, traveling-wave, no end-effect)', () => {
+    expect(referenceLength('sloping-v', 14.150)).toBeCloseTo(lambda * 2.0, 4);
+  });
+
+  it('vertical-whip: quarter-wave monopole (0.25λ × end-effect)', () => {
+    expect(referenceLength('vertical-whip', 14.150)).toBeCloseTo(lambda * 0.25 * 0.95, 4);
+  });
+
+  it('inverted-l: total wire for resonant quarter-wave (0.25λ × end-effect)', () => {
+    expect(referenceLength('inverted-l', 14.150)).toBeCloseTo(lambda * 0.25 * 0.95, 4);
+  });
+
+  it('folded-dipole: same resonant length as standard dipole', () => {
+    expect(referenceLength('folded-dipole', 14.150)).toBeCloseTo(lambda * 0.5 * 0.95, 4);
+  });
+
+  it('unknown type falls back to dipole default', () => {
+    expect(referenceLength('unknown' as AntennaType, 14.150)).toBeCloseTo(lambda * 0.5 * 0.95, 4);
+  });
+});
+
+describe('ground presets', () => {
+  it('findGroundPreset returns correct preset for valid id', () => {
+    const preset = findGroundPreset('sea');
+    expect(preset.id).toBe('sea');
+    expect(preset.label).toBe('Sea water');
+  });
+
+  it('findGroundPreset throws on unknown id', () => {
+    expect(() => findGroundPreset('unknown-ground-type')).toThrowError(
+      'Unknown ground preset id: unknown-ground-type',
+    );
   });
 });
 


### PR DESCRIPTION
Closing — the physics fix and corrected tests have been pushed directly to PR #300 (`spec/fortify-constants-test-15790585385656047159`) instead.