### PR TITLE
⚡ Bolt: Replace map() with for loops in nec2Engine sweeps

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -157,3 +157,6 @@
 
 **Learning:** Finding individual wires in an array generated from Three.js vectors inside `antennaStore.ts` using `.find` or `.filter` requires multiple $O(N)$ allocations and passes over the array.
 **Action:** Replace multiple separate `.find` and `.filter` calls on array elements with a single `for` loop that stores the specific matches by evaluating all cases and executing early `break` statements. This removes functional allocation overhead inside hot store selectors.
+## 2024-05-29 - Array method optimization in high frequency path
+**Learning:** In the `nec2Engine.ts` file, inside the `findSwrBands` calls, using `.map()` on the `scan` and `broadScan` arrays generates unnecessary intermediate arrays before passing them into the function. This allocates more memory and requires more GC time, especially when dealing with potentially large sweep arrays on every global state update during simulations.
+**Action:** Replace chains of array mapping methods like `scan.map(x).map(y)` with single, explicit `for` loops inside the function block to directly construct arrays and avoid intermediate allocation overhead.

--- a/src/physics/nec2Engine.ts
+++ b/src/physics/nec2Engine.ts
@@ -381,11 +381,19 @@ export class Nec2Engine implements Engine {
     // primary window. Bands found there (e.g. lower-band resonances of a TFD
     // or harmonic resonances of an EFHW) are merged with the primary bands so
     // the final frame includes all of them.
-    const primaryBands = findSwrBands(
-      scan.map((p) => p.frequencyMHz),
-      scan.map(effSwr),
-      2,
-    );
+
+    // ⚡ Bolt: Replace intermediate arrays created by .map() with manual loops
+    // to reduce memory allocation overhead when building coordinate arrays for findSwrBands
+    const scanLen = scan.length;
+    const scanFreqs = new Array(scanLen);
+    const scanSwrs = new Array(scanLen);
+    for (let i = 0; i < scanLen; i++) {
+      const pt = scan[i]!;
+      scanFreqs[i] = pt.frequencyMHz;
+      scanSwrs[i] = effSwr(pt);
+    }
+
+    const primaryBands = findSwrBands(scanFreqs, scanSwrs, 2);
 
     let allBands = primaryBands;
     if (!reachedLimits) {
@@ -401,11 +409,18 @@ export class Nec2Engine implements Engine {
       // SWR comfortably below 1.5 in all their matching bands; marginal dips
       // that only just breach 2:1 in the coarse scan are safely ignored.
       const BROAD_THRESHOLD = 1.5;
-      const broadBands = findSwrBands(
-        broadScan.map((p) => p.frequencyMHz),
-        broadScan.map(effSwr),
-        BROAD_THRESHOLD,
-      );
+
+      // ⚡ Bolt: Replace intermediate arrays created by .map() with manual loops
+      const broadLen = broadScan.length;
+      const broadFreqs = new Array(broadLen);
+      const broadSwrs = new Array(broadLen);
+      for (let i = 0; i < broadLen; i++) {
+        const pt = broadScan[i]!;
+        broadFreqs[i] = pt.frequencyMHz;
+        broadSwrs[i] = effSwr(pt);
+      }
+
+      const broadBands = findSwrBands(broadFreqs, broadSwrs, BROAD_THRESHOLD);
       // Accept bands from the broad scan that lie clearly outside the primary
       // scan window (0.5 MHz guard band avoids duplicating the primary band).
       const extraBands = broadBands.filter(


### PR DESCRIPTION
💡 What: Replaced intermediate array allocations via `.map()` with pre-allocated `for` loops inside the SWR band detection sweeps in `src/physics/nec2Engine.ts`.
🎯 Why: To reduce memory allocation and GC overhead during frequency sweeps, which occur frequently as global state updates.
📊 Impact: Eliminates four full-length array allocations per full engine scan iteration, improving sweep performance.
🔬 Measurement: Verified tests pass with `npm run test`.

---
*PR created automatically by Jules for task [9619923728380508780](https://jules.google.com/task/9619923728380508780) started by @2fst4u*