### PR TITLE
🧪 Spec: [Add] DipoleControl

### DIFF
--- a/.jules/spec.md
+++ b/.jules/spec.md
@@ -11,3 +11,6 @@
 ## 2026-05-29 - Adhering to Strict Application Logic in Tests
 **Learning:** When acting as a test engineer to fortify a test suite, it is crucial not to modify existing application logic or business rules (such as altering an error-throwing mechanism into a fallback default) merely to simplify tests or satisfy an assumed pattern, as it masks potential application bugs.
 **Action:** Tests must be written to assert the current behavior of the application (e.g., verifying that an error is correctly thrown on invalid inputs) rather than altering the core logic.
+## 2024-05-30 - App test worker mocking
+**Learning:** In tests/App.test.tsx, the tests fail because Worker is a stub and vitest mock overrides don't provide adequate coverage or isolation for WebWorkers under jsdom without specific stubbing. Additionally, Coverage for src/components/Panel/DipoleControl.tsx is very low.
+**Action:** Added new tests in tests/DipoleControl.test.tsx to improve line coverage and test specific functionality.

--- a/tests/DipoleControl.test.tsx
+++ b/tests/DipoleControl.test.tsx
@@ -155,4 +155,53 @@ describe('DipoleControl', () => {
     expect(screen.getByText('Transformer at feedpoint')).toBeTruthy();
     expect(screen.getByLabelText(/Fit transformer \/ balun at the antenna/i)).toBeTruthy();
   });
+
+  it('updates antenna type when changed', () => {
+    const setAntennaType = vi.fn();
+    vi.mocked(useAntennaStore).mockImplementation((selector: (s: MockState) => unknown) => {
+      return selector(buildMockState({ setAntennaType }));
+    });
+
+    render(<DipoleControl />);
+
+    const typeSelect = screen.getByRole('combobox', { name: /Type/i });
+    fireEvent.change(typeSelect, { target: { value: 'inverted-v' } });
+
+    expect(setAntennaType).toHaveBeenCalledWith('inverted-v');
+  });
+
+  it('updates terminating resistor when input changes', () => {
+    const setTerminatingResistor = vi.fn();
+    vi.mocked(useAntennaStore).mockImplementation((selector: (s: MockState) => unknown) => {
+      return selector(buildMockState({
+        antennaType: 'terminated-delta',
+        terminatingResistor: 0,
+        setTerminatingResistor
+      }));
+    });
+
+    render(<DipoleControl />);
+
+    const resistorInput = document.getElementById('terminating-resistor') as HTMLInputElement;
+    fireEvent.change(resistorInput, { target: { value: '600' } });
+
+    expect(setTerminatingResistor).toHaveBeenCalledWith(600);
+  });
+
+  it('updates inverted-l orientation when input changes', () => {
+    const setOrientation = vi.fn();
+    vi.mocked(useAntennaStore).mockImplementation((selector: (s: MockState) => unknown) => {
+      return selector(buildMockState({
+        antennaType: 'inverted-l',
+        setOrientation
+      }));
+    });
+
+    render(<DipoleControl />);
+
+    const orientInput = document.getElementById('inverted-l-orientation') as HTMLInputElement;
+    fireEvent.change(orientInput, { target: { value: '45' } });
+
+    expect(setOrientation).toHaveBeenCalledWith(45);
+  });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       thresholds: {
-        statements: 69.7,
+        statements: 69.8,
         branches: 61.8,
         functions: 71.3,
         lines: 92.7,


### PR DESCRIPTION
💡 What: Added unit tests for uncovered inputs (`antennaType`, `terminatingResistor`, and `inverted-l-orientation`) in `DipoleControl.tsx` and bumped the coverage threshold.
🎯 Why: To secure uncovered logic and improve the test suite maturity.
📈 Maturity Impact: Bumped statements coverage threshold from 69.7% to 69.8% to lock in progress toward business standards.

---
*PR created automatically by Jules for task [11662869559438921685](https://jules.google.com/task/11662869559438921685) started by @2fst4u*