### PR TITLE
Add .claude/worktrees/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ nec2-build/test-*.mjs
 *.sln
 *.sw?
 coverage/
+
+# Claude Code agent worktrees (ephemeral, local-only)
+.claude/worktrees/


### PR DESCRIPTION
## Summary

- Adds `.claude/worktrees/` to `.gitignore` — these are ephemeral scratch directories created by Claude Code parallel agents and should never be tracked in git.

## Test plan

- [ ] Verify `git status` shows no untracked `.claude/` entries after agents run

https://claude.ai/code/session_013tVn7SGmH8frbX393ASZ5g

---
_Generated by [Claude Code](https://claude.ai/code/session_013tVn7SGmH8frbX393ASZ5g)_