### PR TITLE
⚡ Bolt: Optimize useDipoleGeometry rendering loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -167,3 +167,4 @@
 ## 2025-02-18 - Optimize SWR Chart Data Processing
 **Learning:** High-frequency render blocks passing large arrays to Chart.js shouldn't use `.map()` which generates intermediate copies and garbage, but instead pre-allocate arrays and populate via `for` loops.
 **Action:** Replaced `.map()` with pre-allocated `for` loops in `src/components/Charts/swrChartUtils.ts` (computeChartData).
+## 2026-05-30 - Avoid Map Filter Chaining Array Allocations\n**Learning:** Chaining `.map().filter()` calls inside high-frequency render functions like `useDipoleGeometry` generates unnecessary intermediate shallow array copies and incurs excessive garbage collection pressure, particularly when handling 3D scene re-renders.\n**Action:** Replace functional map/filter chaining with a single standard `for` loop and array `push()` with early `continue` statements to eliminate intermediate allocations.

--- a/src/components/Scene/useDipoleGeometry.ts
+++ b/src/components/Scene/useDipoleGeometry.ts
@@ -74,13 +74,15 @@ export function useDipoleGeometry({
       foldedDipoleAperture,
     });
 
-    return wires.map((w, idx) => {
+    const out = [];
+    for (let idx = 0; idx < wires.length; idx++) {
+      const w = wires[idx]!;
       const a = new THREE.Vector3(...necToScene(w.start));
       const b = new THREE.Vector3(...necToScene(w.end));
       const mid = a.clone().add(b).multiplyScalar(0.5);
       const dir = b.clone().sub(a);
       const lengthScene = dir.length();
-      if (lengthScene < 1e-6) return null;
+      if (lengthScene < 1e-6) continue;
       const q = new THREE.Quaternion();
       q.setFromUnitVectors(new THREE.Vector3(0, 1, 0), dir.clone().normalize());
       const tag = w.tag ?? DIPOLE_TAG;
@@ -90,7 +92,7 @@ export function useDipoleGeometry({
       if (isShield) radius = Math.max(w.radius * 6, 0.025);
       else if (isBridge) radius = Math.max(w.radius * 4, 0.018);
       else radius = Math.max(w.radius * 8, 0.03);
-      return {
+      out.push({
         key: idx,
         tag,
         position: [mid.x, mid.y, mid.z] as [number, number, number],
@@ -101,8 +103,9 @@ export function useDipoleGeometry({
         sceneEnd: [b.x, b.y, b.z] as [number, number, number],
         isShield,
         isBridge,
-      };
-    }).filter((x): x is NonNullable<typeof x> => x !== null);
+      });
+    }
+    return out;
   }, [type, length, height, orientation, wireRadius, segments, feedlineId, feedlineLength, feedlineOffset, vAngle, legSlope, frequency, whipCounterpoise, foldedDipoleAperture]);
 
   const { shield, feedpoint } = useMemo(() => {


### PR DESCRIPTION
💡 What: Replaced the chained `.map().filter()` array methods in `useDipoleGeometry.ts` with a single standard `for` loop and conditional `push()`.

🎯 Why: The original functional chain generated a complete intermediate array (including nulls) before filtering it down, which creates unnecessary memory allocations and garbage collection pressure in a hook that recalculates continuously when users drag the UI length/height sliders.

📊 Impact: Reduces memory allocation by completely eliminating the intermediate array during 3D geometry generation, improving performance during real-time UI interactions.

🔬 Measurement: Review `useDipoleGeometry.ts` to confirm no intermediate arrays are allocated in the `rendered` useMemo block and verify visual scene changes load identically.

---
*PR created automatically by Jules for task [2959755372559155160](https://jules.google.com/task/2959755372559155160) started by @2fst4u*