### PR TITLE
🧪 Spec: Add tests for ConditionsReadout helper formatRange

### DIFF
--- a/src/components/Panel/Propagation/ConditionsReadout.tsx
+++ b/src/components/Panel/Propagation/ConditionsReadout.tsx
@@ -2,7 +2,8 @@ import { useState } from 'react';
 import { PropagationRadar } from '../../Charts/PropagationRadar';
 import type { PropagationPrediction, HopPrediction } from '../../../physics/propagation';
 
-function formatRange(km: number, units: 'metric' | 'imperial'): string {
+// eslint-disable-next-line react-refresh/only-export-components
+export function formatRange(km: number, units: 'metric' | 'imperial'): string {
   if (units === 'imperial') {
     return `${(km / 1.609344).toFixed(0)} mi`;
   }

--- a/tests/ConditionsReadout.test.ts
+++ b/tests/ConditionsReadout.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { formatRange } from '../src/components/Panel/Propagation/ConditionsReadout';
+
+describe('formatRange', () => {
+  it('formats metric distances correctly', () => {
+    expect(formatRange(10, 'metric')).toBe('10 km');
+    expect(formatRange(0, 'metric')).toBe('0 km');
+  });
+
+  it('formats imperial distances correctly', () => {
+    // 1 mi is approx 1.609344 km
+    expect(formatRange(1.609344, 'imperial')).toBe('1 mi');
+    expect(formatRange(16.09344, 'imperial')).toBe('10 mi');
+    expect(formatRange(0, 'imperial')).toBe('0 mi');
+  });
+});


### PR DESCRIPTION
🎯 **What:** The testing gap for `formatRange` function in `ConditionsReadout.tsx` was addressed. It is a simple pure function that was not previously unit tested.
📊 **Coverage:** Added tests for metric and imperial formats. Tested 0 distance as well as common fractional representations to verify truncation/rounding behavior.
✨ **Result:** Test coverage for this helper module has been improved. Tests execute successfully via Vitest without regressions.

---
*PR created automatically by Jules for task [7111874447632779018](https://jules.google.com/task/7111874447632779018) started by @2fst4u*