### PR TITLE
🧪 Spec: Add tests for formatBandwidth

### DIFF
--- a/.jules/spec.md
+++ b/.jules/spec.md
@@ -14,3 +14,6 @@
 ## 2024-05-30 - App test worker mocking
 **Learning:** In tests/App.test.tsx, the tests fail because Worker is a stub and vitest mock overrides don't provide adequate coverage or isolation for WebWorkers under jsdom without specific stubbing. Additionally, Coverage for src/components/Panel/DipoleControl.tsx is very low.
 **Action:** Added new tests in tests/DipoleControl.test.tsx to improve line coverage and test specific functionality.
+## 2026-05-30 - Add tests for formatBandwidth
+**Learning:** JS `.toFixed()` exhibits unexpected rounding behavior with `.5` boundaries (e.g. `(1.555).toFixed(2) === '1.55'`, not `'1.56'`) due to IEEE 754 floating point representation. Tests targeting exact decimal boundaries must reflect this native JS logic rather than purely mathematical rounding.
+**Action:** Created `tests/swrChartUtils.test.ts` ensuring branch logic (< 1MHz and >= 1MHz) is tested while accounting for standard floating point boundaries.

--- a/tests/swrChartUtils.test.ts
+++ b/tests/swrChartUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { computeChartData } from '../src/components/Charts/swrChartUtils';
+import { computeChartData, formatBandwidth } from '../src/components/Charts/swrChartUtils';
 import type { SweepPoint } from '../src/physics/types';
 import type { ComparisonSnapshot } from '../src/store/antennaStore';
 
@@ -114,5 +114,27 @@ describe('computeChartData', () => {
     expect(curDataset.data[0].y).toBeCloseTo(2.0, 5);
     expect(curDataset.data[1].x).toBe(7.1);
     expect(curDataset.data[1].y).toBeCloseTo(1.0, 5);
+  });
+});
+
+describe('formatBandwidth', () => {
+  it('formats values less than 1 MHz in kHz', () => {
+    expect(formatBandwidth(0.5)).toBe('500 kHz');
+    expect(formatBandwidth(0.999)).toBe('999 kHz');
+    expect(formatBandwidth(0.001)).toBe('1 kHz');
+  });
+
+  it('rounds kHz values to the nearest integer', () => {
+    expect(formatBandwidth(0.1234)).toBe('123 kHz');
+    expect(formatBandwidth(0.1236)).toBe('124 kHz');
+  });
+
+  it('formats values exactly 1 MHz or greater in MHz to 2 decimal places', () => {
+    expect(formatBandwidth(1)).toBe('1.00 MHz');
+    expect(formatBandwidth(1.5)).toBe('1.50 MHz');
+    // Note: JS .toFixed() rounds 1.555 down to 1.55 due to floating point representation
+    expect(formatBandwidth(1.555)).toBe('1.55 MHz');
+    expect(formatBandwidth(1.556)).toBe('1.56 MHz');
+    expect(formatBandwidth(10)).toBe('10.00 MHz');
   });
 });


### PR DESCRIPTION
🎯 **What:** The testing gap for the `formatBandwidth` pure formatting function was addressed by implementing targeted tests.
📊 **Coverage:** The new test suite covers happy paths for small values (under 1 MHz formatting as kHz), exact whole numbers, rounding logic for kHz, and two-decimal formatting for MHz when spans equal or exceed 1 MHz.
✨ **Result:** Test coverage for `src/components/Charts/swrChartUtils.ts` has been improved, locking in the intended unit-scaling behavior.

---
*PR created automatically by Jules for task [16882328360766382020](https://jules.google.com/task/16882328360766382020) started by @2fst4u*