### PR TITLE
🧪 Add tests for PropagationInputs time parsers

### DIFF
--- a/src/components/Panel/Propagation/PropagationInputs.tsx
+++ b/src/components/Panel/Propagation/PropagationInputs.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import { useState } from 'react';
 import { useAntennaStore } from '../../../store/antennaStore';
 import { useShallow } from 'zustand/react/shallow';
@@ -9,14 +10,14 @@ const MONTH_NAMES = [
 ];
 
 /** Converts fractional UTC hour to HH:mm string format. */
-function hourToHHmm(h: number): string {
+export function hourToHHmm(h: number): string {
   const hours = Math.floor(h);
   const minutes = Math.round((h - hours) * 60);
   return `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`;
 }
 
 /** Converts HH:mm or HHmm string format back to fractional UTC hour, or null if invalid. */
-function HHmmToHour(s: string): number | null {
+export function HHmmToHour(s: string): number | null {
   const digits = s.replace(/[^0-9]/g, '');
   if (digits.length !== 4) return null;
   const h = parseInt(digits.substring(0, 2), 10);

--- a/tests/PropagationInputs.test.ts
+++ b/tests/PropagationInputs.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { hourToHHmm, HHmmToHour } from '../src/components/Panel/Propagation/PropagationInputs';
+
+describe('PropagationInputs time parsers', () => {
+  describe('hourToHHmm', () => {
+    it('converts integer hours correctly', () => {
+      expect(hourToHHmm(0)).toBe('00:00');
+      expect(hourToHHmm(12)).toBe('12:00');
+      expect(hourToHHmm(23)).toBe('23:00');
+    });
+
+    it('converts fractional hours to minutes correctly', () => {
+      expect(hourToHHmm(1.5)).toBe('01:30');
+      expect(hourToHHmm(14.25)).toBe('14:15');
+      expect(hourToHHmm(9.75)).toBe('09:45');
+      expect(hourToHHmm(10.1)).toBe('10:06');
+    });
+
+    it('rounds minutes correctly', () => {
+      // 10.333... hours is 10 hours and 20 minutes
+      expect(hourToHHmm(10.333333333333334)).toBe('10:20');
+      // 10.123 hours is 10 hours and 7.38 minutes -> 10:07
+      expect(hourToHHmm(10.123)).toBe('10:07');
+    });
+  });
+
+  describe('HHmmToHour', () => {
+    it('converts valid HH:mm strings to fractional hours', () => {
+      expect(HHmmToHour('00:00')).toBe(0);
+      expect(HHmmToHour('12:00')).toBe(12);
+      expect(HHmmToHour('23:00')).toBe(23);
+      expect(HHmmToHour('01:30')).toBe(1.5);
+      expect(HHmmToHour('14:15')).toBe(14.25);
+      expect(HHmmToHour('09:45')).toBe(9.75);
+    });
+
+    it('converts valid HHmm strings (without colon) to fractional hours', () => {
+      expect(HHmmToHour('0000')).toBe(0);
+      expect(HHmmToHour('1200')).toBe(12);
+      expect(HHmmToHour('2300')).toBe(23);
+      expect(HHmmToHour('0130')).toBe(1.5);
+      expect(HHmmToHour('1415')).toBe(14.25);
+      expect(HHmmToHour('0945')).toBe(9.75);
+    });
+
+    it('handles extra characters by stripping them out', () => {
+      // '12:30 PM' will have non-digits stripped to '1230', which converts to 12.5
+      expect(HHmmToHour('12:30 PM')).toBe(12.5);
+      expect(HHmmToHour('  09:45  ')).toBe(9.75);
+      expect(HHmmToHour('a01b30c')).toBe(1.5);
+    });
+
+    it('returns null for invalid lengths', () => {
+      expect(HHmmToHour('1')).toBe(null);
+      expect(HHmmToHour('12')).toBe(null);
+      expect(HHmmToHour('123')).toBe(null);
+      expect(HHmmToHour('12345')).toBe(null);
+    });
+
+    it('returns null for out-of-bounds hours or minutes', () => {
+      expect(HHmmToHour('24:00')).toBe(null); // h=24 is invalid
+      expect(HHmmToHour('25:00')).toBe(null);
+      expect(HHmmToHour('12:60')).toBe(null); // m=60 is invalid
+      expect(HHmmToHour('12:61')).toBe(null);
+      expect(HHmmToHour('-1:00')).toBe(null); // -1 becomes 100 which is length 3, fails
+    });
+  });
+});


### PR DESCRIPTION
🎯 **What:** The `hourToHHmm` and `HHmmToHour` utility functions in `PropagationInputs.tsx` lacked test coverage. This PR exports them and adds a comprehensive test suite.
📊 **Coverage:** The new tests in `tests/PropagationInputs.test.ts` verify integer/fractional positive numbers and rounding behaviors for `hourToHHmm`, as well as colon/no-colon handling, extra spaces/characters stripping, invalid string lengths, and out-of-bounds limits for `HHmmToHour`.
✨ **Result:** Test coverage for `PropagationInputs` time parsers is now comprehensive and robust.

---
*PR created automatically by Jules for task [8375812797533501052](https://jules.google.com/task/8375812797533501052) started by @2fst4u*