### PR TITLE
🧪 Spec: Add physicsWorker initialization error tests

### DIFF
--- a/tests/physicsWorker.test.ts
+++ b/tests/physicsWorker.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// We mock Nec2Engine and export a mock instance so we can change its behavior per test
+const mockEngineInstance = {
+  init: vi.fn(),
+  simulate: vi.fn(),
+  sweepImpedance: vi.fn()
+};
+
+vi.mock('../src/physics/nec2Engine', () => {
+  return {
+    Nec2Engine: class MockNec2Engine {
+      init = mockEngineInstance.init;
+      simulate = mockEngineInstance.simulate;
+      sweepImpedance = mockEngineInstance.sweepImpedance;
+    }
+  };
+});
+
+describe('physicsWorker error path test', () => {
+  let postMessageSpy: ReturnType<typeof vi.fn>;
+  let addEventListenerSpy: ReturnType<typeof vi.fn>;
+  let consoleErrorSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    postMessageSpy = vi.fn();
+    addEventListenerSpy = vi.fn();
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    // Mock global scope for DedicatedWorkerGlobalScope
+    vi.stubGlobal('postMessage', postMessageSpy);
+    vi.stubGlobal('addEventListener', addEventListenerSpy);
+
+    // Reset mock implementation for each test
+    mockEngineInstance.init.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('posts error message when initialization fails with an Error', async () => {
+    // Set up the mock rejection before importing the worker
+    mockEngineInstance.init.mockRejectedValue(new Error('Mock initialization failure'));
+
+    // Dynamically import to ensure mock globals and mock Nec2Engine are picked up
+    await import('../src/workers/physicsWorker');
+
+    // Wait for the promise chain in physicsWorker.ts to resolve/reject
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(postMessageSpy).toHaveBeenCalledWith({
+      id: -1,
+      type: 'error',
+      message: 'Engine init failed: Mock initialization failure',
+    });
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      '[worker] engine init failed',
+      expect.any(Error)
+    );
+  });
+
+  it('posts error message when initialization fails with a non-Error', async () => {
+    mockEngineInstance.init.mockRejectedValue('String error');
+
+    await import('../src/workers/physicsWorker');
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(postMessageSpy).toHaveBeenCalledWith({
+      id: -1,
+      type: 'error',
+      message: 'Engine init failed: String error',
+    });
+  });
+});


### PR DESCRIPTION
🎯 **What:** Added a unit test for `src/workers/physicsWorker.ts` targeting the initialization error handling path, specifically asserting that proper `postMessage` payloads (with `id: -1` and `type: 'error'`) and `console.error` logs are generated when `Nec2Engine` fails to initialize.
📊 **Coverage:** The tests now explicitly cover both branches of the initialization failure: when the error thrown is an `Error` object, and when it's a primitive (e.g., a string), ensuring the worker safely reports failures back to the main thread.
✨ **Result:** Test coverage for the worker script is enhanced, making refactoring safer. The `physicsWorker` can now confidently communicate errors during initialization instead of failing silently.

---
*PR created automatically by Jules for task [4258309729723838108](https://jules.google.com/task/4258309729723838108) started by @2fst4u*