### PR TITLE
🧹 Refactor referenceLength to use strategy map

### DIFF
--- a/src/physics/constants.ts
+++ b/src/physics/constants.ts
@@ -34,10 +34,10 @@ export function halfWaveLength(frequencyMHz: number, endEffect = 0.95): number {
 
 const REFERENCE_LENGTH_STRATEGIES: Record<AntennaType, (lambda: number, endEffect: number) => number> = {
   dipole: (lambda, endEffect) => lambda * 0.5 * endEffect,
-  // _endEffect is intentionally unused: 0.97 is a fixed apex-angle geometry
+  // endEffect is intentionally omitted: 0.97 is a fixed apex-angle geometry
   // shortening factor specific to the V shape, not a wire-diameter end-effect.
   // Composing it with the caller-supplied endEffect would double-correct.
-  'inverted-v': (lambda, _endEffect) => {
+  'inverted-v': (lambda) => {
     return lambda * 0.5 * 0.97;
   },
   'delta-loop': (lambda) => {

--- a/src/physics/constants.ts
+++ b/src/physics/constants.ts
@@ -32,6 +32,46 @@ export function halfWaveLength(frequencyMHz: number, endEffect = 0.95): number {
   return wavelengthMeters(frequencyMHz) * 0.5 * endEffect;
 }
 
+const REFERENCE_LENGTH_STRATEGIES: Record<AntennaType, (lambda: number, endEffect: number) => number> = {
+  dipole: (lambda, endEffect) => lambda * 0.5 * endEffect,
+  'inverted-v': (lambda) => {
+    // The V geometry reduces the effective horizontal current component;
+    // slightly more wire than a flat dipole is needed to restore resonance.
+    return lambda * 0.5 * 0.97;
+  },
+  'delta-loop': (lambda) => {
+    // Full-wave loop: no free ends, so end-effect does not apply.
+    // ARRL formula (1005/f MHz ft) gives ≈1.02λ for thin wire at HF.
+    return lambda * 1.02;
+  },
+  'sloping-v': (lambda) => {
+    // Traveling-wave V antenna: 1λ per leg. End-effect correction does not
+    // apply to non-resonant traveling-wave structures.
+    return lambda * 2.0;
+  },
+  'terminated-delta': (lambda) => {
+    // Same perimeter as delta-loop. Resonance is irrelevant in a true
+    // terminated configuration, but 1.02λ is the canonical starting point.
+    return lambda * 1.02;
+  },
+  'vertical-whip': (lambda, endEffect) => {
+    // Quarter-wave monopole resonant length.
+    return lambda * 0.25 * endEffect;
+  },
+  'inverted-l': (lambda, endEffect) => {
+    // Total wire (vertical + horizontal) for a resonant quarter-wave.
+    // The horizontal top-loading section adds electrical length so the
+    // mast can be shorter than a full ¼λ vertical.
+    return lambda * 0.25 * endEffect;
+  },
+  'folded-dipole': (lambda, endEffect) => {
+    // Each conductor is a resonant half-wave, same as a standard dipole.
+    // The fold (the second parallel conductor) raises the feedpoint
+    // impedance ~4× but does not change the resonant length.
+    return lambda * 0.5 * endEffect;
+  }
+};
+
 /**
  * Topology-aware reference length (metres).
  *
@@ -50,41 +90,8 @@ export function halfWaveLength(frequencyMHz: number, endEffect = 0.95): number {
  */
 export function referenceLength(type: AntennaType, frequencyMHz: number, endEffect = 0.95): number {
   const lambda = wavelengthMeters(frequencyMHz);
-  switch (type) {
-    case 'dipole':
-      return lambda * 0.5 * endEffect;
-    case 'inverted-v':
-      // The V geometry reduces the effective horizontal current component;
-      // slightly more wire than a flat dipole is needed to restore resonance.
-      return lambda * 0.5 * 0.97;
-    case 'delta-loop':
-      // Full-wave loop: no free ends, so end-effect does not apply.
-      // ARRL formula (1005/f MHz ft) gives ≈1.02λ for thin wire at HF.
-      return lambda * 1.02;
-    case 'sloping-v':
-      // Traveling-wave V antenna: 1λ per leg. End-effect correction does not
-      // apply to non-resonant traveling-wave structures.
-      return lambda * 2.0;
-    case 'terminated-delta':
-      // Same perimeter as delta-loop. Resonance is irrelevant in a true
-      // terminated configuration, but 1.02λ is the canonical starting point.
-      return lambda * 1.02;
-    case 'vertical-whip':
-      // Quarter-wave monopole resonant length.
-      return lambda * 0.25 * endEffect;
-    case 'inverted-l':
-      // Total wire (vertical + horizontal) for a resonant quarter-wave.
-      // The horizontal top-loading section adds electrical length so the
-      // mast can be shorter than a full ¼λ vertical.
-      return lambda * 0.25 * endEffect;
-    case 'folded-dipole':
-      // Each conductor is a resonant half-wave, same as a standard dipole.
-      // The fold (the second parallel conductor) raises the feedpoint
-      // impedance ~4× but does not change the resonant length.
-      return lambda * 0.5 * endEffect;
-    default:
-      return lambda * 0.5 * endEffect;
-  }
+  const strategy = REFERENCE_LENGTH_STRATEGIES[type] || REFERENCE_LENGTH_STRATEGIES.dipole;
+  return strategy(lambda, endEffect);
 }
 
 // --- Geometry Tags ---

--- a/src/physics/constants.ts
+++ b/src/physics/constants.ts
@@ -34,9 +34,10 @@ export function halfWaveLength(frequencyMHz: number, endEffect = 0.95): number {
 
 const REFERENCE_LENGTH_STRATEGIES: Record<AntennaType, (lambda: number, endEffect: number) => number> = {
   dipole: (lambda, endEffect) => lambda * 0.5 * endEffect,
-  'inverted-v': (lambda) => {
-    // The V geometry reduces the effective horizontal current component;
-    // slightly more wire than a flat dipole is needed to restore resonance.
+  // _endEffect is intentionally unused: 0.97 is a fixed apex-angle geometry
+  // shortening factor specific to the V shape, not a wire-diameter end-effect.
+  // Composing it with the caller-supplied endEffect would double-correct.
+  'inverted-v': (lambda, _endEffect) => {
     return lambda * 0.5 * 0.97;
   },
   'delta-loop': (lambda) => {
@@ -84,6 +85,12 @@ const REFERENCE_LENGTH_STRATEGIES: Record<AntennaType, (lambda: number, endEffec
  *   - sloping-v: 2λ total (1λ per leg). Traveling-wave antenna; no
  *     end-effect correction applies.
  *   - terminated-delta: 1.02λ perimeter (same triangle as delta-loop).
+ *   - vertical-whip: 0.2375λ (0.25λ × endEffect). Quarter-wave monopole.
+ *   - inverted-l: 0.2375λ (0.25λ × endEffect). Total wire length (vertical +
+ *     horizontal) for a quarter-wave equivalent; top-loading reduces mast height.
+ *   - folded-dipole: 0.475λ (0.5λ × endEffect). Same resonant length as a
+ *     dipole; the second parallel conductor raises feedpoint impedance ~4× but
+ *     does not alter the resonant length.
  *
  * Applies the standard HF end-effect factor k ~ 0.95 only to resonant
  * half-wave elements (dipole variants, quarter-wave monopoles).

--- a/src/physics/constants.ts
+++ b/src/physics/constants.ts
@@ -34,10 +34,9 @@ export function halfWaveLength(frequencyMHz: number, endEffect = 0.95): number {
 
 const REFERENCE_LENGTH_STRATEGIES: Record<AntennaType, (lambda: number, endEffect: number) => number> = {
   dipole: (lambda, endEffect) => lambda * 0.5 * endEffect,
-  // endEffect is intentionally omitted: 0.97 is a fixed apex-angle geometry
-  // shortening factor specific to the V shape, not a wire-diameter end-effect.
-  // Composing it with the caller-supplied endEffect would double-correct.
   'inverted-v': (lambda) => {
+    // The V geometry reduces the effective horizontal current component;
+    // slightly more wire than a flat dipole is needed to restore resonance.
     return lambda * 0.5 * 0.97;
   },
   'delta-loop': (lambda) => {
@@ -85,12 +84,6 @@ const REFERENCE_LENGTH_STRATEGIES: Record<AntennaType, (lambda: number, endEffec
  *   - sloping-v: 2λ total (1λ per leg). Traveling-wave antenna; no
  *     end-effect correction applies.
  *   - terminated-delta: 1.02λ perimeter (same triangle as delta-loop).
- *   - vertical-whip: 0.2375λ (0.25λ × endEffect). Quarter-wave monopole.
- *   - inverted-l: 0.2375λ (0.25λ × endEffect). Total wire length (vertical +
- *     horizontal) for a quarter-wave equivalent; top-loading reduces mast height.
- *   - folded-dipole: 0.475λ (0.5λ × endEffect). Same resonant length as a
- *     dipole; the second parallel conductor raises feedpoint impedance ~4× but
- *     does not alter the resonant length.
  *
  * Applies the standard HF end-effect factor k ~ 0.95 only to resonant
  * half-wave elements (dipole variants, quarter-wave monopoles).


### PR DESCRIPTION
🎯 **What:** Replaced the large `switch` statement in the `referenceLength` function (`src/physics/constants.ts`) with a `REFERENCE_LENGTH_STRATEGIES` map that uses the `AntennaType` as keys to call dedicated strategy functions.

💡 **Why:** A map of strategy functions is cleaner, reduces the cognitive load of a long `switch` statement, and makes it easier to extend with new antenna types in the future without growing the central function linearly.

✅ **Verification:** Verified by ensuring the fallback logic matches the old default logic (`|| REFERENCE_LENGTH_STRATEGIES.dipole`), and ran the entire test suite (`npm run test`) successfully. 

✨ **Result:** A more maintainable and readable `referenceLength` implementation that behaves identically to the previous version.

---
*PR created automatically by Jules for task [2345639995931861886](https://jules.google.com/task/2345639995931861886) started by @2fst4u*