### PR TITLE
🎨 Palette: Add ARIA alert to scene crash fallback

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -137,7 +137,7 @@ function LiveAntennaScene({ engineReady, loading, error }: { engineReady: boolea
 
 function sceneFallback(err: Error, reset: () => void) {
   return (
-    <div style={{ padding: 20, color: '#ff6b6b', fontFamily: 'monospace' }}>
+    <div style={{ padding: 20, color: '#ff6b6b', fontFamily: 'monospace' }} role="alert" aria-live="assertive">
       <strong>3D scene crashed:</strong> {err.message}
       <button onClick={reset} style={{ marginLeft: 10 }}>Retry</button>
     </div>


### PR DESCRIPTION
💡 **What:**
Added `role="alert"` and `aria-live="assertive"` to the 3D scene's crash fallback UI (`sceneFallback`) in `src/App.tsx`.

🎯 **Why:**
When the React Three Fiber `<Canvas>` crashes and is caught by the `<ErrorBoundary>`, a visible error banner replaces the 3D scene. Previously, this change was purely visual. Screen reader users would not be notified that the visualization had failed unless they manually re-navigated the DOM to discover the crash text. Adding an assertive alert ensures immediate, accessible feedback.

📸 **Before/After:**
- **Before:** Silent fallback replacement.
- **After:** Screen readers announce "Alert: 3D scene crashed: [error message]".

♿ **Accessibility:**
Provides critical context to assistive technologies about catastrophic component failures.

---
*PR created automatically by Jules for task [3149272277612062045](https://jules.google.com/task/3149272277612062045) started by @2fst4u*