### PR TITLE
🧪 Spec: Add physicsWorker tests

### DIFF
--- a/.jules/spec.md
+++ b/.jules/spec.md
@@ -17,3 +17,7 @@
 ## 2026-05-30 - Add tests for formatBandwidth
 **Learning:** JS `.toFixed()` exhibits unexpected rounding behavior with `.5` boundaries (e.g. `(1.555).toFixed(2) === '1.55'`, not `'1.56'`) due to IEEE 754 floating point representation. Tests targeting exact decimal boundaries must reflect this native JS logic rather than purely mathematical rounding.
 **Action:** Created `tests/swrChartUtils.test.ts` ensuring branch logic (< 1MHz and >= 1MHz) is tested while accounting for standard floating point boundaries.
+## 2024-05-30 - Mocking Async Methods and Global Workers
+
+**Learning:** When testing worker components communicating through simulated globals (`addEventListenerSpy`, `postMessageSpy`), resetting mock implementations (`mockReset()`) is critical in `beforeEach()`. Otherwise, mocked rejections from prior test blocks will leak into subsequent setups (e.g. `simulate` continuing to reject), leading to seemingly inexplicable test failures. Ensure `simulate` and `sweepImpedance` mocks are reset before each block.
+**Action:** Explicitly reset all stubbed or mocked engine methods in the test runner's `beforeEach` to ensure a pristine state for the subsequent worker simulation.

--- a/tests/physicsWorker.test.ts
+++ b/tests/physicsWorker.test.ts
@@ -91,7 +91,7 @@ describe('physicsWorker error path test', () => {
   it('posts result message when simulate succeeds', async () => {
     mockEngineInstance.init.mockResolvedValue(undefined);
 
-    let messageHandler: any;
+    let messageHandler: (msg: any) => void; // eslint-disable-line @typescript-eslint/no-explicit-any
     addEventListenerSpy.mockImplementation((type, handler) => {
       if (type === 'message') messageHandler = handler;
     });
@@ -117,7 +117,7 @@ describe('physicsWorker error path test', () => {
   it('posts error message when simulate fails', async () => {
     mockEngineInstance.init.mockResolvedValue(undefined);
 
-    let messageHandler: any;
+    let messageHandler: (msg: any) => void; // eslint-disable-line @typescript-eslint/no-explicit-any
     addEventListenerSpy.mockImplementation((type, handler) => {
       if (type === 'message') messageHandler = handler;
     });
@@ -141,7 +141,7 @@ describe('physicsWorker error path test', () => {
 
   it('handles worker error events', async () => {
     mockEngineInstance.init.mockResolvedValue(undefined);
-    let errorHandler: any;
+    let errorHandler: (ev: any) => void; // eslint-disable-line @typescript-eslint/no-explicit-any
     addEventListenerSpy.mockImplementation((type, handler) => {
       if (type === 'error') errorHandler = handler;
     });
@@ -156,7 +156,7 @@ describe('physicsWorker error path test', () => {
 
   it('handles worker unhandledrejection events', async () => {
     mockEngineInstance.init.mockResolvedValue(undefined);
-    let rejectionHandler: any;
+    let rejectionHandler: (ev: any) => void; // eslint-disable-line @typescript-eslint/no-explicit-any
     addEventListenerSpy.mockImplementation((type, handler) => {
       if (type === 'unhandledrejection') rejectionHandler = handler;
     });
@@ -172,7 +172,7 @@ describe('physicsWorker error path test', () => {
   it('ignores messages with unknown types', async () => {
     mockEngineInstance.init.mockResolvedValue(undefined);
 
-    let messageHandler: any;
+    let messageHandler: (msg: any) => void; // eslint-disable-line @typescript-eslint/no-explicit-any
     addEventListenerSpy.mockImplementation((type, handler) => {
       if (type === 'message') messageHandler = handler;
     });
@@ -197,7 +197,7 @@ describe('physicsWorker error path test', () => {
   it('posts error message when simulate fails with a non-Error object', async () => {
     mockEngineInstance.init.mockResolvedValue(undefined);
 
-    let messageHandler: any;
+    let messageHandler: (msg: any) => void; // eslint-disable-line @typescript-eslint/no-explicit-any
     addEventListenerSpy.mockImplementation((type, handler) => {
       if (type === 'message') messageHandler = handler;
     });

--- a/tests/physicsWorker.test.ts
+++ b/tests/physicsWorker.test.ts
@@ -33,6 +33,8 @@ describe('physicsWorker error path test', () => {
 
     // Reset mock implementation for each test
     mockEngineInstance.init.mockReset();
+    mockEngineInstance.simulate.mockReset();
+    mockEngineInstance.sweepImpedance.mockReset();
   });
 
   afterEach(() => {
@@ -74,6 +76,146 @@ describe('physicsWorker error path test', () => {
       id: -1,
       type: 'error',
       message: 'Engine init failed: String error',
+    });
+  });
+
+  it('posts ready message when initialization succeeds', async () => {
+    mockEngineInstance.init.mockResolvedValue(undefined);
+
+    await import('../src/workers/physicsWorker');
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(postMessageSpy).toHaveBeenCalledWith({ type: 'ready' });
+  });
+
+  it('posts result message when simulate succeeds', async () => {
+    mockEngineInstance.init.mockResolvedValue(undefined);
+
+    let messageHandler: any;
+    addEventListenerSpy.mockImplementation((type, handler) => {
+      if (type === 'message') messageHandler = handler;
+    });
+
+    await import('../src/workers/physicsWorker');
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    mockEngineInstance.simulate.mockResolvedValue({ some: 'result' });
+    mockEngineInstance.sweepImpedance.mockResolvedValue([{ f: 1 }]);
+
+    messageHandler({ data: { id: 123, type: 'simulate', input: { frequency: 14 } } });
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(postMessageSpy).toHaveBeenCalledWith({
+      id: 123,
+      type: 'result',
+      result: { some: 'result' },
+      sweep: [{ f: 1 }]
+    });
+  });
+
+  it('posts error message when simulate fails', async () => {
+    mockEngineInstance.init.mockResolvedValue(undefined);
+
+    let messageHandler: any;
+    addEventListenerSpy.mockImplementation((type, handler) => {
+      if (type === 'message') messageHandler = handler;
+    });
+
+    await import('../src/workers/physicsWorker');
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    mockEngineInstance.simulate.mockRejectedValue(new Error('Simulate failed'));
+    mockEngineInstance.sweepImpedance.mockResolvedValue([]);
+
+    messageHandler({ data: { id: 124, type: 'simulate', input: { frequency: 14 } } });
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(postMessageSpy).toHaveBeenCalledWith({
+      id: 124,
+      type: 'error',
+      message: 'Simulate failed'
+    });
+  });
+
+  it('handles worker error events', async () => {
+    mockEngineInstance.init.mockResolvedValue(undefined);
+    let errorHandler: any;
+    addEventListenerSpy.mockImplementation((type, handler) => {
+      if (type === 'error') errorHandler = handler;
+    });
+
+    await import('../src/workers/physicsWorker');
+
+    // Simulate an error event
+    errorHandler({ message: 'worker error', error: new Error('test') });
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith('[worker error]', 'worker error', expect.any(Error));
+  });
+
+  it('handles worker unhandledrejection events', async () => {
+    mockEngineInstance.init.mockResolvedValue(undefined);
+    let rejectionHandler: any;
+    addEventListenerSpy.mockImplementation((type, handler) => {
+      if (type === 'unhandledrejection') rejectionHandler = handler;
+    });
+
+    await import('../src/workers/physicsWorker');
+
+    // Simulate an unhandledrejection event
+    rejectionHandler({ reason: 'promise rejected' });
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith('[worker unhandledrejection]', 'promise rejected');
+  });
+
+  it('ignores messages with unknown types', async () => {
+    mockEngineInstance.init.mockResolvedValue(undefined);
+
+    let messageHandler: any;
+    addEventListenerSpy.mockImplementation((type, handler) => {
+      if (type === 'message') messageHandler = handler;
+    });
+
+    await import('../src/workers/physicsWorker');
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    // Reset postMessageSpy to ensure we only catch calls from the message handler
+    postMessageSpy.mockClear();
+
+    // Send a message with an unknown type
+    messageHandler({ data: { id: 125, type: 'unknown_type', input: { frequency: 14 } } });
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    // verify simulate was not called
+    expect(mockEngineInstance.simulate).not.toHaveBeenCalled();
+    // verify postMessage was not called
+    expect(postMessageSpy).not.toHaveBeenCalled();
+  });
+
+  it('posts error message when simulate fails with a non-Error object', async () => {
+    mockEngineInstance.init.mockResolvedValue(undefined);
+
+    let messageHandler: any;
+    addEventListenerSpy.mockImplementation((type, handler) => {
+      if (type === 'message') messageHandler = handler;
+    });
+
+    await import('../src/workers/physicsWorker');
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    mockEngineInstance.simulate.mockRejectedValue('String Error');
+    mockEngineInstance.sweepImpedance.mockResolvedValue([]);
+
+    messageHandler({ data: { id: 124, type: 'simulate', input: { frequency: 14 } } });
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(postMessageSpy).toHaveBeenCalledWith({
+      id: 124,
+      type: 'error',
+      message: 'String Error'
     });
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,10 +9,10 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       thresholds: {
-        statements: 69.8,
-        branches: 61.8,
-        functions: 71.3,
-        lines: 92.7,
+        statements: 70.5,
+        branches: 62.8,
+        functions: 72.4,
+        lines: 93.4,
       }
     }
   },


### PR DESCRIPTION
🧪 Spec: Add physicsWorker tests

💡 What: Added unit tests for successful engine initialization, simulate success/failure paths, worker error/unhandledrejection handlers, and unknown message types in `physicsWorker.ts`. Also fixed mock cleanup for the engine instance in `beforeEach`.
🎯 Why: `physicsWorker.ts` previously had dangerously low coverage (mostly error initialization paths) because simulating workers via Vitest and JSDOM required manual global scoping and careful event wiring. These tests fortify the boundary between the main thread and the physics engine.
📈 Maturity Impact: Bumped coverage thresholds for statements (69.8 to 70.5), branches (61.8 to 62.8), functions (71.3 to 72.4), and lines (92.7 to 93.4) to lock in progress toward business standards.

---
*PR created automatically by Jules for task [5121702294745077825](https://jules.google.com/task/5121702294745077825) started by @2fst4u*