### PR TITLE
🧪 Spec: Add physicsWorker tests

### DIFF
--- a/.jules/spec.md
+++ b/.jules/spec.md
@@ -17,3 +17,6 @@
 ## 2026-05-30 - Add tests for formatBandwidth
 **Learning:** JS `.toFixed()` exhibits unexpected rounding behavior with `.5` boundaries (e.g. `(1.555).toFixed(2) === '1.55'`, not `'1.56'`) due to IEEE 754 floating point representation. Tests targeting exact decimal boundaries must reflect this native JS logic rather than purely mathematical rounding.
 **Action:** Created `tests/swrChartUtils.test.ts` ensuring branch logic (< 1MHz and >= 1MHz) is tested while accounting for standard floating point boundaries.
+## 2024-11-20 - [Avoid SetTimeout in tests for Macrotask flushing]
+**Learning:** In Vitest, using `setTimeout(resolve, 0)` to wait for asynchronous operations or dynamic imports like worker mock initializations introduces flakiness and is strictly prohibited. Use `setImmediate` via a `flushPromises` utility function (e.g., `const flushPromises = () => new Promise(resolve => setImmediate(resolve));`) for cleanly flushing the promise queue.
+**Action:** Replaced `setTimeout` with a `flushPromises` helper using `setImmediate` in `tests/physicsWorker.test.ts`.

--- a/tests/physicsWorker.test.ts
+++ b/tests/physicsWorker.test.ts
@@ -17,7 +17,9 @@ vi.mock('../src/physics/nec2Engine', () => {
   };
 });
 
-describe('physicsWorker error path test', () => {
+const flushPromises = () => new Promise(resolve => setImmediate(resolve));
+
+describe('physicsWorker tests', () => {
   let postMessageSpy: ReturnType<typeof vi.fn>;
   let addEventListenerSpy: ReturnType<typeof vi.fn>;
   let consoleErrorSpy: ReturnType<typeof vi.fn>;
@@ -41,39 +43,142 @@ describe('physicsWorker error path test', () => {
     consoleErrorSpy.mockRestore();
   });
 
-  it('posts error message when initialization fails with an Error', async () => {
-    // Set up the mock rejection before importing the worker
-    mockEngineInstance.init.mockRejectedValue(new Error('Mock initialization failure'));
+  describe('Initialization error paths', () => {
+    it('posts error message when initialization fails with an Error', async () => {
+      // Set up the mock rejection before importing the worker
+      mockEngineInstance.init.mockRejectedValue(new Error('Mock initialization failure'));
 
-    // Dynamically import to ensure mock globals and mock Nec2Engine are picked up
-    await import('../src/workers/physicsWorker');
+      // Dynamically import to ensure mock globals and mock Nec2Engine are picked up
+      await import('../src/workers/physicsWorker');
 
-    // Wait for the promise chain in physicsWorker.ts to resolve/reject
-    await new Promise(resolve => setTimeout(resolve, 0));
+      // Wait for the promise chain in physicsWorker.ts to resolve/reject
+      await flushPromises();
 
-    expect(postMessageSpy).toHaveBeenCalledWith({
-      id: -1,
-      type: 'error',
-      message: 'Engine init failed: Mock initialization failure',
+      expect(postMessageSpy).toHaveBeenCalledWith({
+        id: -1,
+        type: 'error',
+        message: 'Engine init failed: Mock initialization failure',
+      });
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        '[worker] engine init failed',
+        expect.any(Error)
+      );
     });
 
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      '[worker] engine init failed',
-      expect.any(Error)
-    );
+    it('posts error message when initialization fails with a non-Error', async () => {
+      mockEngineInstance.init.mockRejectedValue('String error');
+
+      await import('../src/workers/physicsWorker');
+
+      await flushPromises();
+
+      expect(postMessageSpy).toHaveBeenCalledWith({
+        id: -1,
+        type: 'error',
+        message: 'Engine init failed: String error',
+      });
+    });
   });
 
-  it('posts error message when initialization fails with a non-Error', async () => {
-    mockEngineInstance.init.mockRejectedValue('String error');
+  describe('Standard operation paths', () => {
+    it('posts ready message when initialization succeeds', async () => {
+      mockEngineInstance.init.mockResolvedValue(undefined);
+      await import('../src/workers/physicsWorker');
+      await flushPromises();
+      expect(postMessageSpy).toHaveBeenCalledWith({ type: 'ready' });
+    });
 
-    await import('../src/workers/physicsWorker');
+    it('logs worker error to console', async () => {
+      mockEngineInstance.init.mockResolvedValue(undefined);
+      await import('../src/workers/physicsWorker');
+      await flushPromises();
 
-    await new Promise(resolve => setTimeout(resolve, 0));
+      const errorCall = addEventListenerSpy.mock.calls.find(call => call[0] === 'error');
+      expect(errorCall).toBeDefined();
 
-    expect(postMessageSpy).toHaveBeenCalledWith({
-      id: -1,
-      type: 'error',
-      message: 'Engine init failed: String error',
+      const errorHandler = errorCall[1];
+      errorHandler({ message: 'test error', error: new Error('test') });
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith('[worker error]', 'test error', expect.any(Error));
+    });
+
+    it('logs worker unhandledrejection to console', async () => {
+      mockEngineInstance.init.mockResolvedValue(undefined);
+      await import('../src/workers/physicsWorker');
+      await flushPromises();
+
+      const rejectionCall = addEventListenerSpy.mock.calls.find(call => call[0] === 'unhandledrejection');
+      expect(rejectionCall).toBeDefined();
+
+      const rejectionHandler = rejectionCall[1];
+      rejectionHandler({ reason: 'test rejection' });
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith('[worker unhandledrejection]', 'test rejection');
+    });
+
+    it('handles simulate message and posts result on success', async () => {
+      mockEngineInstance.init.mockResolvedValue(undefined);
+      mockEngineInstance.simulate.mockResolvedValue({ some: 'result' });
+      mockEngineInstance.sweepImpedance.mockResolvedValue([{ some: 'sweep' }]);
+
+      await import('../src/workers/physicsWorker');
+      await flushPromises();
+
+      const messageCall = addEventListenerSpy.mock.calls.find(call => call[0] === 'message');
+      expect(messageCall).toBeDefined();
+
+      const messageHandler = messageCall[1];
+      messageHandler({ data: { id: 123, type: 'simulate', input: { frequency: 14 } } });
+
+      await flushPromises();
+
+      expect(postMessageSpy).toHaveBeenCalledWith({
+        id: 123,
+        type: 'result',
+        result: { some: 'result' },
+        sweep: [{ some: 'sweep' }]
+      });
+    });
+
+    it('handles simulate message and posts error on failure', async () => {
+      mockEngineInstance.init.mockResolvedValue(undefined);
+      mockEngineInstance.simulate.mockRejectedValue(new Error('Simulate error'));
+
+      await import('../src/workers/physicsWorker');
+      await flushPromises();
+
+      const messageCall = addEventListenerSpy.mock.calls.find(call => call[0] === 'message');
+      const messageHandler = messageCall[1];
+      messageHandler({ data: { id: 456, type: 'simulate', input: { frequency: 14 } } });
+
+      await flushPromises();
+
+      expect(postMessageSpy).toHaveBeenCalledWith({
+        id: 456,
+        type: 'error',
+        message: 'Simulate error'
+      });
+    });
+
+    it('handles simulate message and posts string error on failure', async () => {
+      mockEngineInstance.init.mockResolvedValue(undefined);
+      mockEngineInstance.simulate.mockRejectedValue('String Simulate error');
+
+      await import('../src/workers/physicsWorker');
+      await flushPromises();
+
+      const messageCall = addEventListenerSpy.mock.calls.find(call => call[0] === 'message');
+      const messageHandler = messageCall[1];
+      messageHandler({ data: { id: 456, type: 'simulate', input: { frequency: 14 } } });
+
+      await flushPromises();
+
+      expect(postMessageSpy).toHaveBeenCalledWith({
+        id: 456,
+        type: 'error',
+        message: 'String Simulate error'
+      });
     });
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,10 +9,10 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       thresholds: {
-        statements: 69.8,
-        branches: 61.8,
-        functions: 71.3,
-        lines: 92.7,
+        statements: 70.5,
+        branches: 62.7,
+        functions: 72.4,
+        lines: 93.4,
       }
     }
   },


### PR DESCRIPTION
💡 **What:** Added tests to `tests/physicsWorker.test.ts` to fully cover the Web Worker initialization, successful `ready` state emitting, simulated successes/failures handled via `postMessage`, and logging of unhandled errors directly to `console.error`. Grouped into distinct `describe` blocks.
🎯 **Why:** The `physicsWorker.ts` module handles the core async orchestration of the NEC-2 engine and its test coverage was severely lagging (statements: ~52%, functions: 14%).
📈 **Maturity Impact:** Bumped coverage thresholds in `vitest.config.ts` from (statements: 69.8%, branches: 61.8%, functions: 71.3%, lines: 92.7%) to (statements: 70.5%, branches: 62.7%, functions: 72.4%, lines: 93.4%) to lock in progress toward business standards.

---
*PR created automatically by Jules for task [18018118544856556429](https://jules.google.com/task/18018118544856556429) started by @2fst4u*