### PR TITLE
fix(sweep): keep narrowband antennas framed on their operating band

### DIFF
--- a/src/physics/nec2Engine.ts
+++ b/src/physics/nec2Engine.ts
@@ -22,7 +22,7 @@ import { buildNecCards } from './necCard';
 import { parseNecImpedanceSweep, parseNecOutput } from './necParser';
 import { computeTerminationDiagnostics } from './terminationDiagnostics';
 import { swr, mismatchLossFactor } from './impedance';
-import { findSwrBands } from './bandwidth';
+import { findSwrBands, type SwrBand } from './bandwidth';
 import type { Engine, ImpedanceResult, SimulationInput, SimulationResult, SweepPoint } from './types';
 
 interface EmscriptenFS {
@@ -400,6 +400,53 @@ export class Nec2Engine implements Engine {
       2,
     );
 
+    // Frame the final sweep window around a set of ≤2:1 bands, keeping the
+    // operating-frequency marker in view and clamping to the HF band limits.
+    const frameWindow = (bands: readonly SwrBand[]): { start: number; end: number } => {
+      let winStart: number;
+      let winEnd: number;
+      if (bands.length > 0) {
+        const unionLow = bands[0]!.fLow;
+        const unionHigh = bands[bands.length - 1]!.fHigh;
+        const width = Math.max(unionHigh - unionLow, f * 0.02);
+        const margin = Math.max(width * 0.25, f * 0.02);
+        // When a band is clipped the actual crossing lies beyond the scan boundary.
+        // Use the appropriate HF limit as the anchor on that side.
+        const lowAnchor = bands[0]!.lowClipped
+          ? (reachedLimits ? loEdge : F_MIN)
+          : unionLow;
+        const highAnchor = bands[bands.length - 1]!.highClipped
+          ? (reachedLimits ? hiEdge : F_MAX)
+          : unionHigh;
+        winStart = lowAnchor - margin;
+        winEnd = highAnchor + margin;
+      } else {
+        // Never dips below 2:1 within the explored window — show what we scanned.
+        winStart = loEdge;
+        winEnd = hiEdge;
+      }
+      winStart = Math.max(F_MIN, Math.min(winStart, f));
+      winEnd = Math.min(F_MAX, Math.max(winEnd, f));
+      if (!(winEnd > winStart)) {
+        ({ start: winStart, end: winEnd } = this.clampSpan(f, 0.1));
+      }
+      return { start: winStart, end: winEnd };
+    };
+
+    // Width of the operating-frequency band — the primary band containing f, or
+    // failing that the primary band nearest f. Used to protect that band's
+    // resolution when deciding whether to widen the window for distant bands.
+    const operatingBandWidth = ((): number => {
+      if (primaryBands.length === 0) return f * 0.02;
+      const containing = primaryBands.find((b) => f >= b.fLow && f <= b.fHigh);
+      const distance = (b: SwrBand): number =>
+        Math.min(Math.abs(b.fLow - f), Math.abs(b.fHigh - f));
+      const band =
+        containing ??
+        primaryBands.reduce((best, b) => (distance(b) < distance(best) ? b : best));
+      return Math.max(band.fHigh - band.fLow, f * 0.001);
+    })();
+
     let allBands = primaryBands;
     if (!reachedLimits) {
       // ~1 pt/MHz across 1.0–30 MHz — detects any band ≥ ~2 MHz wide.
@@ -428,41 +475,29 @@ export class Nec2Engine implements Engine {
         (b) => b.fHigh < loEdge - 0.5 || b.fLow > hiEdge + 0.5,
       );
       if (extraBands.length > 0) {
-        allBands = [...extraBands, ...primaryBands].sort((a, b) => a.fLow - b.fLow);
+        const merged = [...extraBands, ...primaryBands].sort((a, b) => a.fLow - b.fLow);
+        if (primaryBands.length === 0) {
+          // No operating-frequency band to protect — show whatever band exists.
+          allBands = merged;
+        } else {
+          // Resolve-aware merge: only widen the window to include a distant band
+          // (e.g. a harmonic resonance of a narrowband dipole) if the operating
+          // band stays adequately sampled at the final point count. Otherwise
+          // the operating band falls between samples — its dip vanishes from the
+          // chart and the marker reads an off-resonance SWR — so we keep the
+          // window focused on the operating band instead.
+          const MIN_OPERATING_BAND_SAMPLES = 4;
+          const { start, end } = frameWindow(merged);
+          const spacing = points > 1 ? (end - start) / (points - 1) : end - start;
+          const samplesInOperatingBand = spacing > 0 ? operatingBandWidth / spacing : Infinity;
+          if (samplesInOperatingBand >= MIN_OPERATING_BAND_SAMPLES) {
+            allBands = merged;
+          }
+        }
       }
     }
 
-    // Frame the final sweep window around every detected ≤2:1 band.
-    let winStart: number;
-    let winEnd: number;
-    if (allBands.length > 0) {
-      const unionLow = allBands[0]!.fLow;
-      const unionHigh = allBands[allBands.length - 1]!.fHigh;
-      const width = Math.max(unionHigh - unionLow, f * 0.02);
-      const margin = Math.max(width * 0.25, f * 0.02);
-      // When a band is clipped the actual crossing lies beyond the scan boundary.
-      // Use the appropriate HF limit as the anchor on that side.
-      const lowAnchor = allBands[0]!.lowClipped
-        ? (reachedLimits ? loEdge : F_MIN)
-        : unionLow;
-      const highAnchor = allBands[allBands.length - 1]!.highClipped
-        ? (reachedLimits ? hiEdge : F_MAX)
-        : unionHigh;
-      winStart = lowAnchor - margin;
-      winEnd = highAnchor + margin;
-    } else {
-      // Never dips below 2:1 within the explored window — show what we scanned.
-      winStart = loEdge;
-      winEnd = hiEdge;
-    }
-
-    // Keep the operating-frequency marker in view and clamp to the HF band.
-    winStart = Math.max(F_MIN, Math.min(winStart, f));
-    winEnd = Math.min(F_MAX, Math.max(winEnd, f));
-    if (!(winEnd > winStart)) {
-      ({ start: winStart, end: winEnd } = this.clampSpan(f, 0.1));
-    }
-
+    const { start: winStart, end: winEnd } = frameWindow(allBands);
     return this.runScan(input, winStart, winEnd, points);
   }
 

--- a/tests/nec2Engine.sweep.test.ts
+++ b/tests/nec2Engine.sweep.test.ts
@@ -139,4 +139,55 @@ describe('adaptive sweep framing (no spanFraction)', () => {
     }
     expect(minEff).toBeLessThan(2);
   }, 90_000);
+
+  it('keeps a narrowband dipole framed on its operating band, not a harmonic', async () => {
+    // Regression: a regular horizontal dipole is resonant on its fundamental
+    // AND on harmonics (a 26.58 m dipole driven on the 60 m band at 5.358 MHz
+    // is also resonant near ~28 MHz). The broad-scan multi-band detection used
+    // to merge that distant harmonic into the window, stretching the sweep to
+    // span the whole HF range. With only 15 points across ~29 MHz the narrow
+    // operating band fell between samples — so Min SWR / the marker reported
+    // the harmonic instead of the resonant operating frequency. The
+    // resolve-aware merge must keep the window focused on the operating band.
+    const engine = new Nec2Engine({ baseUrl: wasmUrl });
+    await engine.init();
+
+    const opFreq = 5.358;
+    const state = {
+      ...useAntennaStore.getState(),
+      antennaType: 'dipole',
+      length: 26.58,
+      height: 8,
+      frequency: opFreq,
+      orientation: 'EW',
+      transformerEnabled: false,
+      feedlineId: 'none',
+    } as AntennaState;
+
+    const sweep = await engine.sweepImpedance(selectSimulationInput(state), { points: 15 });
+
+    const start = sweep[0]!.frequencyMHz;
+    const end = sweep[sweep.length - 1]!.frequencyMHz;
+
+    // Operating frequency is in view, framed by a window centred on its band.
+    expect(start).toBeLessThanOrEqual(opFreq);
+    expect(end).toBeGreaterThanOrEqual(opFreq);
+    // The distant ~28 MHz harmonic must NOT pull the window open — the span
+    // stays tight around the operating band rather than reaching up to it.
+    expect(end).toBeLessThan(10);
+
+    // The resolved minimum SWR sits on the operating band (low and near opFreq),
+    // not on the harmonic up near 28 MHz.
+    let minSwr = Infinity;
+    let minFreq = 0;
+    for (const p of sweep) {
+      if (p.swr < minSwr) {
+        minSwr = p.swr;
+        minFreq = p.frequencyMHz;
+      }
+    }
+    expect(minSwr).toBeLessThan(2);
+    expect(minFreq).toBeGreaterThan(4.5);
+    expect(minFreq).toBeLessThan(6.5);
+  }, 90_000);
 });


### PR DESCRIPTION
## Problem

For a narrowband antenna like a regular horizontal dipole, the SWR sweep was framing the chart around the wrong resonance. Example reported: a 26.58 m dipole at 8 m driven on the 60 m band (5.358 MHz):

- **Min SWR** reported `1.33:1 at 27.929 MHz` and **2:1 BW** `(27.843 – 28.106 MHz)` — i.e. the chart focused on a *harmonic*, not the operating frequency.
- At the operating frequency the chart marker read SWR ≈ 4.47, even though the true source impedance there (53.6 + j18.6 Ω) gives SWR 1.44.

### Root cause (`adaptiveSweep` in `src/physics/nec2Engine.ts`)

1. Phase 1 correctly framed a narrow window around the 5.358 MHz operating band.
2. Phase 2 does a coarse broad scan (1–30 MHz, ~1 pt/MHz) to find *additional* ≤2:1 bands for genuine multi-band antennas (T2FD/EFHW). A dipole is also resonant on a harmonic near ~28 MHz, so the broad scan caught it and **merged it as an extra band**.
3. Framing then spanned from the 5.358 MHz band all the way to the ~28 MHz band → clamped to essentially the full HF range.
4. The final sweep runs only `points` (~15) samples across that ~29 MHz span ≈ 1.7 MHz/sample. The narrow operating band fell **between** samples and vanished from the chart, while a sample landed on the harmonic. Hence Min SWR / 2:1 BW / the marker all reflected the harmonic.

## Fix

Make the multi-band merge **resolve-aware**: a distant extra band is only merged into the window if the operating-frequency band stays adequately sampled (≥ 4 points) at the final point count. Otherwise the window stays focused on the operating band.

- Narrowband dipoles with widely-separated harmonics now stay framed on the operating band.
- Contiguous / broadband multi-band antennas (T2FD/EFHW with wide bands) are unaffected — their merged window keeps fine sample spacing, so the merge is still accepted.
- When there is no operating-frequency band to protect (antenna not resonant near the chosen frequency), the detected band is still shown.

Also refactors the window-framing logic into a reusable `frameWindow` helper so the resolution check and the final framing share one implementation.

### Verification

For the reported case the window now frames **5.194 – 5.642 MHz** with Min SWR **1.168 @ 5.418 MHz** — centred on the operating band instead of the harmonic.

- Added a regression test (`tests/nec2Engine.sweep.test.ts`) reproducing the 60 m dipole scenario.
- Existing broadband T2FD widening test still passes (multi-band path intact).
- Full suite: **636 tests pass**; `tsc -b` and `eslint` clean.

https://claude.ai/code/session_016s7y1RVmcsW8Zs3SmBmaPM

---
_Generated by [Claude Code](https://claude.ai/code/session_016s7y1RVmcsW8Zs3SmBmaPM)_