### PR TITLE
Scale 3D pattern bubble to realized gain

### DIFF
--- a/src/components/Charts/PolarPlots.tsx
+++ b/src/components/Charts/PolarPlots.tsx
@@ -13,6 +13,7 @@ import {
 import { useAntennaStore } from '../../store/antennaStore';
 import { useShallow } from 'zustand/react/shallow';
 import { useMemo } from 'react';
+import { displayedFeedMetrics } from '../../physics/impedance';
 import type { GainPattern } from '../../physics/types';
 
 ChartJS.register(RadialLinearScale, PointElement, LineElement, Filler, Tooltip);
@@ -102,13 +103,35 @@ export function PolarPlots() {
     showPolarCuts,
     orientation,
     theme,
+    transformerEnabled,
+    transformerRatio,
+    feedlineId,
   } = useAntennaStore(useShallow((s) => ({
     result: s.result,
     dbRange: s.dbRange,
     showPolarCuts: s.showPolarCuts,
     orientation: s.orientation,
     theme: s.theme,
+    transformerEnabled: s.transformerEnabled,
+    transformerRatio: s.transformerRatio,
+    feedlineId: s.feedlineId,
   })));
+
+  // The cuts are normalised to the pattern peak (shape only), but the ring
+  // labels report absolute dBi. Reference them to the realized-gain peak —
+  // gain minus feedpoint mismatch/insertion loss — so the rings agree with the
+  // 3D bubble and the stats readout instead of advertising the intrinsic gain.
+  // The offset is direction-independent, so relabelling every ring by it is
+  // exact for every point on the cut.
+  const peakDbi = useMemo(() => {
+    if (!result) return 0;
+    const { displayedRealizedGainDbi } = displayedFeedMetrics(result, {
+      transformerEnabled,
+      transformerRatio,
+      feedlineActive: feedlineId !== 'none',
+    });
+    return displayedRealizedGainDbi ?? result.maxGainDbi;
+  }, [result, transformerEnabled, transformerRatio, feedlineId]);
 
   const azData = useMemo(() => {
     if (!result) return null;
@@ -171,7 +194,7 @@ export function PolarPlots() {
           count: 5,
           callback: (val) => {
             if (!result) return '';
-            return `${(Number(val) + (result.maxGainDbi - dbRange)).toFixed(0)} dBi`;
+            return `${(Number(val) + (peakDbi - dbRange)).toFixed(0)} dBi`;
           },
         },
         grid: { color: chartGrid, circular: true },
@@ -179,7 +202,7 @@ export function PolarPlots() {
         pointLabels: { color: chartText, font: { size: 10 }, padding: 0 },
       },
     },
-  }), [dbRange, chartText, chartGrid, result]);
+  }), [dbRange, chartText, chartGrid, result, peakDbi]);
 
   const color = 'rgba(79, 179, 255, 0.55)';
 

--- a/src/components/Panel/StatsReadout.tsx
+++ b/src/components/Panel/StatsReadout.tsx
@@ -1,11 +1,8 @@
 import { useAntennaStore, DIPOLE_LEFT_TAG, DIPOLE_RIGHT_TAG } from '../../store/antennaStore';
 import { useShallow } from 'zustand/react/shallow';
-import {
-  mismatchLossFactor,
-  swr,
-} from '../../physics/impedance';
+import { displayedFeedMetrics } from '../../physics/impedance';
 import { TRANSFORMER_INSERTION_LOSS_DB } from '../../physics/constants';
-import type { ImpedanceResult, TerminationDiagnostics } from '../../physics/types';
+import type { TerminationDiagnostics } from '../../physics/types';
 
 export function StatsReadout() {
   // ⚡ Bolt: Performance Optimization
@@ -38,44 +35,15 @@ export function StatsReadout() {
     );
   }
 
-  // When a feedline is active and the transformer is engaged, the NEC
-  // simulation already includes the impedance-transforming unun via an NT
-  // card — so `result.impedance` is already what the rig sees, no extra
-  // de-embed/divide/re-embed math required.
-  //
-  // When there's no feedline, the transformer is a "phantom" (nowhere
-  // physical to put it in the NEC model), so we apply Z/ratio here on the
-  // display side as a best-effort idealised representation.
-  const transformerInModel = transformerEnabled && feedlineActive && transformerRatio > 1;
-  const transformerInDisplay = transformerEnabled && !feedlineActive && transformerRatio > 1;
-
-  const displayedZ: ImpedanceResult = transformerInDisplay
-    ? { R: result.impedance.R / transformerRatio, X: result.impedance.X / transformerRatio }
-    : result.impedance;
-  const displayedSwr = transformerInDisplay ? swr(displayedZ) : result.swr;
-
-  let displayedRealizedGainDbi: number | undefined;
-  if (transformerInDisplay) {
-    const mlf = mismatchLossFactor(displayedZ);
-    if (mlf > 0) {
-      displayedRealizedGainDbi =
-        result.maxGainDbi + 10 * Math.log10(mlf) - TRANSFORMER_INSERTION_LOSS_DB;
-    }
-  } else if (transformerInModel) {
-    // NEC's realized gain already accounts for the matched feedpoint;
-    // subtract the transformer hardware's insertion loss.
-    displayedRealizedGainDbi = result.maxRealizedGainDbi != null
-      ? result.maxRealizedGainDbi - TRANSFORMER_INSERTION_LOSS_DB
-      : undefined;
-  } else if (transformerEnabled) {
-    // Choke-only case (ratio == 1, or transformer engaged without a feedline
-    // and with ratio 1). Use NEC's realized gain, plus insertion loss.
-    displayedRealizedGainDbi = result.maxRealizedGainDbi != null
-      ? result.maxRealizedGainDbi - TRANSFORMER_INSERTION_LOSS_DB
-      : undefined;
-  } else {
-    displayedRealizedGainDbi = result.maxRealizedGainDbi ?? undefined;
-  }
+  // The displayed feedpoint metrics (impedance, SWR, realized gain) fold in any
+  // impedance transformer — either modelled in NEC (feedline present) or applied
+  // as an idealised display-side transform (no feedline). The same helper drives
+  // the 3D pattern's realized-gain scaling, so the readout and the bubble agree.
+  const { displayedZ, displayedSwr, displayedRealizedGainDbi } = displayedFeedMetrics(result, {
+    transformerEnabled,
+    transformerRatio,
+    feedlineActive,
+  });
 
   const impedanceLabel = feedlineActive ? 'Source impedance (R + jX)' : 'Feedpoint (R + jX)';
   const impedanceTitle = feedlineActive

--- a/src/components/Scene/AntennaScene.tsx
+++ b/src/components/Scene/AntennaScene.tsx
@@ -7,12 +7,13 @@
 
 import { Canvas } from '@react-three/fiber';
 import { OrbitControls, GizmoHelper, GizmoViewport } from '@react-three/drei';
-import { Suspense } from 'react';
+import { Suspense, useMemo } from 'react';
 import { DipoleWire } from './DipoleWire';
 import { GroundPlane } from './GroundPlane';
 import { RadiationPattern } from './RadiationPattern';
 import { useAntennaStore, type ComparisonSnapshot } from '../../store/antennaStore';
 import { useShallow } from 'zustand/react/shallow';
+import { displayedFeedMetrics } from '../../physics/impedance';
 import { THEME_COLORS } from '../../utils/themeColors';
 
 interface AntennaSceneProps {
@@ -33,6 +34,8 @@ export function AntennaScene({ snapshot = null }: AntennaSceneProps) {
     liveFeedlineLength,
     liveFeedlineOffset,
     liveWhipCounterpoise,
+    liveTransformerEnabled,
+    liveTransformerRatio,
     showGrid,
     showAxes,
     patternScale,
@@ -53,6 +56,8 @@ export function AntennaScene({ snapshot = null }: AntennaSceneProps) {
     liveFeedlineLength: s.feedlineLength,
     liveFeedlineOffset: s.feedlineOffset,
     liveWhipCounterpoise: s.whipCounterpoise,
+    liveTransformerEnabled: s.transformerEnabled,
+    liveTransformerRatio: s.transformerRatio,
     showGrid: s.showGrid,
     showAxes: s.showAxes,
     patternScale: s.patternScale,
@@ -74,6 +79,20 @@ export function AntennaScene({ snapshot = null }: AntennaSceneProps) {
   const feedlineLength = snapshot?.feedlineLength ?? liveFeedlineLength;
   const feedlineOffset = snapshot?.feedlineOffset ?? liveFeedlineOffset;
   const whipCounterpoise = snapshot?.whipCounterpoise ?? liveWhipCounterpoise;
+
+  // Scale the pattern bubble to realized gain: the gain actually delivered after
+  // feedpoint mismatch (and any transformer) loss. The offset is realizedGain −
+  // gain, the same constant the stats readout applies. Comparison snapshots don't
+  // capture transformer settings, so they fall back to plain realized gain.
+  const realizedGainOffsetDb = useMemo(() => {
+    if (!result || result.maxRealizedGainDbi == null) return 0;
+    const { displayedRealizedGainDbi } = displayedFeedMetrics(result, {
+      transformerEnabled: snapshot ? false : liveTransformerEnabled,
+      transformerRatio: snapshot ? 1 : liveTransformerRatio,
+      feedlineActive: feedlineId !== 'none',
+    });
+    return displayedRealizedGainDbi != null ? displayedRealizedGainDbi - result.maxGainDbi : 0;
+  }, [result, snapshot, liveTransformerEnabled, liveTransformerRatio, feedlineId]);
 
   return (
     <Canvas
@@ -112,6 +131,7 @@ export function AntennaScene({ snapshot = null }: AntennaSceneProps) {
           dbRange={dbRange}
           colorMaxDb={colorMaxDb}
           colormap={colormap}
+          realizedGainOffsetDb={realizedGainOffsetDb}
         />
       </Suspense>
 

--- a/src/components/Scene/RadiationPattern.tsx
+++ b/src/components/Scene/RadiationPattern.tsx
@@ -12,6 +12,14 @@ interface Props {
   readonly dbRange: number;
   readonly colorMaxDb: number;
   readonly colormap: Colormap;
+  /**
+   * Constant dB offset applied to every direction to turn the intrinsic gain
+   * pattern into the realized-gain pattern (= realizedGain − gain). Mismatch
+   * and insertion losses are direction-independent, so a single offset shrinks
+   * the whole bubble uniformly to what actually reaches the air. Defaults to 0
+   * (raw gain) when realized gain is unavailable.
+   */
+  readonly realizedGainOffsetDb?: number;
 }
 
 export function RadiationPattern({
@@ -21,6 +29,7 @@ export function RadiationPattern({
   dbRange,
   colorMaxDb,
   colormap,
+  realizedGainOffsetDb = 0,
 }: Props) {
   const lod = useAdaptiveLOD();
 
@@ -93,10 +102,12 @@ export function RadiationPattern({
 
       const v0 = v00 * (1 - fp) + v01 * fp;
       const v1 = v10 * (1 - fp) + v11 * fp;
-      gains[i] = v0 * (1 - ft) + v1 * ft;
+      // Add the realized-gain offset so radius and colour both represent the
+      // gain actually delivered after feedpoint mismatch/insertion loss.
+      gains[i] = v0 * (1 - ft) + v1 * ft + realizedGainOffsetDb;
     }
     return gains;
-  }, [result, cachedGeo]);
+  }, [result, cachedGeo, realizedGainOffsetDb]);
 
   // 2. Compute vertex positions. Re-run if gains or pattern scale change.
   const vertexPositions = useMemo(() => {

--- a/src/physics/impedance.ts
+++ b/src/physics/impedance.ts
@@ -1,7 +1,7 @@
 // Impedance/SWR helpers.
 
 import { Z0_SYSTEM, TRANSFORMER_INSERTION_LOSS_DB } from './constants';
-import type { ImpedanceResult } from './types';
+import type { ImpedanceResult, SimulationResult } from './types';
 
 /**
  * Reflection coefficient magnitude for a load Z against the system impedance.
@@ -42,6 +42,66 @@ export function swr(z: ImpedanceResult, z0: number = Z0_SYSTEM): number {
 export function mismatchLossFactor(z: ImpedanceResult, z0: number = Z0_SYSTEM): number {
   const gamma = reflectionCoefficientMag(z, z0);
   return 1 - gamma * gamma;
+}
+
+/** Feedpoint metrics as actually presented to the user. */
+export interface DisplayedFeedMetrics {
+  /** Impedance the radio sees (after any idealised display-side transformer). */
+  readonly displayedZ: ImpedanceResult;
+  /** SWR vs 50 Ω matching `displayedZ`. */
+  readonly displayedSwr: number;
+  /**
+   * Peak realized gain (dBi) the user is shown: intrinsic gain reduced by
+   * feedpoint mismatch loss and any transformer insertion loss. Undefined when
+   * the mismatch loss cannot be evaluated (total reflection / non-passive R).
+   */
+  readonly displayedRealizedGainDbi: number | undefined;
+}
+
+/**
+ * Resolve the feedpoint metrics shown to the user, accounting for an impedance
+ * transformer that is either modelled directly in NEC (feedline present, so
+ * `result.impedance`/`maxRealizedGainDbi` already include it) or applied as an
+ * idealised display-side transform (no feedline, nowhere physical to place it).
+ *
+ * Mismatch loss (1 − |Γ|²) and the transformer's fixed insertion loss are both
+ * direction-independent scalars, so `displayedRealizedGainDbi` always differs
+ * from `result.maxGainDbi` by a single constant — the exact offset the 3D
+ * pattern applies to render realized gain. Centralising the rule here keeps the
+ * stats readout and the pattern bubble in lock-step.
+ */
+export function displayedFeedMetrics(
+  result: Pick<SimulationResult, 'impedance' | 'swr' | 'maxGainDbi' | 'maxRealizedGainDbi'>,
+  config: { transformerEnabled: boolean; transformerRatio: number; feedlineActive: boolean },
+): DisplayedFeedMetrics {
+  const { transformerEnabled, transformerRatio, feedlineActive } = config;
+  const transformerInDisplay = transformerEnabled && !feedlineActive && transformerRatio > 1;
+
+  const displayedZ: ImpedanceResult = transformerInDisplay
+    ? { R: result.impedance.R / transformerRatio, X: result.impedance.X / transformerRatio }
+    : result.impedance;
+  const displayedSwr = transformerInDisplay ? swr(displayedZ) : result.swr;
+
+  let displayedRealizedGainDbi: number | undefined;
+  if (transformerInDisplay) {
+    // Phantom transformer: NEC never saw it, so derive realized gain from the
+    // intrinsic gain and the mismatch against the transformed (radio-side) Z.
+    const mlf = mismatchLossFactor(displayedZ);
+    if (mlf > 0) {
+      displayedRealizedGainDbi =
+        result.maxGainDbi + 10 * Math.log10(mlf) - TRANSFORMER_INSERTION_LOSS_DB;
+    }
+  } else if (transformerEnabled) {
+    // Transformer (or choke-only, ratio 1) modelled in NEC: its realized gain
+    // already reflects the matched feedpoint; just deduct the hardware loss.
+    displayedRealizedGainDbi = result.maxRealizedGainDbi != null
+      ? result.maxRealizedGainDbi - TRANSFORMER_INSERTION_LOSS_DB
+      : undefined;
+  } else {
+    displayedRealizedGainDbi = result.maxRealizedGainDbi ?? undefined;
+  }
+
+  return { displayedZ, displayedSwr, displayedRealizedGainDbi };
 }
 
 /**

--- a/tests/PolarPlots.test.tsx
+++ b/tests/PolarPlots.test.tsx
@@ -3,12 +3,16 @@ import { render, cleanup } from '@testing-library/react';
 import { PolarPlots } from '../src/components/Charts/PolarPlots';
 import { useAntennaStore } from '../src/store/antennaStore';
 
+const { tickCbs } = vi.hoisted(() => ({ tickCbs: [] as Array<(v: number) => string> }));
+
 vi.mock('react-chartjs-2', () => ({
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   Radar: (props: any) => {
-    // Simulate Chart.js calling the tick callback
-    if (props.options?.scales?.r?.ticks?.callback) {
-      props.options.scales.r.ticks.callback(10);
+    const cb = props.options?.scales?.r?.ticks?.callback;
+    if (cb) {
+      // Simulate Chart.js calling the tick callback, and expose it for assertions.
+      cb(10);
+      tickCbs.push(cb);
     }
     return <div data-testid="mock-radar-chart" />;
   },
@@ -17,6 +21,7 @@ vi.mock('react-chartjs-2', () => ({
 describe('PolarPlots', () => {
   beforeEach(() => {
     cleanup();
+    tickCbs.length = 0;
     useAntennaStore.setState({
       showPolarCuts: true,
       orientation: 'NS',
@@ -85,5 +90,49 @@ describe('PolarPlots', () => {
     useAntennaStore.setState({ showPolarCuts: false });
     const { container } = render(<PolarPlots />);
     expect(container.firstChild).toBeNull();
+  });
+
+  it('labels the outer ring with the realized-gain peak, not the intrinsic gain', () => {
+    // Severely mismatched antenna: 9.03 dBi gain but only −2.94 dBi realized.
+    useAntennaStore.setState({
+      dbRange: 40,
+      transformerEnabled: false,
+      feedlineId: 'none',
+      result: {
+        swr: 60.89,
+        computeTimeMs: 10,
+        impedance: { R: 1.7, X: 50.9 },
+        maxGainDbi: 9.03,
+        maxRealizedGainDbi: -2.94,
+        takeoffElevationDeg: 90,
+        takeoffAzimuthDeg: 0,
+        pattern: { data: new Float32Array(0), thetaSteps: 91, phiSteps: 72, dTheta: 1, dPhi: 5 },
+      } as unknown as import('../src/physics/types').SimulationResult,
+    });
+    render(<PolarPlots />);
+    // val = dbRange maps to the outer ring; it should read the realized peak.
+    expect(tickCbs[0]!(40)).toBe('-3 dBi');
+    // A ring 10 dB down reads 10 dB below the realized peak (offset is uniform).
+    expect(tickCbs[0]!(30)).toBe('-13 dBi');
+  });
+
+  it('falls back to intrinsic gain when realized gain is unavailable', () => {
+    useAntennaStore.setState({
+      dbRange: 40,
+      transformerEnabled: false,
+      feedlineId: 'none',
+      result: {
+        swr: 1.5,
+        computeTimeMs: 10,
+        impedance: { R: 50, X: 0 },
+        maxGainDbi: 6,
+        maxRealizedGainDbi: undefined,
+        takeoffElevationDeg: 30,
+        takeoffAzimuthDeg: 0,
+        pattern: { data: new Float32Array(0), thetaSteps: 91, phiSteps: 72, dTheta: 1, dPhi: 5 },
+      } as unknown as import('../src/physics/types').SimulationResult,
+    });
+    render(<PolarPlots />);
+    expect(tickCbs[0]!(40)).toBe('6 dBi');
   });
 });

--- a/tests/impedance.test.ts
+++ b/tests/impedance.test.ts
@@ -1,6 +1,81 @@
 import { vi } from "vitest";
 import { describe, expect, it } from 'vitest';
-import { swr, mismatchLossFactor, transformImpedance, deembedThroughLine, transformThroughLine, transformWithTransformerAtAntenna, realizedGainWithTransformer, suggestedTransformerRatio } from '../src/physics/impedance';
+import { swr, mismatchLossFactor, transformImpedance, deembedThroughLine, transformThroughLine, transformWithTransformerAtAntenna, realizedGainWithTransformer, suggestedTransformerRatio, displayedFeedMetrics } from '../src/physics/impedance';
+import { TRANSFORMER_INSERTION_LOSS_DB } from '../src/physics/constants';
+import type { SimulationResult } from '../src/physics/types';
+
+// Minimal result stub carrying only the fields displayedFeedMetrics reads.
+function stubResult(over: Partial<Pick<SimulationResult, 'impedance' | 'swr' | 'maxGainDbi' | 'maxRealizedGainDbi'>>) {
+  const impedance = over.impedance ?? { R: 50, X: 0 };
+  return {
+    impedance,
+    swr: over.swr ?? swr(impedance),
+    maxGainDbi: over.maxGainDbi ?? 0,
+    maxRealizedGainDbi:
+      'maxRealizedGainDbi' in over
+        ? over.maxRealizedGainDbi
+        : (over.maxGainDbi ?? 0) + 10 * Math.log10(mismatchLossFactor(impedance)),
+  } as Pick<SimulationResult, 'impedance' | 'swr' | 'maxGainDbi' | 'maxRealizedGainDbi'>;
+}
+
+describe('displayedFeedMetrics', () => {
+  const noTransformer = { transformerEnabled: false, transformerRatio: 1, feedlineActive: false };
+
+  it('no transformer: realized gain equals NEC realized gain; offset = 10·log10(1−|Γ|²)', () => {
+    // The 1.5λ dipole from the bug report: high gain, severe mismatch.
+    const result = stubResult({ impedance: { R: 1.7, X: 50.9 }, maxGainDbi: 9.03 });
+    const m = displayedFeedMetrics(result, noTransformer);
+
+    // Bubble offset the scene applies = realizedGain − gain.
+    const offset = m.displayedRealizedGainDbi! - result.maxGainDbi;
+    expect(offset).toBeCloseTo(10 * Math.log10(mismatchLossFactor(result.impedance)), 10);
+    // Sanity: lands near the readout's ~ −2.9 dBi (rounded inputs, so a loose
+    // bound) and the displayed Z is left untouched.
+    expect(m.displayedRealizedGainDbi!).toBeGreaterThan(-3.1);
+    expect(m.displayedRealizedGainDbi!).toBeLessThan(-2.7);
+    expect(m.displayedZ).toEqual(result.impedance);
+    expect(m.displayedSwr).toBe(result.swr);
+  });
+
+  it('perfect match: offset is 0 (bubble equals raw gain pattern)', () => {
+    const result = stubResult({ impedance: { R: 50, X: 0 }, maxGainDbi: 2.15 });
+    const m = displayedFeedMetrics(result, noTransformer);
+    expect(m.displayedRealizedGainDbi! - result.maxGainDbi).toBeCloseTo(0, 10);
+  });
+
+  it('phantom transformer (no feedline): divides Z by ratio and deducts insertion loss', () => {
+    const result = stubResult({ impedance: { R: 450, X: 0 }, maxGainDbi: 5 });
+    const m = displayedFeedMetrics(result, { transformerEnabled: true, transformerRatio: 9, feedlineActive: false });
+
+    const expectedZ = { R: 50, X: 0 };
+    expect(m.displayedZ).toEqual(expectedZ);
+    expect(m.displayedSwr).toBeCloseTo(1, 6); // 450/9 = 50 → matched
+    expect(m.displayedRealizedGainDbi!).toBeCloseTo(
+      5 + 10 * Math.log10(mismatchLossFactor(expectedZ)) - TRANSFORMER_INSERTION_LOSS_DB,
+      10,
+    );
+  });
+
+  it('transformer modelled in NEC (feedline active): NEC realized gain minus insertion loss', () => {
+    const result = stubResult({ impedance: { R: 50, X: 0 }, maxGainDbi: 5, maxRealizedGainDbi: 4.6 });
+    const m = displayedFeedMetrics(result, { transformerEnabled: true, transformerRatio: 9, feedlineActive: true });
+    // Z/SWR are taken as-is (NEC already includes the transformer).
+    expect(m.displayedZ).toEqual(result.impedance);
+    expect(m.displayedRealizedGainDbi!).toBeCloseTo(4.6 - TRANSFORMER_INSERTION_LOSS_DB, 10);
+  });
+
+  it('choke-only (ratio 1): NEC realized gain minus insertion loss', () => {
+    const result = stubResult({ impedance: { R: 73, X: 0 }, maxGainDbi: 2.15, maxRealizedGainDbi: 2.0 });
+    const m = displayedFeedMetrics(result, { transformerEnabled: true, transformerRatio: 1, feedlineActive: true });
+    expect(m.displayedRealizedGainDbi!).toBeCloseTo(2.0 - TRANSFORMER_INSERTION_LOSS_DB, 10);
+  });
+
+  it('undefined NEC realized gain leaves displayed realized gain undefined', () => {
+    const result = stubResult({ impedance: { R: 50, X: 0 }, maxGainDbi: 3, maxRealizedGainDbi: undefined });
+    const m = displayedFeedMetrics(result, noTransformer);
+    expect(m.displayedRealizedGainDbi).toBeUndefined();
+  });
+});
 
 describe('reflection coefficient and SWR', () => {
   it('perfect match => |Γ|=0, SWR=1', () => {


### PR DESCRIPTION
## Problem

The 3D radiation-pattern bubble was sized from **intrinsic gain** only, ignoring feedpoint mismatch loss. So a badly mismatched antenna — e.g. a 1.5 λ dipole at 7.1 MHz showing **9.03 dBi gain but 60.89:1 SWR** — drew a large 9 dBi lobe even though only ~6 % of the power actually reaches the air. That visually contradicted the **−2.94 dBi realized-gain** readout right next to it, and undercut the tool's purpose of showing what happens in real life.

## Fix

Mismatch loss (`1 − |Γ|²`) and any transformer insertion loss are **direction-independent scalars**, so the realized-gain pattern is just the gain pattern shifted down by a single constant:

```
G_r(θ,φ) [dBi] = G(θ,φ) [dBi] + 10·log10(1 − |Γ|²)
```

- `RadiationPattern` now takes a `realizedGainOffsetDb` prop (= `realizedGain − gain`) and folds it into the sampled gain, so **both** the bubble radius and the absolute-dBi colouring reflect delivered performance. The colormap legend stays truthful because the surface now represents realized-gain dBi against the same ceiling.
- The bubble's peak is now guaranteed to equal the displayed realized-gain number to the bit, because both come from a new shared `displayedFeedMetrics` helper.

## Refactor

Extracted the displayed-realized-gain rule (transformer-in-model / phantom transformer / choke-only / none) out of `StatsReadout` into `displayedFeedMetrics` in `physics/impedance.ts`. `StatsReadout` and `AntennaScene` both consume it, so the readout and the 3D bubble can't drift apart.

Comparison snapshots don't capture transformer settings, so they fall back to plain mismatch-vs-50 Ω realized gain (correct for that path).

## Tests

Added a `displayedFeedMetrics` suite to `tests/impedance.test.ts` covering the offset = `10·log10(1−|Γ|²)` identity, the perfect-match (offset 0) case, phantom transformer (Z/ratio + insertion loss), in-model transformer, choke-only, and the undefined-realized-gain path. Full suite: **642 tests passing**, typecheck and lint clean.

https://claude.ai/code/session_01TqEoWYMYLG7Rq9dfM8mD3g

---
_Generated by [Claude Code](https://claude.ai/code/session_01TqEoWYMYLG7Rq9dfM8mD3g)_