### PR TITLE
Add idealised mast-base ATU with Q-based loss

### DIFF
--- a/src/components/Charts/PolarPlots.tsx
+++ b/src/components/Charts/PolarPlots.tsx
@@ -10,7 +10,7 @@ import {
   Tooltip,
   type ChartOptions,
 } from 'chart.js';
-import { useAntennaStore } from '../../store/antennaStore';
+import { useAntennaStore, selectAtuConfig } from '../../store/antennaStore';
 import { useShallow } from 'zustand/react/shallow';
 import { useMemo } from 'react';
 import { displayedFeedMetrics } from '../../physics/impedance';
@@ -106,6 +106,10 @@ export function PolarPlots() {
     transformerEnabled,
     transformerRatio,
     feedlineId,
+    frequency,
+    feedlineLength,
+    atuEnabled,
+    atuMainFeedlineLength,
   } = useAntennaStore(useShallow((s) => ({
     result: s.result,
     dbRange: s.dbRange,
@@ -115,6 +119,10 @@ export function PolarPlots() {
     transformerEnabled: s.transformerEnabled,
     transformerRatio: s.transformerRatio,
     feedlineId: s.feedlineId,
+    frequency: s.frequency,
+    feedlineLength: s.feedlineLength,
+    atuEnabled: s.atuEnabled,
+    atuMainFeedlineLength: s.atuMainFeedlineLength,
   })));
 
   // The cuts are normalised to the pattern peak (shape only), but the ring
@@ -129,9 +137,10 @@ export function PolarPlots() {
       transformerEnabled,
       transformerRatio,
       feedlineActive: feedlineId !== 'none',
+      atu: selectAtuConfig({ atuEnabled, frequency, feedlineId, feedlineLength, atuMainFeedlineLength }),
     });
     return displayedRealizedGainDbi ?? result.maxGainDbi;
-  }, [result, transformerEnabled, transformerRatio, feedlineId]);
+  }, [result, transformerEnabled, transformerRatio, feedlineId, atuEnabled, frequency, feedlineLength, atuMainFeedlineLength]);
 
   const azData = useMemo(() => {
     if (!result) return null;

--- a/src/components/Panel/FeedlineControl.tsx
+++ b/src/components/Panel/FeedlineControl.tsx
@@ -36,9 +36,13 @@ export function FeedlineControl() {
     feedlineId,
     feedlineLength,
     feedlineOffset,
+    atuEnabled,
+    atuMainFeedlineLength,
     setFeedline,
     setFeedlineLength,
     setFeedlineOffset,
+    setAtuEnabled,
+    setAtuMainFeedlineLength,
   } = useAntennaStore(useShallow((s) => ({
     units: s.units,
     antennaType: s.antennaType,
@@ -47,9 +51,13 @@ export function FeedlineControl() {
     feedlineId: s.feedlineId,
     feedlineLength: s.feedlineLength,
     feedlineOffset: s.feedlineOffset,
+    atuEnabled: s.atuEnabled,
+    atuMainFeedlineLength: s.atuMainFeedlineLength,
     setFeedline: s.setFeedline,
     setFeedlineLength: s.setFeedlineLength,
     setFeedlineOffset: s.setFeedlineOffset,
+    setAtuEnabled: s.setAtuEnabled,
+    setAtuMainFeedlineLength: s.setAtuMainFeedlineLength,
   })));
 
   const preset = findFeedlinePreset(feedlineId);
@@ -69,11 +77,23 @@ export function FeedlineControl() {
     }
   }
 
+  const dispMainLen = toDisplayLength(atuMainFeedlineLength, units);
+  const [localMainLen, setLocalMainLen] = useState(dispMainLen.toFixed(2));
+  const [mainFocused, setMainFocused] = useState(false);
+  const [prevDispMainLen, setPrevDispMainLen] = useState(dispMainLen);
+  if (dispMainLen !== prevDispMainLen) {
+    setPrevDispMainLen(dispMainLen);
+    if (!mainFocused) {
+      setLocalMainLen(dispMainLen.toFixed(2));
+    }
+  }
+
   if (!SUPPORTED_ANTENNA_TYPES.has(antennaType)) return null;
 
   const offsetLimit = Math.max(0, dipoleLength / 2 - 0.05);
   const dispOffsetLimit = toDisplayLength(offsetLimit, units);
   const lossDb = enabled ? feedlineLossDb(preset, frequency, feedlineLength) : 0;
+  const mainRunLossDb = enabled ? feedlineLossDb(preset, frequency, atuMainFeedlineLength) : 0;
 
   return (
     <section className="panel-section">
@@ -166,6 +186,56 @@ export function FeedlineControl() {
           <div className="stat">
             <span className="stat-label">Cable loss @ {frequency.toFixed(2)} MHz</span>
             <span className="stat-value">{lossDb.toFixed(2)} dB</span>
+          </div>
+
+          <div style={{ marginTop: 12, borderTop: '1px solid var(--border)', paddingTop: 10 }}>
+            <label
+              htmlFor="atu-enable"
+              style={{ display: 'flex', alignItems: 'center', gap: 6, textTransform: 'none', letterSpacing: 0, margin: 0, fontSize: 12 }}
+            >
+              <input
+                id="atu-enable"
+                type="checkbox"
+                checked={atuEnabled}
+                onChange={(e) => setAtuEnabled(e.target.checked)}
+              />
+              ATU at the base of the mast
+            </label>
+
+            {atuEnabled && (
+              <>
+                <label htmlFor="atu-main-length" style={{ marginTop: 10 }}>
+                  Main run, ATU → shack ({unit})
+                </label>
+                <input
+                  id="atu-main-length"
+                  type="number"
+                  min={0}
+                  max={units === 'metric' ? 300 : 984}
+                  step={units === 'metric' ? 0.5 : 1}
+                  value={localMainLen}
+                  aria-describedby="atu-hint"
+                  onFocus={() => setMainFocused(true)}
+                  onChange={(e) => {
+                    const s = e.target.value;
+                    setLocalMainLen(s);
+                    const val = parseFloat(s);
+                    if (!isNaN(val)) setAtuMainFeedlineLength(fromDisplayLength(val, units));
+                  }}
+                  onBlur={() => {
+                    setMainFocused(false);
+                    setLocalMainLen(dispMainLen.toFixed(2));
+                  }}
+                />
+                <div id="atu-hint" style={{ marginTop: 6, fontSize: 11, color: 'var(--text-muted)', lineHeight: 1.4 }}>
+                  The feedline above becomes the short up-mast run (carries the antenna's native SWR);
+                  the tuner conjugate-matches at the base, so this main run to the shack stays ~1:1
+                  (matched loss {mainRunLossDb.toFixed(2)} dB). Realized gain keeps the up-mast loss
+                  under SWR, this main-run loss, and a Q-based tuner loss — but a tuner cannot recover
+                  ohmic/termination (efficiency) loss.
+                </div>
+              </>
+            )}
           </div>
         </>
       )}

--- a/src/components/Panel/StatsReadout.tsx
+++ b/src/components/Panel/StatsReadout.tsx
@@ -1,4 +1,4 @@
-import { useAntennaStore, DIPOLE_LEFT_TAG, DIPOLE_RIGHT_TAG } from '../../store/antennaStore';
+import { useAntennaStore, selectAtuConfig, DIPOLE_LEFT_TAG, DIPOLE_RIGHT_TAG } from '../../store/antennaStore';
 import { useShallow } from 'zustand/react/shallow';
 import { displayedFeedMetrics } from '../../physics/impedance';
 import { TRANSFORMER_INSERTION_LOSS_DB } from '../../physics/constants';
@@ -16,6 +16,10 @@ export function StatsReadout() {
     transformerEnabled,
     transformerRatio,
     feedlineId,
+    frequency,
+    feedlineLength,
+    atuEnabled,
+    atuMainFeedlineLength,
   } = useAntennaStore(useShallow((s) => ({
     result: s.result,
     mode: s.mode,
@@ -23,8 +27,13 @@ export function StatsReadout() {
     transformerEnabled: s.transformerEnabled,
     transformerRatio: s.transformerRatio,
     feedlineId: s.feedlineId,
+    frequency: s.frequency,
+    feedlineLength: s.feedlineLength,
+    atuEnabled: s.atuEnabled,
+    atuMainFeedlineLength: s.atuMainFeedlineLength,
   })));
   const feedlineActive = feedlineId !== 'none';
+  const atu = selectAtuConfig({ atuEnabled, frequency, feedlineId, feedlineLength, atuMainFeedlineLength });
   if (!result) {
     return (
       <section className="panel-section">
@@ -39,23 +48,34 @@ export function StatsReadout() {
   // impedance transformer — either modelled in NEC (feedline present) or applied
   // as an idealised display-side transform (no feedline). The same helper drives
   // the 3D pattern's realized-gain scaling, so the readout and the bubble agree.
-  const { displayedZ, displayedSwr, displayedRealizedGainDbi } = displayedFeedMetrics(result, {
+  const { displayedZ, displayedSwr, displayedRealizedGainDbi, atuLoss } = displayedFeedMetrics(result, {
     transformerEnabled,
     transformerRatio,
     feedlineActive,
+    atu,
   });
 
-  const impedanceLabel = feedlineActive ? 'Source impedance (R + jX)' : 'Feedpoint (R + jX)';
-  const impedanceTitle = feedlineActive
-    ? `Impedance at the source end of the feedline (what the radio sees)${transformerEnabled ? `, with the ${transformerRatio}:1 transformer fitted at the antenna terminals` : ''}. To see the antenna terminals directly, set Feedline = none.`
+  const impedanceLabel = atu || feedlineActive ? 'Source impedance (R + jX)' : 'Feedpoint (R + jX)';
+  const impedanceTitle = atu
+    ? 'Impedance the radio sees with the ATU at the mast base matched: an idealised tuner presents 50 Ω. To see the antenna terminals directly, disable the ATU and set Feedline = none.'
+    : feedlineActive
+      ? `Impedance at the source end of the feedline (what the radio sees)${transformerEnabled ? `, with the ${transformerRatio}:1 transformer fitted at the antenna terminals` : ''}. To see the antenna terminals directly, set Feedline = none.`
+      : transformerEnabled
+        ? `Impedance after the ${transformerRatio}:1 transformer fitted at the antenna terminals.`
+        : 'Impedance at the antenna feedpoint. NEC places the excitation directly at the antenna terminals.';
+  const swrTitle = atu
+    ? 'Voltage SWR your radio sees with the mast-base ATU matched. The tuner flattens the main run to ~1:1; the antenna\'s native mismatch still stands on the short up-mast feedline.'
+    : feedlineActive
+      ? `Voltage SWR at the source end of the feedline against 50 Ω${transformerEnabled ? ` (with the transformer fitted at the antenna)` : ''}. This is what your radio's SWR meter would see.`
+      : transformerEnabled
+        ? `Voltage SWR at the radio side of the antenna's ${transformerRatio}:1 transformer against 50 Ω.`
+        : 'Voltage SWR at the antenna feedpoint against 50 Ω.';
+
+  const realizedGainTitle = atu
+    ? `Realized gain (dBi): antenna gain delivered through the mast-base ATU. The tuner cancels the feedpoint mismatch (no mismatch loss), leaving${atuLoss ? ` up-mast feedline loss ${atuLoss.upmastDb.toFixed(2)} dB + main feedline loss ${atuLoss.mainDb.toFixed(2)} dB + tuner loss ${atuLoss.tunerDb.toFixed(2)} dB` : ' feedline and tuner losses'}. A tuner cannot recover ohmic/termination (efficiency) loss.`
     : transformerEnabled
-      ? `Impedance after the ${transformerRatio}:1 transformer fitted at the antenna terminals.`
-      : 'Impedance at the antenna feedpoint. NEC places the excitation directly at the antenna terminals.';
-  const swrTitle = feedlineActive
-    ? `Voltage SWR at the source end of the feedline against 50 Ω${transformerEnabled ? ` (with the transformer fitted at the antenna)` : ''}. This is what your radio's SWR meter would see.`
-    : transformerEnabled
-      ? `Voltage SWR at the radio side of the antenna's ${transformerRatio}:1 transformer against 50 Ω.`
-      : 'Voltage SWR at the antenna feedpoint against 50 Ω.';
+      ? `Realized gain (dBi): antenna gain after mismatch loss against 50 Ω with the ${transformerRatio}:1 transformer fitted at the antenna terminals, minus ${TRANSFORMER_INSERTION_LOSS_DB.toFixed(1)} dB transformer insertion loss.`
+      : 'Realized gain (dBi): antenna gain after mismatch loss against 50 Ω. = Gain × (1 − |Γ|²).';
 
   return (
     <section className="panel-section">
@@ -81,11 +101,7 @@ export function StatsReadout() {
         <div className="stat">
           <span
             className="stat-label"
-            title={
-              transformerEnabled
-                ? `Realized gain (dBi): antenna gain after mismatch loss against 50 Ω with the ${transformerRatio}:1 transformer fitted at the antenna terminals, minus ${TRANSFORMER_INSERTION_LOSS_DB.toFixed(1)} dB transformer insertion loss.`
-                : 'Realized gain (dBi): antenna gain after mismatch loss against 50 Ω. = Gain × (1 − |Γ|²).'
-            }
+            title={realizedGainTitle}
           >Realized gain</span>
           <span className="stat-value">{displayedRealizedGainDbi.toFixed(2)} dBi</span>
         </div>

--- a/src/components/Scene/AntennaScene.tsx
+++ b/src/components/Scene/AntennaScene.tsx
@@ -11,7 +11,7 @@ import { Suspense, useMemo } from 'react';
 import { DipoleWire } from './DipoleWire';
 import { GroundPlane } from './GroundPlane';
 import { RadiationPattern } from './RadiationPattern';
-import { useAntennaStore, type ComparisonSnapshot } from '../../store/antennaStore';
+import { useAntennaStore, selectAtuConfig, type ComparisonSnapshot } from '../../store/antennaStore';
 import { useShallow } from 'zustand/react/shallow';
 import { displayedFeedMetrics } from '../../physics/impedance';
 import { THEME_COLORS } from '../../utils/themeColors';
@@ -36,6 +36,9 @@ export function AntennaScene({ snapshot = null }: AntennaSceneProps) {
     liveWhipCounterpoise,
     liveTransformerEnabled,
     liveTransformerRatio,
+    liveFrequency,
+    liveAtuEnabled,
+    liveAtuMainFeedlineLength,
     showGrid,
     showAxes,
     patternScale,
@@ -58,6 +61,9 @@ export function AntennaScene({ snapshot = null }: AntennaSceneProps) {
     liveWhipCounterpoise: s.whipCounterpoise,
     liveTransformerEnabled: s.transformerEnabled,
     liveTransformerRatio: s.transformerRatio,
+    liveFrequency: s.frequency,
+    liveAtuEnabled: s.atuEnabled,
+    liveAtuMainFeedlineLength: s.atuMainFeedlineLength,
     showGrid: s.showGrid,
     showAxes: s.showAxes,
     patternScale: s.patternScale,
@@ -81,18 +87,26 @@ export function AntennaScene({ snapshot = null }: AntennaSceneProps) {
   const whipCounterpoise = snapshot?.whipCounterpoise ?? liveWhipCounterpoise;
 
   // Scale the pattern bubble to realized gain: the gain actually delivered after
-  // feedpoint mismatch (and any transformer) loss. The offset is realizedGain −
-  // gain, the same constant the stats readout applies. Comparison snapshots don't
-  // capture transformer settings, so they fall back to plain realized gain.
+  // feedpoint mismatch (and any transformer/ATU) loss. The offset is realizedGain
+  // − gain, the same constant the stats readout applies. Comparison snapshots
+  // don't capture transformer/ATU settings, so they fall back to plain realized
+  // gain.
   const realizedGainOffsetDb = useMemo(() => {
     if (!result || result.maxRealizedGainDbi == null) return 0;
     const { displayedRealizedGainDbi } = displayedFeedMetrics(result, {
       transformerEnabled: snapshot ? false : liveTransformerEnabled,
       transformerRatio: snapshot ? 1 : liveTransformerRatio,
       feedlineActive: feedlineId !== 'none',
+      atu: snapshot ? undefined : selectAtuConfig({
+        atuEnabled: liveAtuEnabled,
+        frequency: liveFrequency,
+        feedlineId,
+        feedlineLength,
+        atuMainFeedlineLength: liveAtuMainFeedlineLength,
+      }),
     });
     return displayedRealizedGainDbi != null ? displayedRealizedGainDbi - result.maxGainDbi : 0;
-  }, [result, snapshot, liveTransformerEnabled, liveTransformerRatio, feedlineId]);
+  }, [result, snapshot, liveTransformerEnabled, liveTransformerRatio, feedlineId, feedlineLength, liveAtuEnabled, liveFrequency, liveAtuMainFeedlineLength]);
 
   return (
     <Canvas

--- a/src/physics/constants.ts
+++ b/src/physics/constants.ts
@@ -461,3 +461,17 @@ export const TRANSFORMER_CHOKE_OHMS = 2000;
  * representative number, deliberately conservative.
  */
 export const TRANSFORMER_INSERTION_LOSS_DB = 0.2;
+
+/**
+ * Representative unloaded Q of the reactive components in an antenna tuning
+ * unit (dominated by the inductor). This is the *only* parameter the ATU-loss
+ * model takes, which keeps it network-topology-agnostic: L, T and π tuners
+ * differ in how they're driven, but their achievable loss is bounded by the
+ * component Q and the impedance transformation demanded. 150 is typical of a
+ * decent HF tuner inductor (roller/air-wound ~150–250; small toroidal cores
+ * lower). Higher Q → lower loss.
+ */
+export const ATU_COMPONENT_Q = 150;
+
+/** Default length (m) of the main feedline run from a mast-base ATU to the shack. */
+export const DEFAULT_ATU_MAIN_FEEDLINE_LENGTH_M = 50;

--- a/src/physics/impedance.ts
+++ b/src/physics/impedance.ts
@@ -1,13 +1,14 @@
 // Impedance/SWR helpers.
 
-import { Z0_SYSTEM, TRANSFORMER_INSERTION_LOSS_DB } from './constants';
+import { Z0_SYSTEM, TRANSFORMER_INSERTION_LOSS_DB, feedlineLossDb } from './constants';
+import type { FeedlinePreset } from './constants';
 import type { ImpedanceResult, SimulationResult } from './types';
 
 /**
  * Reflection coefficient magnitude for a load Z against the system impedance.
  * |Γ| = |Z - Z0| / |Z + Z0|, where Z is complex.
  */
-function reflectionCoefficientMag(z: ImpedanceResult, z0: number = Z0_SYSTEM): number {
+export function reflectionCoefficientMag(z: ImpedanceResult, z0: number = Z0_SYSTEM): number {
   const numR = z.R - z0;
   const numX = z.X;
   const denR = z.R + z0;
@@ -44,6 +45,68 @@ export function mismatchLossFactor(z: ImpedanceResult, z0: number = Z0_SYSTEM): 
   return 1 - gamma * gamma;
 }
 
+/**
+ * Extra loss when a feedline runs into a mismatched load: the standing wave
+ * raises current/voltage maxima along the line, so the cable dissipates more
+ * than its matched loss. Standard closed form (Walt Maxwell / ARRL):
+ *
+ *   total(dB) = 10·log10[ (a² − |Γ|²) / (a·(1 − |Γ|²)) ],   a = 10^(ML/10)
+ *
+ * where ML is the matched-line loss (dB) of that section and |Γ| is the
+ * reflection coefficient magnitude at the load against the *line's* Z₀.
+ * Reduces to ML when |Γ| → 0. |Γ| is invariant along a lossless-ish line, so
+ * it may be evaluated at either end.
+ */
+export function feedlineLossUnderSwrDb(matchedLossDb: number, gammaMag: number): number {
+  if (matchedLossDb <= 0) return 0;
+  const a = Math.pow(10, matchedLossDb / 10);
+  // Clamp just shy of total reflection so the (1 − |Γ|²) denominator is finite.
+  const g2 = Math.min(gammaMag * gammaMag, 0.999999);
+  return 10 * Math.log10((a * a - g2) / (a * (1 - g2)));
+}
+
+/**
+ * Insertion loss (dB) of an idealised antenna tuner matching a complex load Z
+ * to a real system impedance, parameterised solely by the components' unloaded
+ * Q — i.e. independent of the tuner topology (L/T/π).
+ *
+ * The tuner must transform R + jX to z₀, which forces it to circulate reactive
+ * power. The minimum reactive "throughput Q" of *any* lossless matching
+ * network performing that transformation is captured, model-agnostically, by
+ * the geometric-mean-normalised distance of the load from the matched point:
+ *
+ *   Q_net = ( |R − z₀| + |X| ) / √(R · z₀)
+ *
+ * (zero at a perfect match; grows with both the resistance ratio and the
+ * residual reactance). Feeding that through the single-section efficiency
+ * bound η = Q_u / (Q_u + Q_net) gives the loss. Real T/π tuners can only
+ * approach this minimum, so it is an optimistic-but-fair estimate.
+ */
+export function atuLossDb(z: ImpedanceResult, componentQ: number, z0: number = Z0_SYSTEM): number {
+  if (componentQ <= 0 || z.R <= 0) return 0;
+  const qNet = (Math.abs(z.R - z0) + Math.abs(z.X)) / Math.sqrt(z.R * z0);
+  const efficiency = componentQ / (componentQ + qNet);
+  return -10 * Math.log10(efficiency);
+}
+
+/**
+ * Configuration for an idealised ATU sited at the base of the mast: a short
+ * feedline runs up the mast to the antenna (carrying its native SWR), the
+ * tuner conjugate-matches at the base, and a longer main run continues to the
+ * shack at ~1:1. Both runs are assumed to be the same cable type.
+ */
+export interface AtuMatchConfig {
+  readonly frequencyMHz: number;
+  /** Cable type shared by both runs (the up-mast run and the main run). */
+  readonly preset: FeedlinePreset;
+  /** Up-mast run, feedpoint → ATU: runs at the antenna's native SWR. */
+  readonly upmastLengthM: number;
+  /** Main run, ATU → shack: runs matched (~1:1). */
+  readonly mainLengthM: number;
+  /** Unloaded Q of the tuner's reactive components. */
+  readonly componentQ: number;
+}
+
 /** Feedpoint metrics as actually presented to the user. */
 export interface DisplayedFeedMetrics {
   /** Impedance the radio sees (after any idealised display-side transformer). */
@@ -56,6 +119,15 @@ export interface DisplayedFeedMetrics {
    * the mismatch loss cannot be evaluated (total reflection / non-passive R).
    */
   readonly displayedRealizedGainDbi: number | undefined;
+  /** Per-stage loss (dB) when a mast-base ATU is modelled; undefined otherwise. */
+  readonly atuLoss?: {
+    /** Up-mast feedline loss under the antenna's native SWR. */
+    readonly upmastDb: number;
+    /** Main feedline loss (matched, ~1:1). */
+    readonly mainDb: number;
+    /** Tuner insertion loss (Q-based). */
+    readonly tunerDb: number;
+  };
 }
 
 /**
@@ -72,9 +144,44 @@ export interface DisplayedFeedMetrics {
  */
 export function displayedFeedMetrics(
   result: Pick<SimulationResult, 'impedance' | 'swr' | 'maxGainDbi' | 'maxRealizedGainDbi'>,
-  config: { transformerEnabled: boolean; transformerRatio: number; feedlineActive: boolean },
+  config: {
+    transformerEnabled: boolean;
+    transformerRatio: number;
+    feedlineActive: boolean;
+    /** When present, an idealised ATU at the mast base supersedes the transformer. */
+    atu?: AtuMatchConfig;
+  },
 ): DisplayedFeedMetrics {
-  const { transformerEnabled, transformerRatio, feedlineActive } = config;
+  const { transformerEnabled, transformerRatio, feedlineActive, atu } = config;
+
+  if (atu) {
+    // The tuner conjugate-matches whatever impedance reaches the mast base, so
+    // the rig sees 50 Ω at 1:1 and mismatch loss → 0. `result.impedance` is the
+    // impedance at the foot of the (lossless-in-NEC) up-mast feedline — exactly
+    // where the tuner sits — so it is both the load the tuner matches and the
+    // point whose |Γ| sets the up-mast standing-wave loss. What remains:
+    //   • up-mast feedline loss under the antenna's native SWR,
+    //   • main feedline loss (matched, ~1:1),
+    //   • the tuner's own Q-based loss.
+    const z = result.impedance;
+    const gammaUpmast = atu.preset.z0 > 0 ? reflectionCoefficientMag(z, atu.preset.z0) : 0;
+    const upmastDb = feedlineLossUnderSwrDb(
+      feedlineLossDb(atu.preset, atu.frequencyMHz, atu.upmastLengthM),
+      gammaUpmast,
+    );
+    const mainDb = feedlineLossDb(atu.preset, atu.frequencyMHz, atu.mainLengthM);
+    const tunerDb = atuLossDb(z, atu.componentQ);
+    return {
+      displayedZ: { R: Z0_SYSTEM, X: 0 },
+      displayedSwr: 1,
+      // A non-passive feedpoint (R ≤ 0) can't be matched — leave realized gain
+      // undefined so the readout hides it, consistent with the other branches.
+      displayedRealizedGainDbi:
+        z.R > 0 ? result.maxGainDbi - upmastDb - mainDb - tunerDb : undefined,
+      atuLoss: { upmastDb, mainDb, tunerDb },
+    };
+  }
+
   const transformerInDisplay = transformerEnabled && !feedlineActive && transformerRatio > 1;
 
   const displayedZ: ImpedanceResult = transformerInDisplay

--- a/src/store/antennaStore.ts
+++ b/src/store/antennaStore.ts
@@ -22,8 +22,10 @@ import type {
 } from '../physics/types';
 import {
   TRANSFORMER_CHOKE_OHMS,
+  ATU_COMPONENT_Q,
   DEFAULT_FEEDLINE_ID,
   DEFAULT_FEEDLINE_LENGTH_M,
+  DEFAULT_ATU_MAIN_FEEDLINE_LENGTH_M,
   DEFAULT_GROUND_ID,
   DEFAULT_WIRE_RADIUS_M,
   SLOPING_V_MIN_TIP_Z_M,
@@ -76,6 +78,7 @@ export {
 };
 import type { Theme } from '../utils/themeColors';
 import type { UnitSystem } from '../physics/units';
+import type { AtuMatchConfig } from '../physics/impedance';
 import {
   buildInvertedVWires,
   buildSlopingVWires,
@@ -199,6 +202,12 @@ export interface AntennaState {
   /** Impedance transformation ratio n² (e.g. 9 for a 3:1 turns-ratio transformer). */
   transformerRatio: number;
 
+  // Idealised ATU at the base of the mast (post-processing display only). The
+  // feedline above acts as the up-mast run; this is the main run down to the
+  // shack, which the tuner keeps at ~1:1.
+  atuEnabled: boolean;
+  atuMainFeedlineLength: number;
+
   // Propagation
   tIndex: number;
   latitudeDeg: number | null;
@@ -253,6 +262,8 @@ export interface AntennaState {
   setShowPolarCuts(v: boolean): void;
   setTransformerEnabled(enabled: boolean): void;
   setTransformerRatio(ratio: number): void;
+  setAtuEnabled(enabled: boolean): void;
+  setAtuMainFeedlineLength(meters: number): void;
   captureComparisonReference(): void;
   clearComparisonReference(): void;
 
@@ -312,6 +323,9 @@ export const useAntennaStore = create<AntennaState>()(
       showPolarCuts: true,
       transformerEnabled: false,
       transformerRatio: 9,
+
+      atuEnabled: false,
+      atuMainFeedlineLength: DEFAULT_ATU_MAIN_FEEDLINE_LENGTH_M,
 
       tIndex: 30,
       latitudeDeg: null,
@@ -553,6 +567,11 @@ export const useAntennaStore = create<AntennaState>()(
       setTransformerRatio: (ratio) => set((s) => {
         if (!Number.isFinite(ratio) || ratio <= 0) return;
         s.transformerRatio = Math.max(1, ratio);
+      }),
+      setAtuEnabled: (enabled) => set((s) => { s.atuEnabled = !!enabled; }),
+      setAtuMainFeedlineLength: (meters) => set((s) => {
+        if (!Number.isFinite(meters)) return;
+        s.atuMainFeedlineLength = Math.max(0, Math.min(300, meters));
       }),
       captureComparisonReference: () => set((s) => {
         s.comparisonReference = createComparisonSnapshot(s);
@@ -1245,6 +1264,31 @@ function buildTerminationElements(state: AntennaState, wires: Wire[]) {
   }
 
   return { extraWires, loads };
+}
+
+/**
+ * Build the idealised mast-base ATU config for the realized-gain post-processing,
+ * or `undefined` when the ATU is off. The currently-selected feedline doubles as
+ * the up-mast run; `atuMainFeedlineLength` is the matched run down to the shack.
+ * Pure (no store access) so it serves both the live state and comparison
+ * snapshots, and ATU fields are deliberately absent from `selectSimulationInput`
+ * — it's post-processing and must never trigger a NEC re-solve.
+ */
+export function selectAtuConfig(args: {
+  atuEnabled: boolean;
+  frequency: number;
+  feedlineId: string;
+  feedlineLength: number;
+  atuMainFeedlineLength: number;
+}): AtuMatchConfig | undefined {
+  if (!args.atuEnabled) return undefined;
+  return {
+    frequencyMHz: args.frequency,
+    preset: findFeedlinePreset(args.feedlineId),
+    upmastLengthM: args.feedlineLength,
+    mainLengthM: args.atuMainFeedlineLength,
+    componentQ: ATU_COMPONENT_Q,
+  };
 }
 
 export function selectSimulationInput(state: AntennaState): SimulationInput {

--- a/tests/FeedlineControl.test.tsx
+++ b/tests/FeedlineControl.test.tsx
@@ -42,4 +42,37 @@ describe('FeedlineControl', () => {
     expect(screen.queryByLabelText(/Attachment offset/)).toBeNull();
     expect(screen.queryByRole('button', { name: 'Centre feedpoint offset' })).toBeNull();
   });
+
+  it('shows the ATU toggle and reveals the main-run length only when enabled', () => {
+    useAntennaStore.setState({ atuEnabled: false });
+    const { rerender } = render(<FeedlineControl />);
+
+    const toggle = screen.getByLabelText('ATU at the base of the mast') as HTMLInputElement;
+    expect(toggle.checked).toBe(false);
+    expect(screen.queryByLabelText(/Main run/)).toBeNull();
+
+    fireEvent.click(toggle);
+    expect(useAntennaStore.getState().atuEnabled).toBe(true);
+
+    rerender(<FeedlineControl />);
+    expect(screen.getByLabelText(/Main run/)).toBeDefined();
+  });
+
+  it('hides the ATU controls entirely when cable is "none"', () => {
+    useAntennaStore.setState({ feedlineId: 'none', atuEnabled: true });
+    render(<FeedlineControl />);
+    expect(screen.queryByLabelText('ATU at the base of the mast')).toBeNull();
+  });
+
+  it('updates the main-run length and clamps to the 0–300 m range', () => {
+    useAntennaStore.setState({ atuEnabled: true, atuMainFeedlineLength: 50 });
+    render(<FeedlineControl />);
+
+    const input = screen.getByLabelText(/Main run/) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '80' } });
+    expect(useAntennaStore.getState().atuMainFeedlineLength).toBe(80);
+
+    useAntennaStore.getState().setAtuMainFeedlineLength(9999);
+    expect(useAntennaStore.getState().atuMainFeedlineLength).toBe(300);
+  });
 });

--- a/tests/impedance.test.ts
+++ b/tests/impedance.test.ts
@@ -1,7 +1,7 @@
 import { vi } from "vitest";
 import { describe, expect, it } from 'vitest';
-import { swr, mismatchLossFactor, transformImpedance, deembedThroughLine, transformThroughLine, transformWithTransformerAtAntenna, realizedGainWithTransformer, suggestedTransformerRatio, displayedFeedMetrics } from '../src/physics/impedance';
-import { TRANSFORMER_INSERTION_LOSS_DB } from '../src/physics/constants';
+import { swr, mismatchLossFactor, transformImpedance, deembedThroughLine, transformThroughLine, transformWithTransformerAtAntenna, realizedGainWithTransformer, suggestedTransformerRatio, displayedFeedMetrics, atuLossDb, feedlineLossUnderSwrDb } from '../src/physics/impedance';
+import { TRANSFORMER_INSERTION_LOSS_DB, ATU_COMPONENT_Q, feedlineLossDb, findFeedlinePreset } from '../src/physics/constants';
 import type { SimulationResult } from '../src/physics/types';
 
 // Minimal result stub carrying only the fields displayedFeedMetrics reads.
@@ -74,6 +74,100 @@ describe('displayedFeedMetrics', () => {
     const result = stubResult({ impedance: { R: 50, X: 0 }, maxGainDbi: 3, maxRealizedGainDbi: undefined });
     const m = displayedFeedMetrics(result, noTransformer);
     expect(m.displayedRealizedGainDbi).toBeUndefined();
+  });
+});
+
+describe('feedlineLossUnderSwrDb', () => {
+  it('zero matched loss → zero total loss', () => {
+    expect(feedlineLossUnderSwrDb(0, 0.9)).toBe(0);
+  });
+
+  it('matched (|Γ|=0) → equals the matched loss', () => {
+    expect(feedlineLossUnderSwrDb(1, 0)).toBeCloseTo(1, 10);
+  });
+
+  it('standing wave inflates loss above the matched value', () => {
+    expect(feedlineLossUnderSwrDb(1, 0.5)).toBeGreaterThan(1);
+    // 10·log10[(a²−|Γ|²)/(a(1−|Γ|²))], a=10^0.1, |Γ|²=0.25 ⇒ ≈1.50 dB
+    expect(feedlineLossUnderSwrDb(1, 0.5)).toBeCloseTo(1.50, 1);
+  });
+
+  it('total reflection stays finite (clamped)', () => {
+    expect(Number.isFinite(feedlineLossUnderSwrDb(0.5, 1))).toBe(true);
+  });
+});
+
+describe('atuLossDb', () => {
+  it('perfect match → no loss', () => {
+    expect(atuLossDb({ R: 50, X: 0 }, 150)).toBeCloseTo(0, 10);
+  });
+
+  it('non-passive R or non-positive Q → no loss', () => {
+    expect(atuLossDb({ R: -5, X: 0 }, 150)).toBe(0);
+    expect(atuLossDb({ R: 50, X: 0 }, 0)).toBe(0);
+  });
+
+  it('folded-dipole 300 Ω is a gentle match (~0.06 dB at Q=150)', () => {
+    // Q_net = 250/√(300·50) = 2.041 ⇒ loss = -10log10(150/152.04) ≈ 0.059 dB
+    expect(atuLossDb({ R: 300, X: 0 }, 150)).toBeCloseTo(0.06, 2);
+  });
+
+  it('heavy reactance costs more loss', () => {
+    expect(atuLossDb({ R: 50, X: 500 }, 150)).toBeGreaterThan(atuLossDb({ R: 300, X: 0 }, 150));
+  });
+
+  it('higher component Q → lower loss', () => {
+    const nasty = { R: 5, X: 80 };
+    expect(atuLossDb(nasty, 250)).toBeLessThan(atuLossDb(nasty, 80));
+  });
+});
+
+describe('displayedFeedMetrics — mast-base ATU', () => {
+  const preset = findFeedlinePreset('rg213');
+  const atu = {
+    frequencyMHz: 14.2,
+    preset,
+    upmastLengthM: 6,
+    mainLengthM: 50,
+    componentQ: ATU_COMPONENT_Q,
+  };
+
+  it('presents 50 Ω at 1:1 and subtracts feedline + tuner losses from gain', () => {
+    const result = stubResult({ impedance: { R: 18, X: -40 }, maxGainDbi: 6 });
+    const m = displayedFeedMetrics(result, {
+      transformerEnabled: false, transformerRatio: 1, feedlineActive: true, atu,
+    });
+
+    expect(m.displayedZ).toEqual({ R: 50, X: 0 });
+    expect(m.displayedSwr).toBe(1);
+    expect(m.atuLoss).toBeDefined();
+
+    // Cross-check each stage against the standalone loss functions.
+    const matchedUp = feedlineLossDb(preset, 14.2, 6);
+    const gamma = Math.hypot(18 - preset.z0, -40) / Math.hypot(18 + preset.z0, -40);
+    expect(m.atuLoss!.upmastDb).toBeCloseTo(feedlineLossUnderSwrDb(matchedUp, gamma), 10);
+    expect(m.atuLoss!.mainDb).toBeCloseTo(feedlineLossDb(preset, 14.2, 50), 10);
+    expect(m.atuLoss!.tunerDb).toBeCloseTo(atuLossDb({ R: 18, X: -40 }, ATU_COMPONENT_Q), 10);
+
+    const total = m.atuLoss!.upmastDb + m.atuLoss!.mainDb + m.atuLoss!.tunerDb;
+    expect(m.displayedRealizedGainDbi!).toBeCloseTo(6 - total, 10);
+  });
+
+  it('the ATU supersedes a transformer when both are set', () => {
+    const result = stubResult({ impedance: { R: 300, X: 0 }, maxGainDbi: 2 });
+    const m = displayedFeedMetrics(result, {
+      transformerEnabled: true, transformerRatio: 9, feedlineActive: true, atu,
+    });
+    expect(m.displayedZ).toEqual({ R: 50, X: 0 });
+  });
+
+  it('a non-passive feedpoint leaves realized gain undefined but still reports losses', () => {
+    const result = stubResult({ impedance: { R: -3, X: 20 }, maxGainDbi: 4 });
+    const m = displayedFeedMetrics(result, {
+      transformerEnabled: false, transformerRatio: 1, feedlineActive: true, atu,
+    });
+    expect(m.displayedRealizedGainDbi).toBeUndefined();
+    expect(m.atuLoss).toBeDefined();
   });
 });
 


### PR DESCRIPTION
## What

Models the real-world setup you described: an **ATU at the base of the mast**, with a short feedline running up the mast to the feedpoint and a longer main run continuing to the shack.

- The existing **feedline** acts as the **up-mast run** (carries the antenna's native SWR).
- A new **main-run length** (default **50 m**) is the cable from the ATU down to the shack.
- The tuner **conjugate-matches at the base**, so the rig sees **50 Ω at 1:1** and feedpoint mismatch loss is **fully recovered**.

## Realized-gain loss budget

`Realized gain = Gain − up-mast loss − main-run loss − tuner loss`:

| Stage | Model |
|---|---|
| Up-mast feedline | Matched loss **inflated by the standing wave** (standard `(a²−|Γ|²)/(a(1−|Γ|²))` form) — short, so small |
| Main run (ATU → shack) | Matched loss only (runs ~1:1) |
| Tuner | **Q-based**, see below |

This makes the key physical point visible: a tuner recovers **mismatch** loss but never **ohmic/termination (efficiency)** loss. A folded dipole recovers fully; a terminated sloping V does not (its Directivity→Gain gap is untouched).

## Q-based, model-agnostic tuner loss

The tuner loss is parameterised **only by the components' unloaded Q** (`ATU_COMPONENT_Q = 150`), independent of L/T/π topology. It uses a geometric-mean-normalised transformation Q:

```
Q_net = (|R − Z₀| + |X|) / √(R·Z₀)          // 0 at a perfect match
loss  = −10·log10( Q_u / (Q_u + Q_net) )      // single-section efficiency bound
```

Real T/π tuners can only approach this minimum, so it's an optimistic-but-fair, topology-agnostic estimate. Higher component Q → lower loss; heavy reactance / extreme R → more loss.

## UI

A toggle in the Feedline panel — **"ATU at the base of the mast"** — reveals the main-run length input (default 50 m) when enabled, with a hint explaining the model and what a tuner can/can't recover.

## Wiring

All three views update through the shared `displayedFeedMetrics` helper, so they stay in lock-step:
- stats **Realized gain** (with a per-stage loss breakdown in its tooltip),
- the **3D bubble** (shrinks to delivered gain),
- the **polar-cut ring labels**.

It's **post-processing only** — ATU fields are deliberately absent from `selectSimulationInput`, so toggling the ATU never triggers a NEC re-solve. Comparison snapshots (which don't capture ATU settings) fall back to plain realized gain.

## Tests

Added coverage for `feedlineLossUnderSwrDb`, `atuLossDb` (perfect match, reactance penalty, Q monotonicity, guards), the `displayedFeedMetrics` ATU branch (50 Ω/1:1 output, per-stage cross-check against the standalone loss fns, transformer supersession, non-passive guard), and the FeedlineControl toggle/length UI + clamping. **659 tests passing**, typecheck, lint, and production build all clean.

https://claude.ai/code/session_01TqEoWYMYLG7Rq9dfM8mD3g

---
_Generated by [Claude Code](https://claude.ai/code/session_01TqEoWYMYLG7Rq9dfM8mD3g)_