### PR TITLE
🎨 Palette: Add a11y attributes to global ErrorBoundary

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,3 +4,6 @@
 ## 2024-05-28 - Missing `aria-describedby` for complex type select element
 **Learning:** `DipoleControl.tsx` has a `<select>` for antenna type, but no `aria-describedby` link to the helper hint text about how to set up the selected antenna. This makes the interface less intuitive for screen reader users as they miss context.
 **Action:** Always link `<select>` elements with complex options to a hint text element via `aria-describedby` when context changes based on selection.
+## 2024-05-28 - Missing ARIA alert on global error boundary
+**Learning:** React ErrorBoundary fallback UIs for rendering app crashes do not natively announce themselves to screen readers because they replace the current DOM without a page reload or focus shift.
+**Action:** Always add `role="alert"` and `aria-live="assertive"` to the container of critical error messages or crash fallbacks so screen reader users are immediately notified.

--- a/src/components/UI/ErrorBoundary.tsx
+++ b/src/components/UI/ErrorBoundary.tsx
@@ -31,15 +31,19 @@ export class ErrorBoundary extends Component<Props, State> {
     if (this.state.error) {
       if (this.props.fallback) return this.props.fallback(this.state.error, this.reset);
       return (
-        <div style={{
-          padding: 20,
-          color: 'var(--danger, #ff6b6b)',
-          background: 'var(--bg, #111)',
-          fontFamily: 'monospace',
-          whiteSpace: 'pre-wrap',
-          height: '100%',
-          overflow: 'auto',
-        }}>
+        <div
+          role="alert"
+          aria-live="assertive"
+          style={{
+            padding: 20,
+            color: 'var(--danger, #ff6b6b)',
+            background: 'var(--bg, #111)',
+            fontFamily: 'monospace',
+            whiteSpace: 'pre-wrap',
+            height: '100%',
+            overflow: 'auto',
+          }}
+        >
           <h2 style={{ marginTop: 0 }}>Render error</h2>
           <div style={{ marginBottom: 12 }}>{this.state.error.message}</div>
           <button onClick={this.reset}>Try again</button>


### PR DESCRIPTION
💡 **What:** Added `role="alert"` and `aria-live="assertive"` to the global `<ErrorBoundary>` container in `src/components/UI/ErrorBoundary.tsx`.

🎯 **Why:** React ErrorBoundary fallback UIs replace the current DOM seamlessly upon an app crash, without a page reload or a native focus shift. This means screen reader users are left entirely unaware that the application has critically failed. These ARIA attributes ensure that assistive technologies immediately announce the error state, providing critical context to the user.

📸 **Before/After:**
*   **Before:** Fallback rendered as a silent `<div>`.
*   **After:** Fallback rendered with `role="alert" aria-live="assertive"`, triggering an immediate announcement.

♿ **Accessibility:** This aligns the global crash fallback with WCAG guidelines for dynamically injected error messages, a pattern previously missing here but crucial for robust single-page applications.

---
*PR created automatically by Jules for task [803994095092319475](https://jules.google.com/task/803994095092319475) started by @2fst4u*