### PR TITLE
📚 Archivist: Add Keyboard Shortcuts documentation

### DIFF
--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -56,3 +56,7 @@
 ## 2026-06-04 - Folded Dipole Termination Topology Drift
 **Learning:** The `docs/antenna-spec.md` incorrectly stated that the terminated folded dipole's termination resistor sits on an odd-numbered centre segment of a single opposite conductor. In reality, the codebase (`src/store/antennaGeometry.ts`) splits the opposite conductor into two symmetric halves and uses a separate short horizontal bridge wire (`FOLDED_DIPOLE_TERM_BRIDGE_TAG`) to house the resistor, mirroring the terminated delta topology.
 **Action:** Updated `docs/antenna-spec.md` sections 7.3 and 7.5 to correctly document the split opposite conductor, the termination bridge wire, and the correct total wire count.
+
+## 2026-06-05 - Undiscoverable Keyboard Shortcuts
+**Learning:** Global keyboard shortcuts (`t` for Theme, `u` for Units, `m` for Mode) were fully implemented in the root `App.tsx` component via `useKeyboardShortcuts` but were not documented anywhere. This leaves powerful application features completely undiscoverable to users.
+**Action:** Always audit for global event listeners (like `keydown` on `window`) when verifying documentation completeness. Added a `## Keyboard Shortcuts` section to `README.md` to expose these features.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ While this repository is fully open source and developers are welcome to fork or
 
 Current scope (Phase 1): horizontal dipoles, inverted Vs, sloping Vs, delta loops, terminated deltas, vertical whips, inverted Ls, and folded dipoles, 1.8–30 MHz, real-ground support, offset feed points, feedlines & baluns, comparison mode, SWR/polar cut charts, dark/light theming, metric/imperial toggle.
 
+## Keyboard Shortcuts
+
+- **`t`**: Toggle dark/light theme
+- **`u`**: Toggle metric/imperial units
+- **`m`**: Return to normal mode
+
 ## Stack
 
 - React 19 + Vite + TypeScript (strict)


### PR DESCRIPTION
💡 Problem: Global keyboard shortcuts (`t` for Theme, `u` for Units, `m` for Mode) were fully implemented in the root `App.tsx` component via `useKeyboardShortcuts` but were completely undocumented, making them undiscoverable to users.
🎯 Fix: Added a new `## Keyboard Shortcuts` section to `README.md` and added a learning entry to `.jules/archivist.md` about auditing for global event listeners.
🧪 Verification: Read the updated files, verified the layout and exact commands, and ensured no linting errors by running `npm run lint`. Also ensured tests and build succeed.
🔎 Scope: Only markdown files (`README.md` and `.jules/archivist.md`) were updated.

---
*PR created automatically by Jules for task [12862438797163067504](https://jules.google.com/task/12862438797163067504) started by @2fst4u*