### PR TITLE
🎨 Palette: Add aria-live to dynamic contextual hints

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-28 - Missing ARIA alert on global error boundary
 **Learning:** React ErrorBoundary fallback UIs for rendering app crashes do not natively announce themselves to screen readers because they replace the current DOM without a page reload or focus shift.
 **Action:** Always add `role="alert"` and `aria-live="assertive"` to the container of critical error messages or crash fallbacks so screen reader users are immediately notified.
+## 2024-05-28 - Dynamic hint text accessibility
+**Learning:** Even when a dynamic hint text is linked to an input via `aria-describedby`, screen readers may not reliably announce changes to the hint text if focus remains on the input while the hint changes (e.g. using arrow keys in a `<select>` or adjusting a `<input type="range">`).
+**Action:** Always add `aria-live="polite"` to dynamic hint text containers (like `#feedline-hint` or `#whip-counterpoise-hint`) so screen reader users are notified immediately when the contextual guidance updates.

--- a/src/components/Panel/DipoleControl.tsx
+++ b/src/components/Panel/DipoleControl.tsx
@@ -307,7 +307,7 @@ export function DipoleControl() {
               if (!isNaN(val)) setFoldedDipoleAperture(fromDisplayLength(val, units));
             }}
           />
-          <div id="folded-dipole-aperture-hint" style={{ marginTop: 6, fontSize: 11, color: 'var(--text-muted)', lineHeight: 1.4 }}>
+          <div id="folded-dipole-aperture-hint" aria-live="polite" style={{ marginTop: 6, fontSize: 11, color: 'var(--text-muted)', lineHeight: 1.4 }}>
             Vertical spacing between the bottom (fed) and top (un-fed) conductors. The fed conductor is at the antenna height; the top conductor is aperture above it. For equal-diameter wires the feedpoint stays ~4× a plain dipole (~300 Ω) regardless of spacing; wider spacing raises Z₀ of the two-wire line (currently Z₀ ≈ {tfdZ0} Ω), requiring a higher terminating resistor for a broadband T2FD match. Capped at {maxApertureDisp.toFixed(2)} {unit} — beyond a realistic folded-dipole spacing the structure morphs toward a loop and no longer solves reliably as two close parallel wires.
           </div>
         </>
@@ -359,7 +359,7 @@ export function DipoleControl() {
               Off
             </button>
           </div>
-          <div id="terminating-resistor-hint" style={{ marginTop: 6, fontSize: 11, color: 'var(--text-muted)', lineHeight: 1.4 }}>
+          <div id="terminating-resistor-hint" aria-live="polite" style={{ marginTop: 6, fontSize: 11, color: 'var(--text-muted)', lineHeight: 1.4 }}>
             {terminatingResistor === 0
               ? antennaType === 'folded-dipole'
                 ? 'Unterminated: a classic folded dipole — ~300 Ω feedpoint, narrowband, same gain and pattern as a plain dipole. Add a resistor for a broadband terminated folded dipole (T2FD); click Z₀ to set the optimal termination for this conductor spacing. Use the Match button in the Transformer section below to apply the suggested ratio.'
@@ -388,7 +388,7 @@ export function DipoleControl() {
             />
             Add ¼λ counterpoise radials
           </label>
-          <div id="whip-counterpoise-hint" style={{ marginTop: 6, fontSize: 11, color: 'var(--text-muted)', lineHeight: 1.4 }}>
+          <div id="whip-counterpoise-hint" aria-live="polite" style={{ marginTop: 6, fontSize: 11, color: 'var(--text-muted)', lineHeight: 1.4 }}>
             {whipCounterpoise
               ? '4 horizontal ¼λ radials fan out from the base, giving the source a proper low-loss return path (canonical ground-plane vertical).'
               : 'No counterpoise. NEC will report the high reactance and poor SWR that a radial-less base-fed antenna actually exhibits — switch the toggle on to model a proper ground-plane antenna.'}

--- a/src/components/Panel/FeedlineControl.tsx
+++ b/src/components/Panel/FeedlineControl.tsx
@@ -110,7 +110,7 @@ export function FeedlineControl() {
           <option key={f.id} value={f.id}>{f.label}</option>
         ))}
       </select>
-      <div id="feedline-hint" style={{ marginTop: 6, fontSize: 11, color: 'var(--text-muted)' }}>
+      <div id="feedline-hint" aria-live="polite" style={{ marginTop: 6, fontSize: 11, color: 'var(--text-muted)' }}>
         {preset.hint}
       </div>
 
@@ -227,7 +227,7 @@ export function FeedlineControl() {
                     setLocalMainLen(dispMainLen.toFixed(2));
                   }}
                 />
-                <div id="atu-hint" style={{ marginTop: 6, fontSize: 11, color: 'var(--text-muted)', lineHeight: 1.4 }}>
+                <div id="atu-hint" aria-live="polite" style={{ marginTop: 6, fontSize: 11, color: 'var(--text-muted)', lineHeight: 1.4 }}>
                   The feedline above becomes the short up-mast run (carries the antenna's native SWR);
                   the tuner conjugate-matches at the base, so this main run to the shack stays ~1:1
                   (matched loss {mainRunLossDb.toFixed(2)} dB). Realized gain keeps the up-mast loss

--- a/src/components/Panel/TransformerControl.tsx
+++ b/src/components/Panel/TransformerControl.tsx
@@ -134,7 +134,7 @@ export function TransformerControl() {
               </button>
             )}
           </div>
-          <div id="transformer-hint" style={{ fontSize: 11, color: 'var(--text-muted)', marginTop: 6, lineHeight: 1.4 }}>
+          <div id="transformer-hint" aria-live="polite" style={{ fontSize: 11, color: 'var(--text-muted)', marginTop: 6, lineHeight: 1.4 }}>
             {transformerRatio === 1
               ? 'Ratio 1:1 — a current ("choke") balun. Suppresses common-mode current on the feedline shield, leaves antenna impedance unchanged.'
               : `Ratio ${transformerRatio}:1 — divides antenna feedpoint impedance by ${transformerRatio} and chokes common-mode current on the shield.`}


### PR DESCRIPTION
💡 **What:** Added `aria-live="polite"` to dynamically changing hint text containers throughout the application's control panels (`DipoleControl`, `FeedlineControl`, `TransformerControl`).

🎯 **Why:** When users change select options or toggle checkboxes, the contextual hint text below the input changes to explain the new selection. Although these hints are linked via `aria-describedby`, screen readers do not always announce updates to the text if the user's focus remains on the active input element. Adding `aria-live="polite"` ensures the updated guidance is spoken immediately.

📸 **Before/After:** Not applicable (non-visual structural change).

♿ **Accessibility:** Guarantees that visually impaired users receive the critical, dynamically updated context regarding their currently selected antenna, feedline, or transformer configurations.

---
*PR created automatically by Jules for task [7187407232602498686](https://jules.google.com/task/7187407232602498686) started by @2fst4u*