### PR TITLE
🔭 Scout: Add Open Graph image alt tags and site_name

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,12 +19,15 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://www.gain.observer/" />
     <meta property="og:image" content="https://www.gain.observer/favicon.svg" />
+    <meta property="og:image:alt" content="HF Gain Visualiser 3D Radiation Pattern Logo" />
+    <meta property="og:site_name" content="HF Gain Visualiser" />
 
     <!-- Twitter Card Metadata -->
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="HF Gain Visualiser" />
     <meta name="twitter:description" content="HF antenna gain visualiser — 3D radiation patterns powered by NEC-2 WebAssembly." />
     <meta name="twitter:image" content="https://www.gain.observer/favicon.svg" />
+    <meta name="twitter:image:alt" content="HF Gain Visualiser 3D Radiation Pattern Logo" />
 
     <title>HF Gain Visualiser</title>
 
@@ -35,6 +38,7 @@
         "@type": "WebApplication",
         "name": "HF Gain Visualiser",
         "url": "https://www.gain.observer/",
+        "image": "https://www.gain.observer/favicon.svg",
         "description": "HF antenna gain visualiser — 3D radiation patterns powered by NEC-2 WebAssembly.",
         "applicationCategory": "DeveloperApplication",
         "browserRequirements": "Requires WebAssembly support",


### PR DESCRIPTION
💡 What: Added missing `og:image:alt`, `og:site_name`, and `twitter:image:alt` meta tags, along with an `image` property to the JSON-LD schema in `index.html`.
🎯 Why: Improves SEO, discoverability, and accessibility on social sharing previews and rich search snippets by providing text alternatives and explicit context for the preview image.
📊 Value: Richer search snippets and more accessible social sharing cards.
🔬 Measurement: Verify the presence of the tags in the DOM `<head>` via `cat index.html`.

---
*PR created automatically by Jules for task [8386663861291628796](https://jules.google.com/task/8386663861291628796) started by @2fst4u*