### PR TITLE
test: Remove outdated delta loop regression comment

### DIFF
--- a/tests/antennaStore.test.ts
+++ b/tests/antennaStore.test.ts
@@ -1207,11 +1207,6 @@ describe("antennaStore actions", () => {
     });
 
     describe("Delta Loop Preset Verification — low mast heights", () => {
-      // Regression: at h=8 and h=8.5 the feedline shield was incorrectly
-      // extended below the delta loop base wire, causing the NEC MOM solver
-      // to produce -999.99 sentinel gains and negative resistance. The fix
-      // clamps the shield bottom to the base wire z-coordinate so the shield
-      // never crosses the base wire plane.
       it.each([
         { name: "160m", mhz: 1.9, height: 8 },
         { name: "160m", mhz: 1.9, height: 8.5 },


### PR DESCRIPTION
Removed the regression comment regarding "negative resistance for low mast height delta loops" as the bug is already fixed in `src/store/antennaGeometry.ts`.

---
*PR created automatically by Jules for task [16596444752406721904](https://jules.google.com/task/16596444752406721904) started by @2fst4u*