### PR TITLE
🧹 Sweep: Extract duplicated cleanZero function

### DIFF
--- a/.jules/sweep.md
+++ b/.jules/sweep.md
@@ -7,3 +7,6 @@
 ## 2024-05-23 - Internal Definitions and Export Cleanup
 **Learning:** `knip` flagged `INVERTED_L_HORIZONTAL_TAG` and `INVERTED_L_RADIAL_TAG` as unused exports in `src/store/antennaStore.ts`. However, these constants are actually defined in `src/physics/constants.ts` and used in `src/store/antennaGeometry.ts`. The re-export in the store file was unnecessary, but the actual declarations were not dead code.
 **Action:** When `knip` reports an unused export, particularly in a file that seems to be re-exporting things (like an aggregator or a store), trace the variable back to its definition and do a global search (`grep`) to see if it is used *anywhere* else in the application. Only delete the original definition if it is 100% dead code application-wide. If it is used elsewhere but the re-export is truly unused, only remove the re-export.
+## 2024-06-07 - Extracted duplicated cleanZero function
+**Learning:** Ensure all duplicated instances of a function are removed when extracting it to a central utility file.
+**Action:** Replaced all 4 local declarations of cleanZero with an import from the new math utility file.

--- a/src/store/antennaGeometry.ts
+++ b/src/store/antennaGeometry.ts
@@ -1,3 +1,4 @@
+import { cleanZero } from "../utils/math";
 import {
   SLOPING_V_MIN_TIP_Z_M,
   wavelengthMeters,
@@ -132,7 +133,7 @@ export function buildInvertedVWires(params: InvertedVWiresParams): Wire[] {
   const bridgeHalf = FEED_BRIDGE_LENGTH_M / 2;
   const h = params.height;
   const [dx, dy] = orientationVector(params.orientation);
-  const cleanZero = (v: number): number => (v === 0 ? 0 : v);
+
 
   const slopeDeg = (180 - params.vAngle) / 2;
 
@@ -250,7 +251,7 @@ export function buildSlopingVWires(params: SlopingVWiresParams): Wire[] {
   const cosV = Math.cos(halfV);
   const sinV = Math.sin(halfV);
 
-  const cleanZero = (v: number): number => (v === 0 ? 0 : v);
+
 
   function legPointAt(axis: number, side: number): [number, number, number] {
     // axis is distance along the sloping leg starting from the apex.
@@ -909,7 +910,7 @@ export function buildFoldedDipoleWires(params: FoldedDipoleWiresParams): Wire[] 
   const hasTermination = (params.terminatingResistor ?? 0) > 0;
 
   const [dx, dy] = orientationVector(params.orientation);
-  const cleanZero = (v: number): number => (v === 0 ? 0 : v);
+
 
   // Bottom (fed) conductor at z = h; top (opposite) conductor at z = h + aperture.
   const zBottom = h;

--- a/src/store/antennaStore.ts
+++ b/src/store/antennaStore.ts
@@ -5,6 +5,7 @@
 //     the component edge via useUnits() / toDisplayLength().
 //   - `result` is read-only for UI code; it is written only by the physics
 //     worker bridge via the underscored _setResult action.
+import { cleanZero } from "../utils/math";
 
 import { create } from 'zustand';
 import { subscribeWithSelector } from 'zustand/middleware';
@@ -882,7 +883,7 @@ export function buildWires(
   }
 
   const [dx, dy] = orientationVector(state.orientation);
-  const cleanZero = (v: number): number => (v === 0 ? 0 : v);
+
 
   const layout = computeFeedlineLayout(state);
 

--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -1,0 +1,1 @@
+export const cleanZero = (v: number): number => (v === 0 ? 0 : v);


### PR DESCRIPTION
🎯 **What:** Extracted the inline `cleanZero` function into a shared utility file at `src/utils/math.ts` and replaced all duplicated local declarations in `src/store/antennaGeometry.ts` and `src/store/antennaStore.ts` with an import.
💡 **Why:** Reduces code duplication, making it easier to maintain and test this logic centrally.
✅ **Verification:** Verified by checking all occurrences using `grep`, replacing them, and running `npm run lint`, `npm run build`, and `npm run test`, which all passed.
✨ **Result:** A cleaner codebase with reduced redundancy.

---
*PR created automatically by Jules for task [8539643584038757003](https://jules.google.com/task/8539643584038757003) started by @2fst4u*