### PR TITLE
🧹 Sweep: Genericize "dipole" variables to "antenna" terminology

### DIFF
--- a/src/components/Panel/ControlPanel.tsx
+++ b/src/components/Panel/ControlPanel.tsx
@@ -1,5 +1,5 @@
 import { FrequencyControl } from './FrequencyControl';
-import { DipoleControl } from './DipoleControl';
+import { GeometryControl } from './GeometryControl';
 import { GroundControl } from './GroundControl';
 import { FeedlineControl } from './FeedlineControl';
 import { ModeSelector } from './ModeSelector';
@@ -39,7 +39,7 @@ export function ControlPanel() {
       <ModeSelector />
       <ComparisonControl />
       <FrequencyControl />
-      <DipoleControl />
+      <GeometryControl />
       <GroundControl />
       <FeedlineControl />
       <StatsReadout />

--- a/src/components/Panel/GeometryControl.tsx
+++ b/src/components/Panel/GeometryControl.tsx
@@ -14,7 +14,7 @@ import {
 import { FOLDED_DIPOLE_MAX_APERTURE_M } from '../../physics/constants';
 import { TransformerControl } from './TransformerControl';
 
-export function DipoleControl() {
+export function GeometryControl() {
   // ⚡ Bolt: Performance Optimization
   // Grouped multiple individual Zustand store selector subscriptions into a single useShallow block.
   // This reduces React hook allocation overhead and minimizes the number of store listeners,

--- a/src/components/Panel/StatsReadout.tsx
+++ b/src/components/Panel/StatsReadout.tsx
@@ -1,4 +1,4 @@
-import { useAntennaStore, selectAtuConfig, DIPOLE_LEFT_TAG, DIPOLE_RIGHT_TAG } from '../../store/antennaStore';
+import { useAntennaStore, selectAtuConfig, LEFT_LEG_TAG, RIGHT_LEG_TAG } from '../../store/antennaStore';
 import { useShallow } from 'zustand/react/shallow';
 import { displayedFeedMetrics } from '../../physics/impedance';
 import { TRANSFORMER_INSERTION_LOSS_DB } from '../../physics/constants';
@@ -194,8 +194,8 @@ function rippleColor(rippleDb: number): string {
 }
 
 function legLabel(tagNo: number): string {
-  if (tagNo === DIPOLE_LEFT_TAG) return 'Left leg ripple';
-  if (tagNo === DIPOLE_RIGHT_TAG) return 'Right leg ripple';
+  if (tagNo === LEFT_LEG_TAG) return 'Left leg ripple';
+  if (tagNo === RIGHT_LEG_TAG) return 'Right leg ripple';
   return `Tag ${tagNo} ripple`;
 }
 
@@ -211,7 +211,7 @@ function TerminationSection({ diagnostics }: { diagnostics: TerminationDiagnosti
 
   const { currentRippleByTag, powerBudget, frontBackDb } = diagnostics;
   const legRipples = currentRippleByTag.filter(
-    (r) => r.tagNo === DIPOLE_LEFT_TAG || r.tagNo === DIPOLE_RIGHT_TAG,
+    (r) => r.tagNo === LEFT_LEG_TAG || r.tagNo === RIGHT_LEG_TAG,
   );
 
   const hasContent =

--- a/src/components/Scene/AntennaScene.tsx
+++ b/src/components/Scene/AntennaScene.tsx
@@ -8,7 +8,7 @@
 import { Canvas } from '@react-three/fiber';
 import { OrbitControls, GizmoHelper, GizmoViewport } from '@react-three/drei';
 import { Suspense, useMemo } from 'react';
-import { DipoleWire } from './DipoleWire';
+import { AntennaWire } from './AntennaWire';
 import { GroundPlane } from './GroundPlane';
 import { RadiationPattern } from './RadiationPattern';
 import { useAntennaStore, selectAtuConfig, type ComparisonSnapshot } from '../../store/antennaStore';
@@ -126,7 +126,7 @@ export function AntennaScene({ snapshot = null }: AntennaSceneProps) {
 
       <Suspense fallback={null}>
         <GroundPlane groundId={groundId} height={height} showGrid={showGrid} />
-        <DipoleWire
+        <AntennaWire
           type={type}
           length={length}
           height={height}

--- a/src/components/Scene/AntennaWire.tsx
+++ b/src/components/Scene/AntennaWire.tsx
@@ -11,16 +11,16 @@
 import { useShallow } from 'zustand/react/shallow';
 import { useAntennaStore } from '../../store/antennaStore';
 import { THEME_COLORS } from '../../utils/themeColors';
-import { useDipoleGeometry, type DipoleWireProps } from './useDipoleGeometry';
+import { useAntennaGeometry, type AntennaWireProps } from './useAntennaGeometry';
 
-export function DipoleWire(props: DipoleWireProps) {
+export function AntennaWire(props: AntennaWireProps) {
   const { theme, transformerEnabled, terminatingResistor } = useAntennaStore(useShallow((s) => ({
     theme: s.theme,
     transformerEnabled: s.transformerEnabled,
     terminatingResistor: s.terminatingResistor,
   })));
 
-  const { rendered, shield, feedpoint, terminatedDeltaSplit } = useDipoleGeometry(props);
+  const { rendered, shield, feedpoint, terminatedDeltaSplit } = useAntennaGeometry(props);
   return (
     <group>
       {rendered.map((s) => (

--- a/src/components/Scene/useAntennaGeometry.ts
+++ b/src/components/Scene/useAntennaGeometry.ts
@@ -4,8 +4,8 @@ import { useShallow } from 'zustand/react/shallow';
 import {
   useAntennaStore,
   buildWires,
-  DIPOLE_TAG,
-  DIPOLE_LEFT_TAG,
+  MAIN_WIRE_TAG,
+  LEFT_LEG_TAG,
   FEED_BRIDGE_TAG,
   FEEDLINE_SHIELD_TAG,
   TERMINATED_DELTA_LEFT_BASE_TAG,
@@ -15,7 +15,7 @@ import {
 } from '../../store/antennaStore';
 import type { AntennaType } from '../../physics/types';
 
-export interface DipoleWireProps {
+export interface AntennaWireProps {
   readonly type: AntennaType;
   readonly length: number;
   readonly height: number;
@@ -32,7 +32,7 @@ function necToScene(p: readonly [number, number, number]): [number, number, numb
   return [p[0], p[2], -p[1]];
 }
 
-export function useDipoleGeometry({
+export function useAntennaGeometry({
   type,
   length,
   height,
@@ -43,7 +43,7 @@ export function useDipoleGeometry({
   feedlineLength,
   feedlineOffset,
   whipCounterpoise,
-}: DipoleWireProps) {
+}: AntennaWireProps) {
   const {
     vAngle,
     legSlope,
@@ -85,7 +85,7 @@ export function useDipoleGeometry({
       if (lengthScene < 1e-6) continue;
       const q = new THREE.Quaternion();
       q.setFromUnitVectors(new THREE.Vector3(0, 1, 0), dir.clone().normalize());
-      const tag = w.tag ?? DIPOLE_TAG;
+      const tag = w.tag ?? MAIN_WIRE_TAG;
       const isShield = tag === FEEDLINE_SHIELD_TAG;
       const isBridge = tag === FEED_BRIDGE_TAG;
       let radius: number;
@@ -113,7 +113,7 @@ export function useDipoleGeometry({
     const isWhip = type === 'vertical-whip';
 
     let bridge: typeof rendered[0] | undefined;
-    let dipoleSingle: typeof rendered[0] | undefined;
+    let mainWireSingle: typeof rendered[0] | undefined;
     let shieldWire: typeof rendered[0] | undefined;
     let apexFedLeft: typeof rendered[0] | undefined;
     let verticalWhip: typeof rendered[0] | undefined;
@@ -125,10 +125,10 @@ export function useDipoleGeometry({
       if (s.isShield && !shieldWire) shieldWire = s;
 
       switch (s.tag) {
-        case DIPOLE_TAG:
-          if (!dipoleSingle) dipoleSingle = s;
+        case MAIN_WIRE_TAG:
+          if (!mainWireSingle) mainWireSingle = s;
           break;
-        case DIPOLE_LEFT_TAG:
+        case LEFT_LEG_TAG:
           if (isDelta && !apexFedLeft) apexFedLeft = s;
           break;
         case VERTICAL_WHIP_TAG:
@@ -139,7 +139,7 @@ export function useDipoleGeometry({
       if (
         bridge &&
         shieldWire &&
-        dipoleSingle &&
+        mainWireSingle &&
         (!isDelta || apexFedLeft) &&
         (!isWhip || verticalWhip)
       ) {
@@ -148,7 +148,7 @@ export function useDipoleGeometry({
     }
 
     // If we have a bridge, the legacy dipole wire isn't the primary feed.
-    const feedSingle = bridge ? undefined : dipoleSingle;
+    const feedSingle = bridge ? undefined : mainWireSingle;
 
     // Feedpoint: bridge midpoint (split-fed) > apex-fed left-leg end >
     // vertical-whip base > dipole wire midpoint (single-wire legacy).

--- a/src/physics/constants.ts
+++ b/src/physics/constants.ts
@@ -95,9 +95,9 @@ export function referenceLength(type: AntennaType, frequencyMHz: number, endEffe
 }
 
 // --- Geometry Tags ---
-export const DIPOLE_TAG = 1; // single-wire dipole (no feedline)
-export const DIPOLE_LEFT_TAG = 1; // left half of split dipole
-export const DIPOLE_RIGHT_TAG = 2; // right half of split dipole
+export const MAIN_WIRE_TAG = 1; // single-wire dipole (no feedline)
+export const LEFT_LEG_TAG = 1; // left leg of split antenna
+export const RIGHT_LEG_TAG = 2; // right leg of split antenna
 export const FEED_BRIDGE_TAG = 3; // 1-segment source bridge
 export const FEEDLINE_SHIELD_TAG = 4; // coax shield (radiating outer surface)
 export const DELTA_BASE_TAG = 6; // base wire of delta loop (left corner to right corner)
@@ -166,8 +166,8 @@ export const SLOPING_V_RIGHT_STUB_TAG = 8;
  * Wire tags for the Terminated Delta antenna.
  *
  * The terminated delta is the same isosceles triangle as a delta loop with
- * the apex at the top and feedpoint at the apex (DIPOLE_LEFT_TAG /
- * DIPOLE_RIGHT_TAG carry the two top legs, exactly as in the delta loop).
+ * the apex at the top and feedpoint at the apex (LEFT_LEG_TAG /
+ * RIGHT_LEG_TAG carry the two top legs, exactly as in the delta loop).
  *
  * The base wire is **split** in the middle into two independent half-base
  * wires, each running inward from its corner toward (but not touching) the
@@ -186,7 +186,7 @@ export const TERMINATED_DELTA_BRIDGE_TAG = 11;
 
 /**
  * Wire tag for the vertical whip (single-wire monopole).
- * Distinct from DIPOLE_TAG so the renderer can place the feedpoint marker
+ * Distinct from MAIN_WIRE_TAG so the renderer can place the feedpoint marker
  * at the base of the whip rather than at its midpoint.
  */
 export const VERTICAL_WHIP_TAG = 12;
@@ -240,8 +240,8 @@ export const INVERTED_L_RADIAL_TAG = 16;
  * Wire tags for the Folded Dipole antenna.
  *
  * Two parallel half-wave conductors joined at both ends form a narrow loop.
- * The lower conductor is fed at its centre (split into DIPOLE_LEFT_TAG /
- * DIPOLE_RIGHT_TAG halves around the FEED_BRIDGE_TAG = 3 source bridge, the
+ * The lower conductor is fed at its centre (split into LEFT_LEG_TAG /
+ * RIGHT_LEG_TAG halves around the FEED_BRIDGE_TAG = 3 source bridge, the
  * same split-fed convention as the standard dipole). The upper conductor is
  * split at its centre into two halves that share a wire junction at the top
  * centre point (FOLDED_DIPOLE_OPPOSITE_TAG × 2); in the unterminated case

--- a/src/store/antennaGeometry.ts
+++ b/src/store/antennaGeometry.ts
@@ -1,8 +1,8 @@
 import {
   SLOPING_V_MIN_TIP_Z_M,
   wavelengthMeters,
-  DIPOLE_LEFT_TAG,
-  DIPOLE_RIGHT_TAG,
+  LEFT_LEG_TAG,
+  RIGHT_LEG_TAG,
   FEED_BRIDGE_TAG,
   FEED_BRIDGE_LENGTH_M,
   DELTA_BASE_TAG,
@@ -175,14 +175,14 @@ export function buildInvertedVWires(params: InvertedVWiresParams): Wire[] {
       end: apexLeft,
       radius: params.wireRadius,
       segments: segmentsPerLeg,
-      tag: DIPOLE_LEFT_TAG,
+      tag: LEFT_LEG_TAG,
     },
     {
       start: apexRight,
       end: legPointAt(legLen, 1),
       radius: params.wireRadius,
       segments: segmentsPerLeg,
-      tag: DIPOLE_RIGHT_TAG,
+      tag: RIGHT_LEG_TAG,
     },
     {
       start: apexLeft,
@@ -222,7 +222,7 @@ export interface SlopingVWiresParams {
  *
  * A leg is emitted as one Wire per graded prefix segment plus one
  * multi-segment Wire covering the uniform tail. All sub-wires of a given leg
- * share the same tag (DIPOLE_LEFT_TAG / DIPOLE_RIGHT_TAG) so that current-
+ * share the same tag (LEFT_LEG_TAG / RIGHT_LEG_TAG) so that current-
  * ripple and load diagnostics continue to group by leg correctly.
  *
  * Convention:
@@ -311,7 +311,7 @@ export function buildSlopingVWires(params: SlopingVWiresParams): Wire[] {
       end: legPointAt(prefixEnd, -1),
       radius: params.wireRadius,
       segments: tailCount,
-      tag: DIPOLE_LEFT_TAG,
+      tag: LEFT_LEG_TAG,
     });
   }
   // (2) Graded prefix wires in reverse (largest to smallest, toward apex).
@@ -321,7 +321,7 @@ export function buildSlopingVWires(params: SlopingVWiresParams): Wire[] {
       end: legPointAt(breakpoints[i]!, -1),
       radius: params.wireRadius,
       segments: 1,
-      tag: DIPOLE_LEFT_TAG,
+      tag: LEFT_LEG_TAG,
     });
   }
 
@@ -333,7 +333,7 @@ export function buildSlopingVWires(params: SlopingVWiresParams): Wire[] {
       end: legPointAt(breakpoints[i + 1]!, 1),
       radius: params.wireRadius,
       segments: 1,
-      tag: DIPOLE_RIGHT_TAG,
+      tag: RIGHT_LEG_TAG,
     });
   }
   // (2) Uniform tail wire from end of prefix out to tip.
@@ -343,7 +343,7 @@ export function buildSlopingVWires(params: SlopingVWiresParams): Wire[] {
       end: legPointAt(legLen, 1),
       radius: params.wireRadius,
       segments: tailCount,
-      tag: DIPOLE_RIGHT_TAG,
+      tag: RIGHT_LEG_TAG,
     });
   }
 
@@ -384,11 +384,11 @@ export interface DeltaLoopWiresParams {
  * preserving the full perimeter.
  *
  * Tags:
- *   DIPOLE_LEFT_TAG  (1) — left leg:  leftCorner → apex
- *   DIPOLE_RIGHT_TAG (2) — right leg: apex → rightCorner
+ *   LEFT_LEG_TAG  (1) — left leg:  leftCorner → apex
+ *   RIGHT_LEG_TAG (2) — right leg: apex → rightCorner
  *   DELTA_BASE_TAG   (6) — base wire: leftCorner → rightCorner
  *
- * Excitation is placed on the last segment of DIPOLE_LEFT_TAG (the apex end).
+ * Excitation is placed on the last segment of LEFT_LEG_TAG (the apex end).
  */
 export function buildDeltaLoopWires(params: DeltaLoopWiresParams): Wire[] {
   const perimeter = params.length;
@@ -445,14 +445,14 @@ export function buildDeltaLoopWires(params: DeltaLoopWiresParams): Wire[] {
       end: apexLeft,
       radius: params.wireRadius,
       segments: segmentsPerLeg,
-      tag: DIPOLE_LEFT_TAG,
+      tag: LEFT_LEG_TAG,
     },
     {
       start: apexRight,
       end: rightCorner,
       radius: params.wireRadius,
       segments: segmentsPerLeg,
-      tag: DIPOLE_RIGHT_TAG,
+      tag: RIGHT_LEG_TAG,
     },
     {
       start: leftCorner,
@@ -513,12 +513,12 @@ export interface TerminatedDeltaWiresParams {
  * physically-correct sloping-V tip-to-earth shunt termination.
  *
  * Tags:
- *   DIPOLE_LEFT_TAG               (1)  — top-left leg:  leftCorner → apex
- *   DIPOLE_RIGHT_TAG              (2)  — top-right leg: apex → rightCorner
+ *   LEFT_LEG_TAG               (1)  — top-left leg:  leftCorner → apex
+ *   RIGHT_LEG_TAG              (2)  — top-right leg: apex → rightCorner
  *   TERMINATED_DELTA_LEFT_BASE_TAG  (9)  — left half-base:  leftCorner → centreLeft
  *   TERMINATED_DELTA_RIGHT_BASE_TAG (10) — right half-base: centreRight → rightCorner
  *
- * Excitation is placed on the last segment of DIPOLE_LEFT_TAG (the apex
+ * Excitation is placed on the last segment of LEFT_LEG_TAG (the apex
  * end), or on the feed bridge / shield when a feedline is active —
  * exactly as for the delta loop.
  */
@@ -595,14 +595,14 @@ export function buildTerminatedDeltaWires(params: TerminatedDeltaWiresParams): W
       end: apexLeft,
       radius: params.wireRadius,
       segments: segmentsPerLeg,
-      tag: DIPOLE_LEFT_TAG,
+      tag: LEFT_LEG_TAG,
     },
     {
       start: apexRight,
       end: rightCorner,
       radius: params.wireRadius,
       segments: segmentsPerLeg,
-      tag: DIPOLE_RIGHT_TAG,
+      tag: RIGHT_LEG_TAG,
     },
     {
       start: leftCorner,
@@ -848,7 +848,7 @@ export function buildInvertedLWires(params: InvertedLWiresParams): Wire[] {
   return wires;
 }
 
-export interface FoldedDipoleWiresParams {
+export interface FoldedAntennaWiresParams {
   /** Each conductor's length, metres (≈½λ resonant). */
   length: number;
   /** Height of the (planar, horizontal) antenna above ground, metres. */
@@ -895,13 +895,13 @@ export interface FoldedDipoleWiresParams {
  *     terminated-delta's centre-gap bridge.
  *
  * Tags:
- *   DIPOLE_LEFT_TAG              (1)  — fed (bottom) conductor, left half (left → bridge)
- *   DIPOLE_RIGHT_TAG             (2)  — fed (bottom) conductor, right half (bridge → right)
+ *   LEFT_LEG_TAG              (1)  — fed (bottom) conductor, left half (left → bridge)
+ *   RIGHT_LEG_TAG             (2)  — fed (bottom) conductor, right half (bridge → right)
  *   FEED_BRIDGE_TAG              (3)  — 1-segment source bridge at the centre
  *   FOLDED_DIPOLE_OPPOSITE_TAG   (17) — un-fed (top) conductor, 2 halves (always split)
  *   FOLDED_DIPOLE_CONNECTOR_TAG  (18) — both end connectors (vertical, bottom → top)
  */
-export function buildFoldedDipoleWires(params: FoldedDipoleWiresParams): Wire[] {
+export function buildFoldedAntennaWires(params: FoldedAntennaWiresParams): Wire[] {
   const h = params.height;
   const half = Math.max(0.1, params.length) / 2;
   const aperture = Math.max(0.02, params.aperture);
@@ -980,7 +980,7 @@ export function buildFoldedDipoleWires(params: FoldedDipoleWiresParams): Wire[] 
       end: bridgeLeft,
       radius: params.wireRadius,
       segments: halfSegs,
-      tag: DIPOLE_LEFT_TAG,
+      tag: LEFT_LEG_TAG,
     },
     // Feed bridge at the centre of the fed conductor.
     {
@@ -996,7 +996,7 @@ export function buildFoldedDipoleWires(params: FoldedDipoleWiresParams): Wire[] 
       end: rightFed,
       radius: params.wireRadius,
       segments: halfSegs,
-      tag: DIPOLE_RIGHT_TAG,
+      tag: RIGHT_LEG_TAG,
     },
     // Un-fed (top) conductor — left half.
     // Unterminated: ends at topCenter (same as right half's start) → continuous.

--- a/src/store/antennaStore.ts
+++ b/src/store/antennaStore.ts
@@ -33,9 +33,9 @@ import {
   findGroundPreset,
   referenceLength,
   halfWaveLength,
-  DIPOLE_TAG,
-  DIPOLE_LEFT_TAG,
-  DIPOLE_RIGHT_TAG,
+  MAIN_WIRE_TAG,
+  LEFT_LEG_TAG,
+  RIGHT_LEG_TAG,
   FEED_BRIDGE_TAG,
   FEEDLINE_SHIELD_TAG,
   FEED_BRIDGE_LENGTH_M,
@@ -58,9 +58,9 @@ import {
 
 // Re-export geometry tags for UI and tests.
 export {
-  DIPOLE_TAG,
-  DIPOLE_LEFT_TAG,
-  DIPOLE_RIGHT_TAG,
+  MAIN_WIRE_TAG,
+  LEFT_LEG_TAG,
+  RIGHT_LEG_TAG,
   FEED_BRIDGE_TAG,
   FEEDLINE_SHIELD_TAG,
   FEED_BRIDGE_LENGTH_M,
@@ -86,7 +86,7 @@ import {
   buildTerminatedDeltaWires,
   buildVerticalWhipWires,
   buildInvertedLWires,
-  buildFoldedDipoleWires,
+  buildFoldedAntennaWires,
   orientationVector,
   type OrientationPreset,
   type Orientation,
@@ -857,7 +857,7 @@ export function buildWires(
 
   if (antennaType === 'folded-dipole') {
     const layout = computeFeedlineLayout(state);
-    const wires = buildFoldedDipoleWires({
+    const wires = buildFoldedAntennaWires({
       length: state.length,
       height: h,
       aperture: state.foldedDipoleAperture ?? FOLDED_DIPOLE_DEFAULT_APERTURE_M,
@@ -892,7 +892,7 @@ export function buildWires(
       end: [cleanZero(half * dx), cleanZero(half * dy), h],
       radius: state.wireRadius,
       segments: state.segments,
-      tag: DIPOLE_TAG,
+      tag: MAIN_WIRE_TAG,
     }];
   }
 
@@ -929,13 +929,13 @@ export function buildWires(
       start: leftTip, end: bridgeStart,
       radius: state.wireRadius,
       segments: leftSeg,
-      tag: DIPOLE_LEFT_TAG,
+      tag: LEFT_LEG_TAG,
     },
     {
       start: bridgeEnd, end: rightTip,
       radius: state.wireRadius,
       segments: rightSeg,
-      tag: DIPOLE_RIGHT_TAG,
+      tag: RIGHT_LEG_TAG,
     },
     {
       start: bridgeStart, end: bridgeEnd,
@@ -1038,8 +1038,8 @@ function buildExcitation(
   } else if (state.antennaType === 'delta-loop' || state.antennaType === 'terminated-delta') {
     // Apex-fed: excitation lives on the last segment of the left leg
     // (whose .end is the apex by convention in build*Wires).
-    const leftLeg = wires.find((w) => w.tag === DIPOLE_LEFT_TAG)!;
-    return { wireTag: DIPOLE_LEFT_TAG, segment: leftLeg.segments };
+    const leftLeg = wires.find((w) => w.tag === LEFT_LEG_TAG)!;
+    return { wireTag: LEFT_LEG_TAG, segment: leftLeg.segments };
   } else if (state.antennaType === 'vertical-whip') {
     // Base-fed monopole: excitation on the first (lowest) segment.
     return { wireTag: VERTICAL_WHIP_TAG, segment: 1 };
@@ -1047,8 +1047,8 @@ function buildExcitation(
     // Base-fed: excitation on the first (lowest) segment of the vertical section.
     return { wireTag: INVERTED_L_VERTICAL_TAG, segment: 1 };
   } else {
-    const dipoleCentreSeg = Math.ceil(state.segments / 2);
-    return { wireTag: DIPOLE_TAG, segment: dipoleCentreSeg };
+    const mainWireCentreSeg = Math.ceil(state.segments / 2);
+    return { wireTag: MAIN_WIRE_TAG, segment: mainWireCentreSeg };
   }
 }
 
@@ -1157,8 +1157,8 @@ function buildTerminationElements(state: AntennaState, wires: Wire[]) {
     let lastRight: Wire | undefined;
     for (let i = 0; i < wires.length; i++) {
       const w = wires[i];
-      if (w.tag === DIPOLE_LEFT_TAG && !firstLeft) firstLeft = w;
-      if (w.tag === DIPOLE_RIGHT_TAG) lastRight = w;
+      if (w.tag === LEFT_LEG_TAG && !firstLeft) firstLeft = w;
+      if (w.tag === RIGHT_LEG_TAG) lastRight = w;
     }
     const leftTip  = firstLeft!.start;
     const rightTip = lastRight!.end;
@@ -1228,7 +1228,7 @@ function buildTerminationElements(state: AntennaState, wires: Wire[]) {
     const R = state.terminatingResistor;
     // Terminated Folded Dipole (TFD) — correct travelling-wave gap-bridge topology.
     //
-    // buildFoldedDipoleWires splits the top (un-fed) conductor into two halves
+    // buildFoldedAntennaWires splits the top (un-fed) conductor into two halves
     // with a gap of TERMINATED_DELTA_CENTRE_GAP_M at the centre when a
     // terminating resistor is non-zero. The gap inner ends are:
     //   left-half  .end = topCenterLeft

--- a/tests/AntennaScene.test.tsx
+++ b/tests/AntennaScene.test.tsx
@@ -15,8 +15,8 @@ vi.mock('@react-three/drei', () => ({
   GizmoViewport: () => <div data-testid="gizmo-viewport" />,
 }));
 
-vi.mock('../src/components/Scene/DipoleWire', () => ({
-  DipoleWire: (props: unknown) => <div data-testid="dipole-wire" data-props={JSON.stringify(props)} />
+vi.mock('../src/components/Scene/AntennaWire', () => ({
+  AntennaWire: (props: unknown) => <div data-testid="antenna-wire" data-props={JSON.stringify(props)} />
 }));
 
 vi.mock('../src/components/Scene/GroundPlane', () => ({
@@ -84,12 +84,12 @@ describe('AntennaScene', () => {
     const { getByTestId } = render(<AntennaScene />);
     expect(getByTestId('canvas')).toBeTruthy();
 
-    // DipoleWire should receive live state props
-    const dipoleWire = getByTestId('dipole-wire');
-    const dipoleProps = JSON.parse(dipoleWire.getAttribute('data-props') || '{}');
-    expect(dipoleProps.type).toBe('dipole');
-    expect(dipoleProps.length).toBe(20);
-    expect(dipoleProps.feedlineId).toBe('coax');
+    // AntennaWire should receive live state props
+    const antennaWire = getByTestId('antenna-wire');
+    const antennaProps = JSON.parse(antennaWire.getAttribute('data-props') || '{}');
+    expect(antennaProps.type).toBe('dipole');
+    expect(antennaProps.length).toBe(20);
+    expect(antennaProps.feedlineId).toBe('coax');
 
     // RadiationPattern should receive live state props
     const radiationPattern = getByTestId('radiation-pattern');
@@ -123,15 +123,15 @@ describe('AntennaScene', () => {
 
     const { getByTestId } = render(<AntennaScene snapshot={snapshot as unknown as import('../src/store/antennaStore').ComparisonSnapshot} />);
 
-    // DipoleWire should receive snapshot state props
-    const dipoleWire = getByTestId('dipole-wire');
-    const dipoleProps = JSON.parse(dipoleWire.getAttribute('data-props') || '{}');
-    expect(dipoleProps.type).toBe('vertical-whip');
-    expect(dipoleProps.length).toBe(5);
-    expect(dipoleProps.height).toBe(0);
-    expect(dipoleProps.orientation).toBe('NS');
-    expect(dipoleProps.feedlineId).toBe('ladder');
-    expect(dipoleProps.whipCounterpoise).toBe(4);
+    // AntennaWire should receive snapshot state props
+    const antennaWire = getByTestId('antenna-wire');
+    const antennaProps = JSON.parse(antennaWire.getAttribute('data-props') || '{}');
+    expect(antennaProps.type).toBe('vertical-whip');
+    expect(antennaProps.length).toBe(5);
+    expect(antennaProps.height).toBe(0);
+    expect(antennaProps.orientation).toBe('NS');
+    expect(antennaProps.feedlineId).toBe('ladder');
+    expect(antennaProps.whipCounterpoise).toBe(4);
 
     // RadiationPattern should receive snapshot state props
     const radiationPattern = getByTestId('radiation-pattern');

--- a/tests/AntennaWire.test.tsx
+++ b/tests/AntennaWire.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, cleanup } from '@testing-library/react';
-import { DipoleWire } from '../src/components/Scene/DipoleWire';
+import { AntennaWire } from '../src/components/Scene/AntennaWire';
 import { useAntennaStore } from '../src/store/antennaStore';
 
 // Mock specific three.js components to avoid jsdom warnings
@@ -16,7 +16,7 @@ vi.mock('../src/store/antennaStore', async () => {
   };
 });
 
-describe('DipoleWire', () => {
+describe('AntennaWire', () => {
   let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
@@ -49,7 +49,7 @@ describe('DipoleWire', () => {
 
   it('renders a basic dipole wire', () => {
     const { container } = render(
-      <DipoleWire
+      <AntennaWire
         type="dipole"
         length={10}
         height={5}
@@ -85,7 +85,7 @@ describe('DipoleWire', () => {
     });
 
     const { container } = render(
-      <DipoleWire
+      <AntennaWire
         type="terminated-delta"
         length={20}
         height={10}
@@ -118,7 +118,7 @@ describe('DipoleWire', () => {
     });
 
     const { container } = render(
-      <DipoleWire
+      <AntennaWire
         type="dipole"
         length={10}
         height={5}

--- a/tests/GeometryControl.test.tsx
+++ b/tests/GeometryControl.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, cleanup } from '@testing-library/react';
-import { DipoleControl } from '../src/components/Panel/DipoleControl';
+import { GeometryControl } from '../src/components/Panel/GeometryControl';
 import { useAntennaStore } from '../src/store/antennaStore';
 
 // Mock the store
@@ -71,7 +71,7 @@ function buildMockState(overrides: Partial<MockState> = {}): MockState {
   };
 }
 
-describe('DipoleControl', () => {
+describe('GeometryControl', () => {
   it('toggles whip counterpoise when antenna is vertical-whip', () => {
     const setWhipCounterpoise = vi.fn();
     vi.mocked(useAntennaStore).mockImplementation((selector: (s: MockState) => unknown) => {
@@ -82,7 +82,7 @@ describe('DipoleControl', () => {
       }));
     });
 
-    render(<DipoleControl />);
+    render(<GeometryControl />);
 
     const checkbox = screen.getByRole('checkbox', { name: /Add ¼λ counterpoise radials/i });
     fireEvent.click(checkbox);
@@ -100,7 +100,7 @@ describe('DipoleControl', () => {
       }));
     });
 
-    render(<DipoleControl />);
+    render(<GeometryControl />);
 
     const apertureInput = screen.getByRole('slider', { name: /Folded dipole conductor spacing/i });
     fireEvent.change(apertureInput, { target: { value: '0.15' } });
@@ -119,7 +119,7 @@ describe('DipoleControl', () => {
       return selector(buildMockState({ setOrientation }));
     });
 
-    render(<DipoleControl />);
+    render(<GeometryControl />);
 
     const orientInput = document.getElementById('dipole-orientation') as HTMLInputElement;
     fireEvent.change(orientInput, { target: { value: '45' } });
@@ -133,7 +133,7 @@ describe('DipoleControl', () => {
       return selector(buildMockState({ setOrientation }));
     });
 
-    render(<DipoleControl />);
+    render(<GeometryControl />);
 
     const nsButton = screen.getByRole('button', { name: 'NS' });
     fireEvent.click(nsButton);
@@ -146,7 +146,7 @@ describe('DipoleControl', () => {
       return selector(buildMockState());
     });
 
-    render(<DipoleControl />);
+    render(<GeometryControl />);
 
     // Both the Antenna section heading and the Transformer subheading
     // should render under the same control — proves the Transformer
@@ -162,7 +162,7 @@ describe('DipoleControl', () => {
       return selector(buildMockState({ setAntennaType }));
     });
 
-    render(<DipoleControl />);
+    render(<GeometryControl />);
 
     const typeSelect = screen.getByRole('combobox', { name: /Type/i });
     fireEvent.change(typeSelect, { target: { value: 'inverted-v' } });
@@ -180,7 +180,7 @@ describe('DipoleControl', () => {
       }));
     });
 
-    render(<DipoleControl />);
+    render(<GeometryControl />);
 
     const resistorInput = document.getElementById('terminating-resistor') as HTMLInputElement;
     fireEvent.change(resistorInput, { target: { value: '600' } });
@@ -197,7 +197,7 @@ describe('DipoleControl', () => {
       }));
     });
 
-    render(<DipoleControl />);
+    render(<GeometryControl />);
 
     const orientInput = document.getElementById('inverted-l-orientation') as HTMLInputElement;
     fireEvent.change(orientInput, { target: { value: '45' } });

--- a/tests/GeometryStatus.test.tsx
+++ b/tests/GeometryStatus.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { render, screen, cleanup } from '@testing-library/react';
-import { DipoleControl } from '../src/components/Panel/DipoleControl';
+import { GeometryControl } from '../src/components/Panel/GeometryControl';
 import { useAntennaStore } from '../src/store/antennaStore';
 
 describe('GeometryStatus', () => {
@@ -21,7 +21,7 @@ describe('GeometryStatus', () => {
     });
 
     // Act
-    render(<DipoleControl />);
+    render(<GeometryControl />);
 
     // Assert
     expect(screen.getByText(/Slope auto-snaps/i)).toBeTruthy();
@@ -38,7 +38,7 @@ describe('GeometryStatus', () => {
     });
 
     // Act
-    render(<DipoleControl />);
+    render(<GeometryControl />);
 
     // Assert
     expect(screen.getByText(/Geometry Clamped/i)).toBeTruthy();

--- a/tests/antennaStore.test.ts
+++ b/tests/antennaStore.test.ts
@@ -6,8 +6,8 @@ import {
   computeEffectiveSlope,
   legMultipleFromLength,
   computeOptimalVAngleDeg,
-  DIPOLE_LEFT_TAG,
-  DIPOLE_RIGHT_TAG,
+  LEFT_LEG_TAG,
+  RIGHT_LEG_TAG,
   DELTA_BASE_TAG,
   FEEDLINE_SHIELD_TAG,
   VERTICAL_WHIP_TAG,
@@ -960,7 +960,7 @@ describe("antennaStore actions", () => {
         antennaType: "inverted-v",
         vAngle: 120,
       });
-      const leftWire = wires.find((w) => w.tag === DIPOLE_LEFT_TAG)!;
+      const leftWire = wires.find((w) => w.tag === LEFT_LEG_TAG)!;
       expect(leftWire.start[2]).toBeCloseTo(5.025);
     });
 
@@ -975,7 +975,7 @@ describe("antennaStore actions", () => {
         height: 2,
         vAngle: 60,
       });
-      const leftWire = wires.find((w) => w.tag === DIPOLE_LEFT_TAG)!;
+      const leftWire = wires.find((w) => w.tag === LEFT_LEG_TAG)!;
       expect(leftWire.start[2]).toBeGreaterThanOrEqual(0.49);
       expect(leftWire.start[2]).toBeLessThanOrEqual(0.51);
     });
@@ -1086,13 +1086,13 @@ describe("antennaStore actions", () => {
       const wires = buildWires(baseState);
       expect(wires).toHaveLength(3);
       const tags = wires.map((w) => w.tag).sort((a, b) => a - b);
-      expect(tags).toEqual([DIPOLE_LEFT_TAG, DIPOLE_RIGHT_TAG, DELTA_BASE_TAG]);
+      expect(tags).toEqual([LEFT_LEG_TAG, RIGHT_LEG_TAG, DELTA_BASE_TAG]);
     });
 
     it("apex is at full mast height on all leg endpoints", () => {
       const wires = buildWires(baseState);
-      const leftLeg = wires.find((w) => w.tag === DIPOLE_LEFT_TAG)!;
-      const rightLeg = wires.find((w) => w.tag === DIPOLE_RIGHT_TAG)!;
+      const leftLeg = wires.find((w) => w.tag === LEFT_LEG_TAG)!;
+      const rightLeg = wires.find((w) => w.tag === RIGHT_LEG_TAG)!;
       // Left leg: start = leftCorner, end = apex
       expect(leftLeg.end[2]).toBeCloseTo(baseState.height);
       // Right leg: start = apex, end = rightCorner
@@ -1110,7 +1110,7 @@ describe("antennaStore actions", () => {
       const equilateralHeight = (lambda * Math.sqrt(3)) / 6;
       const sideLen = lambda / 3;
 
-      const leftLeg = wires.find((w) => w.tag === DIPOLE_LEFT_TAG)!;
+      const leftLeg = wires.find((w) => w.tag === LEFT_LEG_TAG)!;
       const base = wires.find((w) => w.tag === DELTA_BASE_TAG)!;
 
       // Base width = side length (equilateral)
@@ -1129,8 +1129,8 @@ describe("antennaStore actions", () => {
       const shortState = { ...baseState, height: 5 };
       const wires = buildWires(shortState);
 
-      const leftLeg = wires.find((w) => w.tag === DIPOLE_LEFT_TAG)!;
-      const rightLeg = wires.find((w) => w.tag === DIPOLE_RIGHT_TAG)!;
+      const leftLeg = wires.find((w) => w.tag === LEFT_LEG_TAG)!;
+      const rightLeg = wires.find((w) => w.tag === RIGHT_LEG_TAG)!;
       const base = wires.find((w) => w.tag === DELTA_BASE_TAG)!;
 
       const dist3d = (
@@ -1164,8 +1164,8 @@ describe("antennaStore actions", () => {
       };
       const input = selectSimulationInput(state as AntennaState);
 
-      const leftLeg = input.wires.find((w) => w.tag === DIPOLE_LEFT_TAG)!;
-      expect(input.excitation.wireTag).toBe(DIPOLE_LEFT_TAG);
+      const leftLeg = input.wires.find((w) => w.tag === LEFT_LEG_TAG)!;
+      expect(input.excitation.wireTag).toBe(LEFT_LEG_TAG);
       expect(input.excitation.segment).toBe(leftLeg.segments);
     });
 

--- a/tests/apexFeed.test.ts
+++ b/tests/apexFeed.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { useAntennaStore, selectSimulationInput } from '../src/store/antennaStore';
 import { buildNecCards } from '../src/physics/necCard';
 import { parseGwLine, getNecLines, expectExcitation } from './necInspect';
-import { FEED_BRIDGE_TAG, DIPOLE_LEFT_TAG, DELTA_BASE_TAG } from '../src/physics/constants';
+import { FEED_BRIDGE_TAG, LEFT_LEG_TAG, DELTA_BASE_TAG } from '../src/physics/constants';
 
 describe('Apex Feed and Geometry', () => {
   it('should generate a balanced bridge for Inverted V', () => {
@@ -75,13 +75,13 @@ describe('Apex Feed and Geometry', () => {
     const gwLines = getNecLines(deck, 'GW');
 
     // Left leg (tag 1) ends at the apex — excitation must land on its last segment.
-    const leftLegLine = gwLines.find(l => parseGwLine(l).tag === DIPOLE_LEFT_TAG);
+    const leftLegLine = gwLines.find(l => parseGwLine(l).tag === LEFT_LEG_TAG);
     expect(leftLegLine).toBeDefined();
     const leftLeg = parseGwLine(leftLegLine!);
 
-    expectExcitation(deck, DIPOLE_LEFT_TAG, leftLeg.segments);
+    expectExcitation(deck, LEFT_LEG_TAG, leftLeg.segments);
 
-    // Base wire must use DELTA_BASE_TAG (tag 6), not DIPOLE_RIGHT_TAG (tag 2).
+    // Base wire must use DELTA_BASE_TAG (tag 6), not RIGHT_LEG_TAG (tag 2).
     const baseLine = gwLines.find(l => parseGwLine(l).tag === DELTA_BASE_TAG);
     expect(baseLine).toBeDefined();
   });

--- a/tests/deltaLoopTermination.test.ts
+++ b/tests/deltaLoopTermination.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { useAntennaStore, selectSimulationInput } from '../src/store/antennaStore';
 import { buildNecCards } from '../src/physics/necCard';
 import { getNecLines, expectExcitation } from './necInspect';
-import { DIPOLE_LEFT_TAG } from '../src/physics/constants';
+import { LEFT_LEG_TAG } from '../src/physics/constants';
 
 function setupDeltaLoop(terminatingResistor?: number) {
   const store = useAntennaStore.getState();
@@ -38,11 +38,11 @@ describe('Delta Loop termination (removed)', () => {
     expect(useAntennaStore.getState().terminatingResistor).toBe(0);
   });
 
-  it('excitation remains on left leg (DIPOLE_LEFT_TAG) last segment', () => {
+  it('excitation remains on left leg (LEFT_LEG_TAG) last segment', () => {
     setupDeltaLoop(0);
     const input = selectSimulationInput(useAntennaStore.getState());
-    const leftLeg = input.wires.find((w) => w.tag === DIPOLE_LEFT_TAG)!;
-    expectExcitation(buildNecCards(input), DIPOLE_LEFT_TAG, leftLeg.segments);
+    const leftLeg = input.wires.find((w) => w.tag === LEFT_LEG_TAG)!;
+    expectExcitation(buildNecCards(input), LEFT_LEG_TAG, leftLeg.segments);
   });
 
   it('no NT card emitted for delta-loop termination', () => {

--- a/tests/foldedDipole.test.ts
+++ b/tests/foldedDipole.test.ts
@@ -3,8 +3,8 @@ import {
   useAntennaStore,
   buildWires,
   selectSimulationInput,
-  DIPOLE_LEFT_TAG,
-  DIPOLE_RIGHT_TAG,
+  LEFT_LEG_TAG,
+  RIGHT_LEG_TAG,
   FEED_BRIDGE_TAG,
   FOLDED_DIPOLE_OPPOSITE_TAG,
   FOLDED_DIPOLE_CONNECTOR_TAG,
@@ -16,7 +16,7 @@ import { TERMINATED_DELTA_CENTRE_GAP_M, FEEDLINE_SHIELD_TAG } from '../src/physi
 const FREQ = 7.1;
 const APERTURE = 0.5;
 
-function foldedDipoleWires(overrides: Partial<Parameters<typeof buildWires>[0]> = {}) {
+function foldedAntennaWires(overrides: Partial<Parameters<typeof buildWires>[0]> = {}) {
   return buildWires({
     antennaType: 'folded-dipole',
     length: 20,
@@ -35,11 +35,11 @@ function foldedDipoleWires(overrides: Partial<Parameters<typeof buildWires>[0]> 
 
 describe('folded dipole geometry', () => {
   it('emits the seven expected wires with the correct tags', () => {
-    const wires = foldedDipoleWires();
+    const wires = foldedAntennaWires();
     expect(wires).toHaveLength(7);
     const tags = wires.map((w) => w.tag);
-    expect(tags).toContain(DIPOLE_LEFT_TAG);
-    expect(tags).toContain(DIPOLE_RIGHT_TAG);
+    expect(tags).toContain(LEFT_LEG_TAG);
+    expect(tags).toContain(RIGHT_LEG_TAG);
     expect(tags).toContain(FEED_BRIDGE_TAG);
     // Top conductor split into 2 halves — both share FOLDED_DIPOLE_OPPOSITE_TAG.
     expect(tags.filter((t) => t === FOLDED_DIPOLE_OPPOSITE_TAG)).toHaveLength(2);
@@ -48,9 +48,9 @@ describe('folded dipole geometry', () => {
   });
 
   it('places the fed (bottom) conductor at height and the opposite (top) conductor at height + aperture', () => {
-    const wires = foldedDipoleWires({ height: 12 });
+    const wires = foldedAntennaWires({ height: 12 });
     // Fed conductor wires (left half, bridge, right half) must be at z = 12.
-    const fedTags = new Set([DIPOLE_LEFT_TAG, DIPOLE_RIGHT_TAG, FEED_BRIDGE_TAG]);
+    const fedTags = new Set([LEFT_LEG_TAG, RIGHT_LEG_TAG, FEED_BRIDGE_TAG]);
     for (const w of wires.filter((w) => fedTags.has(w.tag))) {
       expect(w.start[2]).toBeCloseTo(12, 9);
       expect(w.end[2]).toBeCloseTo(12, 9);
@@ -72,8 +72,8 @@ describe('folded dipole geometry', () => {
   });
 
   it('separates the two conductors vertically by exactly the aperture', () => {
-    const wires = foldedDipoleWires();
-    const fed = wires.find((w) => w.tag === DIPOLE_LEFT_TAG)!;
+    const wires = foldedAntennaWires();
+    const fed = wires.find((w) => w.tag === LEFT_LEG_TAG)!;
     const opp = wires.find((w) => w.tag === FOLDED_DIPOLE_OPPOSITE_TAG)!;
     // Vertical separation — top conductor is aperture above the bottom conductor.
     expect(opp.start[2] - fed.start[2]).toBeCloseTo(APERTURE, 9);
@@ -83,7 +83,7 @@ describe('folded dipole geometry', () => {
   });
 
   it('unterminated: top conductor halves share a common junction at topCenter (no gap)', () => {
-    const wires = foldedDipoleWires({ height: 12, terminatingResistor: 0 });
+    const wires = foldedAntennaWires({ height: 12, terminatingResistor: 0 });
     const oppWires = wires.filter((w) => w.tag === FOLDED_DIPOLE_OPPOSITE_TAG);
     expect(oppWires).toHaveLength(2);
     // topCenter = (0, 0, height + aperture) for any orientation.
@@ -100,7 +100,7 @@ describe('folded dipole geometry', () => {
   });
 
   it('terminated: top conductor halves have a gap of TERMINATED_DELTA_CENTRE_GAP_M at the centre', () => {
-    const wires = foldedDipoleWires({ height: 12, terminatingResistor: 600 });
+    const wires = foldedAntennaWires({ height: 12, terminatingResistor: 600 });
     const oppWires = wires.filter((w) => w.tag === FOLDED_DIPOLE_OPPOSITE_TAG);
     expect(oppWires).toHaveLength(2);
     const leftEnd = oppWires[0]!.end;    // topCenterLeft
@@ -118,8 +118,8 @@ describe('folded dipole geometry', () => {
   });
 
   it('forms a closed loop — connector endpoints coincide with both conductors', () => {
-    const wires = foldedDipoleWires();
-    const left = wires.find((w) => w.tag === DIPOLE_LEFT_TAG)!;
+    const wires = foldedAntennaWires();
+    const left = wires.find((w) => w.tag === LEFT_LEG_TAG)!;
     const opp = wires.find((w) => w.tag === FOLDED_DIPOLE_OPPOSITE_TAG)!;
     const connectors = wires.filter((w) => w.tag === FOLDED_DIPOLE_CONNECTOR_TAG);
     // One connector must touch the fed conductor's left end and the opposite

--- a/tests/terminatedDeltaGeometry.test.ts
+++ b/tests/terminatedDeltaGeometry.test.ts
@@ -15,8 +15,8 @@ import {
   expectNoGroundTouchingWires,
 } from './necInspect';
 import {
-  DIPOLE_LEFT_TAG,
-  DIPOLE_RIGHT_TAG,
+  LEFT_LEG_TAG,
+  RIGHT_LEG_TAG,
   FEED_BRIDGE_TAG,
   FEEDLINE_SHIELD_TAG,
   SLOPING_V_MIN_TIP_Z_M,
@@ -181,8 +181,8 @@ describe('Terminated Delta — base geometry', () => {
   it('emits two top legs and two half-base wires (no continuous base)', () => {
     setupTerminatedDelta(0);
     const input = selectSimulationInput(useAntennaStore.getState());
-    const leftLeg = input.wires.find((w) => w.tag === DIPOLE_LEFT_TAG);
-    const rightLeg = input.wires.find((w) => w.tag === DIPOLE_RIGHT_TAG);
+    const leftLeg = input.wires.find((w) => w.tag === LEFT_LEG_TAG);
+    const rightLeg = input.wires.find((w) => w.tag === RIGHT_LEG_TAG);
     const leftHalfBase = input.wires.find((w) => w.tag === TERMINATED_DELTA_LEFT_BASE_TAG);
     const rightHalfBase = input.wires.find((w) => w.tag === TERMINATED_DELTA_RIGHT_BASE_TAG);
     expect(leftLeg).toBeDefined();
@@ -194,14 +194,14 @@ describe('Terminated Delta — base geometry', () => {
   it('left leg ends at the apex (.end is at the mast height)', () => {
     setupTerminatedDelta(0);
     const input = selectSimulationInput(useAntennaStore.getState());
-    const leftLeg = input.wires.find((w) => w.tag === DIPOLE_LEFT_TAG)!;
+    const leftLeg = input.wires.find((w) => w.tag === LEFT_LEG_TAG)!;
     expect(leftLeg.end[2]).toBeCloseTo(15, 6);
   });
 
   it('right leg starts at the apex (.start is at the mast height)', () => {
     setupTerminatedDelta(0);
     const input = selectSimulationInput(useAntennaStore.getState());
-    const rightLeg = input.wires.find((w) => w.tag === DIPOLE_RIGHT_TAG)!;
+    const rightLeg = input.wires.find((w) => w.tag === RIGHT_LEG_TAG)!;
     expect(rightLeg.start[2]).toBeCloseTo(15, 6);
   });
 
@@ -246,8 +246,8 @@ describe('Terminated Delta — base geometry', () => {
   it('the outer ends of the half-base wires coincide with the leg corners', () => {
     setupTerminatedDelta(0);
     const input = selectSimulationInput(useAntennaStore.getState());
-    const leftLeg = input.wires.find((w) => w.tag === DIPOLE_LEFT_TAG)!;
-    const rightLeg = input.wires.find((w) => w.tag === DIPOLE_RIGHT_TAG)!;
+    const leftLeg = input.wires.find((w) => w.tag === LEFT_LEG_TAG)!;
+    const rightLeg = input.wires.find((w) => w.tag === RIGHT_LEG_TAG)!;
     const leftHalfBase = input.wires.find((w) => w.tag === TERMINATED_DELTA_LEFT_BASE_TAG)!;
     const rightHalfBase = input.wires.find((w) => w.tag === TERMINATED_DELTA_RIGHT_BASE_TAG)!;
     // Left leg goes leftCorner → apex, so .start is the left corner.
@@ -269,7 +269,7 @@ describe('Terminated Delta — base geometry', () => {
     store.setLength(42);
     store.setHeight(30); // tall enough for equilateral height ~12.12 m
     const input = selectSimulationInput(useAntennaStore.getState());
-    const leftLeg = input.wires.find((w) => w.tag === DIPOLE_LEFT_TAG)!;
+    const leftLeg = input.wires.find((w) => w.tag === LEFT_LEG_TAG)!;
     const legLen = Math.hypot(
       leftLeg.end[0] - leftLeg.start[0],
       leftLeg.end[1] - leftLeg.start[1],
@@ -285,7 +285,7 @@ describe('Terminated Delta — base geometry', () => {
     store.setLength(42);
     store.setHeight(5); // less than equilateral height (~12.12 m)
     const input = selectSimulationInput(useAntennaStore.getState());
-    const leftLeg = input.wires.find((w) => w.tag === DIPOLE_LEFT_TAG)!;
+    const leftLeg = input.wires.find((w) => w.tag === LEFT_LEG_TAG)!;
     const leftHalfBase = input.wires.find((w) => w.tag === TERMINATED_DELTA_LEFT_BASE_TAG)!;
     const rightHalfBase = input.wires.find((w) => w.tag === TERMINATED_DELTA_RIGHT_BASE_TAG)!;
     const legLen = Math.hypot(
@@ -399,8 +399,8 @@ describe('Terminated Delta — terminated (T2FD-style bridge resistor)', () => {
     const input = selectSimulationInput(useAntennaStore.getState());
     const radiatingLoads = (input.loads ?? []).filter(
       (l) =>
-        l.wireTag === DIPOLE_LEFT_TAG ||
-        l.wireTag === DIPOLE_RIGHT_TAG ||
+        l.wireTag === LEFT_LEG_TAG ||
+        l.wireTag === RIGHT_LEG_TAG ||
         l.wireTag === TERMINATED_DELTA_LEFT_BASE_TAG ||
         l.wireTag === TERMINATED_DELTA_RIGHT_BASE_TAG,
     );
@@ -442,15 +442,15 @@ describe('Terminated Delta — excitation', () => {
   it('unterminated: excitation is on the last segment of the left leg (apex)', () => {
     setupTerminatedDelta(0);
     const input = selectSimulationInput(useAntennaStore.getState());
-    const leftLeg = input.wires.find((w) => w.tag === DIPOLE_LEFT_TAG)!;
-    expectExcitation(buildNecCards(input), DIPOLE_LEFT_TAG, leftLeg.segments);
+    const leftLeg = input.wires.find((w) => w.tag === LEFT_LEG_TAG)!;
+    expectExcitation(buildNecCards(input), LEFT_LEG_TAG, leftLeg.segments);
   });
 
   it('terminated: excitation is still on the last segment of the left leg (apex)', () => {
     setupTerminatedDelta(600);
     const input = selectSimulationInput(useAntennaStore.getState());
-    const leftLeg = input.wires.find((w) => w.tag === DIPOLE_LEFT_TAG)!;
-    expectExcitation(buildNecCards(input), DIPOLE_LEFT_TAG, leftLeg.segments);
+    const leftLeg = input.wires.find((w) => w.tag === LEFT_LEG_TAG)!;
+    expectExcitation(buildNecCards(input), LEFT_LEG_TAG, leftLeg.segments);
   });
 });
 

--- a/tests/useAntennaGeometry.test.tsx
+++ b/tests/useAntennaGeometry.test.tsx
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook } from '@testing-library/react';
-import { useDipoleGeometry } from '../src/components/Scene/useDipoleGeometry';
+import { useAntennaGeometry } from '../src/components/Scene/useAntennaGeometry';
 import { useAntennaStore } from '../src/store/antennaStore';
 
-describe('useDipoleGeometry', () => {
+describe('useAntennaGeometry', () => {
   beforeEach(() => {
     useAntennaStore.setState({
       vAngle: 120,
@@ -17,7 +17,7 @@ describe('useDipoleGeometry', () => {
   });
 
   it('generates geometry for a basic dipole', () => {
-    const { result } = renderHook(() => useDipoleGeometry({
+    const { result } = renderHook(() => useAntennaGeometry({
       type: 'dipole',
       length: 10,
       height: 5,
@@ -31,14 +31,14 @@ describe('useDipoleGeometry', () => {
     }));
 
     expect(result.current.rendered.length).toBeGreaterThan(0);
-    expect(result.current.rendered[0].tag).toBe(1); // DIPOLE_TAG
+    expect(result.current.rendered[0].tag).toBe(1); // MAIN_WIRE_TAG
     expect(result.current.shield).toBeUndefined();
     expect(result.current.feedpoint).toBeDefined();
     expect(result.current.terminatedDeltaSplit).toBeNull();
   });
 
   it('generates geometry for a terminated delta', () => {
-    const { result } = renderHook(() => useDipoleGeometry({
+    const { result } = renderHook(() => useAntennaGeometry({
       type: 'terminated-delta',
       length: 20,
       height: 10,
@@ -57,7 +57,7 @@ describe('useDipoleGeometry', () => {
   });
 
   it('handles feedline shield and bridge', () => {
-    const { result } = renderHook(() => useDipoleGeometry({
+    const { result } = renderHook(() => useAntennaGeometry({
       type: 'dipole',
       length: 10,
       height: 5,
@@ -76,7 +76,7 @@ describe('useDipoleGeometry', () => {
   });
 
   it('generates geometry for a vertical whip', () => {
-    const { result } = renderHook(() => useDipoleGeometry({
+    const { result } = renderHook(() => useAntennaGeometry({
       type: 'vertical-whip',
       length: 5,
       height: 0,
@@ -95,7 +95,7 @@ describe('useDipoleGeometry', () => {
   });
 
   it('generates geometry for a delta loop', () => {
-    const { result } = renderHook(() => useDipoleGeometry({
+    const { result } = renderHook(() => useAntennaGeometry({
       type: 'delta-loop',
       length: 20,
       height: 10,

--- a/tests/vBeamTermination.test.ts
+++ b/tests/vBeamTermination.test.ts
@@ -8,8 +8,8 @@ import {
   expectExcitation,
 } from './necInspect';
 import {
-  DIPOLE_LEFT_TAG,
-  DIPOLE_RIGHT_TAG,
+  LEFT_LEG_TAG,
+  RIGHT_LEG_TAG,
   FEED_BRIDGE_TAG,
   SLOPING_V_LEFT_STUB_TAG,
   SLOPING_V_RIGHT_STUB_TAG,
@@ -74,8 +74,8 @@ describe('V-antenna termination topology', () => {
     // With graded segmentation each leg is multiple sub-wires sharing a tag:
     //   LEFT  leg is emitted tip → apex (first sub-wire's `.start` is the tip)
     //   RIGHT leg is emitted apex → tip (last sub-wire's `.end` is the tip)
-    const leftLegWires  = input.wires.filter((w) => w.tag === DIPOLE_LEFT_TAG);
-    const rightLegWires = input.wires.filter((w) => w.tag === DIPOLE_RIGHT_TAG);
+    const leftLegWires  = input.wires.filter((w) => w.tag === LEFT_LEG_TAG);
+    const rightLegWires = input.wires.filter((w) => w.tag === RIGHT_LEG_TAG);
     const leftLegTip  = leftLegWires[0]!.start;
     const rightLegTip = rightLegWires[rightLegWires.length - 1]!.end;
     const leftStub  = input.wires.find((w) => w.tag === SLOPING_V_LEFT_STUB_TAG)!;
@@ -134,7 +134,7 @@ describe('V-antenna termination topology', () => {
     setupSlopingV(800);
     const input = selectSimulationInput(useAntennaStore.getState());
     const legLoads = (input.loads ?? []).filter(
-      (l) => l.wireTag === DIPOLE_LEFT_TAG || l.wireTag === DIPOLE_RIGHT_TAG,
+      (l) => l.wireTag === LEFT_LEG_TAG || l.wireTag === RIGHT_LEG_TAG,
     );
     expect(legLoads).toHaveLength(0);
   });

--- a/tests/vSegmentation.test.ts
+++ b/tests/vSegmentation.test.ts
@@ -6,7 +6,7 @@ import {
   MIN_SEGS_PER_LEG,
   MAX_SEGS_PER_LEG,
 } from '../src/store/antennaGeometry';
-import { wavelengthMeters, FEED_BRIDGE_LENGTH_M, FEED_BRIDGE_TAG, DIPOLE_LEFT_TAG, DIPOLE_RIGHT_TAG } from '../src/physics/constants';
+import { wavelengthMeters, FEED_BRIDGE_LENGTH_M, FEED_BRIDGE_TAG, LEFT_LEG_TAG, RIGHT_LEG_TAG } from '../src/physics/constants';
 import type { Wire } from '../src/physics/types';
 
 const BASE_PARAMS = {
@@ -24,7 +24,7 @@ const V_PARAMS = { ...BASE_PARAMS, vAngle: 90, legSlope: 0 };
  * prefix segment plus one multi-segment Wire for the uniform tail; the
  * effective "segments per leg" is the sum across all of them.
  */
-function legSegs(wires: Wire[], tag: number = DIPOLE_LEFT_TAG): number {
+function legSegs(wires: Wire[], tag: number = LEFT_LEG_TAG): number {
   return wires.filter((w) => w.tag === tag).reduce((sum, w) => sum + w.segments, 0);
 }
 
@@ -45,7 +45,7 @@ describe('V-antenna wavelength-based segmentation', () => {
       const total = 2 * lambda + FEED_BRIDGE_LENGTH_M;
       const wires = buildSlopingVWires({ ...V_PARAMS, frequency: freq, length: total, legSlope: 15 });
 
-      expect(legSegs(wires, DIPOLE_LEFT_TAG)).toBe(legSegs(wires, DIPOLE_RIGHT_TAG));
+      expect(legSegs(wires, LEFT_LEG_TAG)).toBe(legSegs(wires, RIGHT_LEG_TAG));
     });
   });
 
@@ -174,8 +174,8 @@ describe('V-antenna wavelength-based segmentation', () => {
       const total = 20 * lambda + FEED_BRIDGE_LENGTH_M; // 10λ per leg
       const wires = buildSlopingVWires({ ...V_PARAMS, frequency: freq, length: total, legSlope: 10 });
 
-      for (const tag of [DIPOLE_LEFT_TAG, DIPOLE_RIGHT_TAG] as const) {
-        const segs = apexToTipSegLengths(wires, tag, tag === DIPOLE_LEFT_TAG ? 'left' : 'right');
+      for (const tag of [LEFT_LEG_TAG, RIGHT_LEG_TAG] as const) {
+        const segs = apexToTipSegLengths(wires, tag, tag === LEFT_LEG_TAG ? 'left' : 'right');
         // First segment (closest to the apex source) should equal the bridge.
         expect(segs[0]).toBeCloseTo(FEED_BRIDGE_LENGTH_M, 9);
       }
@@ -187,8 +187,8 @@ describe('V-antenna wavelength-based segmentation', () => {
       const total = 20 * lambda + FEED_BRIDGE_LENGTH_M; // 10λ per leg
       const wires = buildSlopingVWires({ ...V_PARAMS, frequency: freq, length: total, legSlope: 10 });
 
-      for (const tag of [DIPOLE_LEFT_TAG, DIPOLE_RIGHT_TAG] as const) {
-        const segs = apexToTipSegLengths(wires, tag, tag === DIPOLE_LEFT_TAG ? 'left' : 'right');
+      for (const tag of [LEFT_LEG_TAG, RIGHT_LEG_TAG] as const) {
+        const segs = apexToTipSegLengths(wires, tag, tag === LEFT_LEG_TAG ? 'left' : 'right');
         for (let i = 1; i < segs.length; i++) {
           const a = segs[i - 1]!;
           const b = segs[i]!;
@@ -203,7 +203,7 @@ describe('V-antenna wavelength-based segmentation', () => {
       const lambda = wavelengthMeters(freq);
       const total = 20 * lambda + FEED_BRIDGE_LENGTH_M; // 10λ per leg
       const wires = buildSlopingVWires({ ...V_PARAMS, frequency: freq, length: total, legSlope: 10 });
-      const segs = apexToTipSegLengths(wires, DIPOLE_RIGHT_TAG, 'right');
+      const segs = apexToTipSegLengths(wires, RIGHT_LEG_TAG, 'right');
 
       // The first few segments should monotonically increase until plateauing
       // at the uniform tail length, which is bounded by λ/SEGS_PER_WAVELENGTH.


### PR DESCRIPTION
This pull request tidies up the backend code by resolving misleading uses of the term "dipole". Previously, "dipole" terms were used to tag, render, and control geometry elements of various antennas like the Delta Loop, Sloping V, etc., causing conceptual confusion.
- Renamed `DIPOLE_LEFT_TAG` to `LEFT_LEG_TAG` and `DIPOLE_RIGHT_TAG` to `RIGHT_LEG_TAG`.
- Renamed `DIPOLE_TAG` to `MAIN_WIRE_TAG`.
- Renamed React components: `DipoleWire` to `AntennaWire` and `DipoleControl` to `GeometryControl`.
- Renamed Custom hook: `useDipoleGeometry` to `useAntennaGeometry`.
- Updated test files correspondingly.
- Passed linting and unit test suites successfully.

---
*PR created automatically by Jules for task [7522458500643227507](https://jules.google.com/task/7522458500643227507) started by @2fst4u*