### PR TITLE
📚 Archivist: Fix Delta Loop geometry documentation drift

### DIFF
--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -64,3 +64,7 @@
 ## 2026-06-08 - Vertical Whip Height Drift
 **Learning:** The documentation assumed the vertical whip antenna defaults to a physically typical ground-mounted height (0m). However, the engine (`src/store/antennaStore.ts`) was enforcing a generic default height (`INITIAL_HEIGHT` = 8m) for the vertical whip, incorrectly treating it as an elevated monopole rather than a ground-mounted radiator. The application logic drifted from the correct, documented physical intention.
 **Action:** The documentation was kept as-is, and the application logic in `src/store/antennaStore.ts` was updated to explicitly default the vertical whip to a height of 0m when selected.
+
+## 2026-06-09 - Delta Loop Feedpoint Topology Drift
+**Learning:** The documentation for the Delta Loop claimed it was fed at the center of the bottom horizontal wire (or 1/4 λ from the apex for vertical polarization) and could be configured apex-down. However, the codebase (`src/store/antennaGeometry.ts`) strictly constructs the delta loop as apex-up and apex-fed (excitation on the last segment of the left leg, nearest the apex). The documentation drifted from the implemented physics model.
+**Action:** The documentation in `docs/antenna-model-spec.md` and `docs/antenna-spec.md` was updated to correctly reflect the apex-up, apex-fed geometry, removing inaccurate claims about base-feeding and vertical polarization.

--- a/docs/antenna-model-spec.md
+++ b/docs/antenna-model-spec.md
@@ -57,10 +57,10 @@ We use the standard NEC-2 Cartesian coordinate system:
 
 - **Structure**: A triangular loop of wire.
 - **Length**: The total perimeter of the loop.
-- **Configuration**: Apex-up or Apex-down.
-- **Height**: Typically the height of the highest point (apex or top wire).
-- **Feedpoint**: Center of the bottom wire (for horizontal polarization) or $1/4 \lambda$ from the apex (for vertical polarization).
-- **Balanced**: Yes (if fed at center of a side).
+- **Configuration**: Apex-up.
+- **Height**: Typically the height of the highest point (apex).
+- **Feedpoint**: The apex.
+- **Balanced**: Yes.
 
 ### 2.5 Terminated Delta
 

--- a/docs/antenna-spec.md
+++ b/docs/antenna-spec.md
@@ -153,9 +153,9 @@ This document defines the physical and mathematical model for all antenna types 
 
 ### 4.2 Feedpoint Definition
 
-- **NEC Excitation:** Center of the bottom horizontal wire (Tag 2).
-- **Segment:** Center segment of Tag 2.
-- **Feed Type:** Single-segment voltage source.
+- **NEC Excitation:** Last segment of the left leg (Tag 1), nearest the apex.
+- **Segment:** Segment `segmentsPerLeg` of Tag 1.
+- **Feed Type:** Single-segment voltage source (or split bridge if feedline connected).
 - **Feedline Support:** Supported (Radiating shield + NEC `TL` card; feedpoint always at apex, offset is not applicable).
 
 ### 4.3 Termination Definition
@@ -171,7 +171,7 @@ This document defines the physical and mathematical model for all antenna types 
 
 - **Density:** 20 segments per $\lambda$.
 - **Minimum:** 9 segments per side.
-- **Alignment:** Bottom wire should have an **odd** number of segments for center feed.
+- **Alignment:** Excitation is placed at the apex, so segment count alignment on the bottom wire is not strictly constrained by feedpoint centering.
 
 ### 4.6 Glossary
 


### PR DESCRIPTION
💡 Problem: The documentation (`docs/antenna-model-spec.md` and `docs/antenna-spec.md`) falsely claimed the Delta Loop antenna was base-fed (or fed 1/4 λ from the apex) and supported an apex-down configuration.
🎯 Fix: Updated the specs to correctly describe the delta loop strictly as an apex-up, apex-fed isosceles triangle, aligning the documentation perfectly with the physics engine construction logic (`src/store/antennaGeometry.ts`). Logged this critical drift into the archivist journal.
🧪 Verification: Confirmed against the `buildDeltaLoopWires` geometry function. Ran `npm run lint` and `npm run test` successfully.
🔎 Scope: Only markdown documentation was changed.

---
*PR created automatically by Jules for task [17478765482763640119](https://jules.google.com/task/17478765482763640119) started by @2fst4u*