### PR TITLE
🔭 Scout: Semantic figure tags for colormap legend

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -34,3 +34,4 @@
 ## 2024-05-28 - React Three Fiber `<Canvas>` SEO
 **Learning:** The R3F `<Canvas>` component renders an opaque WebGL context that is inherently invisible to search engines and screen readers.
 **Action:** Apply `role="img"` and a descriptive `aria-label` directly to the `<Canvas>` element to provide semantic context.
+## 2026-06-09 - Semantics for Colormap Legend\n**Learning:** Using `<figure>` and `<figcaption>` to group related content, instead of generic `<div>`s, adds semantic value without fundamentally modifying the rendering logic or user interaction. Testing confirmed this structural change integrates cleanly with existing styles and React components.\n**Action:** Look for generic containers acting as labels or grouped elements (like legends) and upgrade them to HTML5 semantic structural tags.

--- a/src/components/Scene/ColormapLegend.tsx
+++ b/src/components/Scene/ColormapLegend.tsx
@@ -18,15 +18,16 @@ export function ColormapLegend({ result }: Props) {
   const gradient = getColormapCssGradient(colormap);
 
   return (
-    <div className="colormap-legend">
-      <div className="colormap-legend-labels">
+    /* SEO: Upgrade generic div wrapper to a semantic figure tag, with figcaption for clear labeling */
+    <figure className="colormap-legend" aria-label="Gain colormap legend">
+      <figcaption className="colormap-legend-labels">
         <span>{colorMaxDb.toFixed(1)} dBi</span>
         <span>{minDb.toFixed(1)} dBi</span>
-      </div>
+      </figcaption>
       <div
         className="colormap-legend-gradient"
         style={{ background: gradient }}
       />
-    </div>
+    </figure>
   );
 }


### PR DESCRIPTION
💡 What: Upgraded the generic `<div>` wrapper around the colormap legend to a semantic `<figure>` tag with a `<figcaption>` and an `aria-label`.
🎯 Why: Enhances document outlining and provides clearer structural context for search engines and screen readers when crawling the application.
📊 Value: Improves semantic structure and accessibility without altering visual layout or behavior.
🔬 Measurement: Verify the presence of `<figure class="colormap-legend">` and `<figcaption>` in the rendered DOM output.

---
*PR created automatically by Jules for task [15049728203626399954](https://jules.google.com/task/15049728203626399954) started by @2fst4u*