### PR TITLE
🧹 [code health] Extract duplicated Delta Loop geometry math

### DIFF
--- a/.jules/sweep.md
+++ b/.jules/sweep.md
@@ -10,3 +10,7 @@
 ## 2024-06-07 - Extracted duplicated cleanZero function
 **Learning:** Ensure all duplicated instances of a function are removed when extracting it to a central utility file.
 **Action:** Replaced all 4 local declarations of cleanZero with an import from the new math utility file.
+
+## 2024-06-09 - Extract duplicated Delta Loop geometry math
+**Learning:** We extracted duplicated identical geometry logic from `buildDeltaLoopWires` and `buildTerminatedDeltaWires` into a single helper function `calcDeltaLoopGeometry` in `src/store/antennaGeometry.ts`, destructuring only the required return values.
+**Action:** Created `calcDeltaLoopGeometry` utility function, refactored both callers to use the utility, verified safety with code coverage tests, lint, and build.

--- a/src/store/antennaGeometry.ts
+++ b/src/store/antennaGeometry.ts
@@ -376,6 +376,25 @@ export interface DeltaLoopWiresParams {
   feedlineShield?: FeedlineShield | null;
 }
 
+function calcDeltaLoopGeometry(perimeter: number, h: number) {
+  // Maximum available triangle height given the mast height.
+  // Identical to the delta loop's geometry math so that the two
+  // antennas occupy the same physical envelope for the same length.
+  const equilateralHeight = (perimeter * Math.sqrt(3)) / 6;
+  const maxAvailable = Math.max(0, h - SLOPING_V_MIN_TIP_Z_M);
+  const triHeight = Math.min(equilateralHeight, maxAvailable);
+
+  const bottomZ = h - triHeight;
+
+  // Isosceles triangle with fixed perimeter P and height t:
+  //   leg  = t²/P + P/4
+  //   base = P − 2·leg  →  halfBase = P/4 − t²/P
+  const legLength = (triHeight * triHeight) / perimeter + perimeter / 4;
+  const halfBase = perimeter / 4 - (triHeight * triHeight) / perimeter;
+
+  return { triHeight, bottomZ, legLength, halfBase };
+}
+
 /**
  * Builds the wires for a Delta Loop antenna (apex-up, apex-fed).
  *
@@ -396,18 +415,7 @@ export function buildDeltaLoopWires(params: DeltaLoopWiresParams): Wire[] {
   const h = params.height;
   const [dx, dy] = orientationVector(params.orientation);
 
-  // Maximum available triangle height given the mast height.
-  const equilateralHeight = (perimeter * Math.sqrt(3)) / 6;
-  const maxAvailable = Math.max(0, h - SLOPING_V_MIN_TIP_Z_M);
-  const triHeight = Math.min(equilateralHeight, maxAvailable);
-
-  const bottomZ = h - triHeight;
-
-  // Isosceles triangle with fixed perimeter P and height t:
-  //   leg  = t²/P + P/4
-  //   base = P − 2·leg  →  halfBase = P/4 − t²/P
-  const legLength = (triHeight * triHeight) / perimeter + perimeter / 4;
-  const halfBase = perimeter / 4 - (triHeight * triHeight) / perimeter;
+  const { bottomZ, legLength, halfBase } = calcDeltaLoopGeometry(perimeter, h);
 
   const bridgeHalf = FEED_BRIDGE_LENGTH_M / 2;
   const apex: [number, number, number] = [0, 0, h];
@@ -528,20 +536,7 @@ export function buildTerminatedDeltaWires(params: TerminatedDeltaWiresParams): W
   const h = params.height;
   const [dx, dy] = orientationVector(params.orientation);
 
-  // Maximum available triangle height given the mast height.
-  // Identical to the delta loop's geometry math so that the two
-  // antennas occupy the same physical envelope for the same length.
-  const equilateralHeight = (perimeter * Math.sqrt(3)) / 6;
-  const maxAvailable = Math.max(0, h - SLOPING_V_MIN_TIP_Z_M);
-  const triHeight = Math.min(equilateralHeight, maxAvailable);
-
-  const bottomZ = h - triHeight;
-
-  // Isosceles triangle with fixed perimeter P and height t:
-  //   leg  = t²/P + P/4
-  //   base = P − 2·leg  →  halfBase = P/4 − t²/P
-  const legLength = (triHeight * triHeight) / perimeter + perimeter / 4;
-  const halfBase = perimeter / 4 - (triHeight * triHeight) / perimeter;
+  const { bottomZ, legLength, halfBase } = calcDeltaLoopGeometry(perimeter, h);
 
   const bridgeHalf = FEED_BRIDGE_LENGTH_M / 2;
   const apex: [number, number, number] = [0, 0, h];


### PR DESCRIPTION
🎯 **What:** Extracted duplicated identical geometry math into a single helper function `calcDeltaLoopGeometry` within `src/store/antennaGeometry.ts`.
💡 **Why:** Both `buildDeltaLoopWires` and `buildTerminatedDeltaWires` had 10-15 lines of exactly duplicated isosceles geometry calculations. This change improves codebase maintainability, readability, and adheres to DRY principles.
✅ **Verification:** Verified logic using existing `tests/antennaGeometry.test.ts`, ran full test suite (`npm run test`), lint (`npm run lint`), and build checks. No loss of functionality. 
✨ **Result:** A more maintainable and DRY implementation for Delta Loop antennas.

---
*PR created automatically by Jules for task [5234154607350602624](https://jules.google.com/task/5234154607350602624) started by @2fst4u*