### PR TITLE
🧪 Spec: Add tests for GeometryStatus and TransformerControl

### DIFF
--- a/tests/GeometryStatus.test.tsx
+++ b/tests/GeometryStatus.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { render, screen, cleanup } from '@testing-library/react';
-import { GeometryControl } from '../src/components/Panel/GeometryControl';
+import { GeometryStatus } from '../src/components/Panel/GeometryStatus';
 import { useAntennaStore } from '../src/store/antennaStore';
 
 describe('GeometryStatus', () => {
@@ -12,7 +12,6 @@ describe('GeometryStatus', () => {
   });
 
   it('renders correctly for sloping-v', () => {
-    // Arrange
     useAntennaStore.setState({
       antennaType: 'sloping-v',
       length: 20,
@@ -20,28 +19,61 @@ describe('GeometryStatus', () => {
       units: 'metric',
     });
 
-    // Act
-    render(<GeometryControl />);
-
-    // Assert
+    render(<GeometryStatus />);
     expect(screen.getByText(/Slope auto-snaps/i)).toBeTruthy();
   });
 
   it('renders clamping message for inverted-v when clamped', () => {
-    // Arrange
     useAntennaStore.setState({
       antennaType: 'inverted-v',
       length: 40,
-      height: 5, // very low height, long legs -> will clamp
-      vAngle: 60, // requires steep slope
+      height: 5,
+      vAngle: 60,
       units: 'metric',
     });
 
-    // Act
-    render(<GeometryControl />);
-
-    // Assert
+    render(<GeometryStatus />);
     expect(screen.getByText(/Geometry Clamped/i)).toBeTruthy();
     expect(screen.getByText(/Slope reduced to keep tips/i)).toBeTruthy();
+  });
+
+  it('renders normal message for inverted-v when not clamped', () => {
+    useAntennaStore.setState({
+      antennaType: 'inverted-v',
+      length: 10,
+      height: 20,
+      vAngle: 120,
+      units: 'metric',
+    });
+
+    render(<GeometryStatus />);
+    expect(screen.getByText(/Geometry Status/i)).toBeTruthy();
+    expect(screen.queryByText(/Geometry Clamped/i)).toBeNull();
+  });
+
+  it('renders nothing for unsupported antenna types', () => {
+    useAntennaStore.setState({
+      antennaType: 'dipole',
+      length: 10,
+      height: 20,
+      vAngle: 120,
+      units: 'metric',
+    });
+
+    const { container } = render(<GeometryStatus />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('handles zero length inverted-v', () => {
+    useAntennaStore.setState({
+      antennaType: 'inverted-v',
+      length: 0,
+      height: 10,
+      vAngle: 120,
+      units: 'metric',
+    });
+
+    render(<GeometryStatus />);
+    expect(screen.getByText(/Geometry Clamped/i)).toBeTruthy();
   });
 });

--- a/tests/TransformerControl.test.tsx
+++ b/tests/TransformerControl.test.tsx
@@ -1,6 +1,6 @@
 import { type SimulationResult } from '../src/physics/types';
 import { describe, expect, it, beforeEach } from 'vitest';
-import { render, cleanup } from '@testing-library/react';
+import { render, cleanup, waitFor } from '@testing-library/react';
 import { fireEvent } from '@testing-library/dom';
 import { TransformerControl } from '../src/components/Panel/TransformerControl';
 import { useAntennaStore } from '../src/store/antennaStore';
@@ -127,5 +127,36 @@ describe('TransformerControl', () => {
     });
     const { getByRole } = render(<TransformerControl />);
     expect(getByRole('button', { name: /Match/i })).not.toBeNull();
+  });
+
+  it('updates localRatio from store when not focused', async () => {
+    useAntennaStore.setState({ transformerEnabled: true, transformerRatio: 2 });
+    const { getByLabelText } = render(<TransformerControl />);
+    const input = getByLabelText(/Impedance ratio/i) as HTMLInputElement;
+    expect(input.value).toBe('2');
+
+    // Change ratio from outside (store)
+    useAntennaStore.setState({ transformerRatio: 4 });
+    await waitFor(() => {
+      expect(input.value).toBe('4');
+    });
+  });
+
+  it('does not update localRatio from store when focused', async () => {
+    useAntennaStore.setState({ transformerEnabled: true, transformerRatio: 2 });
+    const { getByLabelText } = render(<TransformerControl />);
+    const input = getByLabelText(/Impedance ratio/i) as HTMLInputElement;
+    expect(input.value).toBe('2');
+
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: '3' } });
+
+    // Change ratio from outside (store)
+    useAntennaStore.setState({ transformerRatio: 4 });
+
+    // Wait a tick to make sure it doesn't change
+    await waitFor(() => {
+      expect(input.value).toBe('3'); // Local state preserved while focused
+    });
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
       provider: 'v8',
       thresholds: {
         statements: 70.68,
-        branches: 62.97,
+        branches: 63.22,
         functions: 72.51,
         lines: 93.32,
       }


### PR DESCRIPTION
💡 What: Added unit tests to `GeometryStatus.test.tsx` and `TransformerControl.test.tsx` to handle edge cases and state synchronization respectively.
🎯 Why: The `GeometryStatus` test file had a flawed configuration explicitly rendering `GeometryControl` instead of `GeometryStatus` failing to cover clamped inverted-v and other branching logic. Similarly, the `TransformerControl` logic for managing internal input value state vs external store updates (unfocused vs focused state) had missing test coverage.
📈 Maturity Impact: Bumped overall coverage threshold for branches from 62.97% to 63.22% to lock in progress toward business standards.

---
*PR created automatically by Jules for task [13263338860602540279](https://jules.google.com/task/13263338860602540279) started by @2fst4u*