### PR TITLE
🧹 Sweep: remove unused exports

### DIFF
--- a/.jules/sweep.md
+++ b/.jules/sweep.md
@@ -18,3 +18,6 @@
 ## 2024-06-11 - Constant export cleanup
 **Learning:** Removing an unused export for a constant that is still used internally within the same file requires leaving the import intact.
 **Action:** When un-exporting variables, do a local grep to see if they are still used in the file; if so, do not remove the import.
+## $(date +%Y-%m-%d) - Un-exporting Internal Utilities and Constants
+**Learning:** `knip` correctly flagged `reflectionCoefficientMag`, `INITIAL_HEIGHT`, and `FEED_BRIDGE_LENGTH_M` (re-export) as unused outside their declaring files. When a function or constant is only used internally, it should not be exported, improving module encapsulation.
+**Action:** When cleaning up unused exports, simply remove the `export` keyword if the symbol is used locally. If it was re-exported in a centralized `export { ... }` block but unused outside, remove it from that block while keeping its import intact if it's used within the aggregator file. Always verify with `npm run build` and `npm run test` afterward.

--- a/src/physics/impedance.ts
+++ b/src/physics/impedance.ts
@@ -8,7 +8,7 @@ import type { ImpedanceResult, SimulationResult } from './types';
  * Reflection coefficient magnitude for a load Z against the system impedance.
  * |Γ| = |Z - Z0| / |Z + Z0|, where Z is complex.
  */
-export function reflectionCoefficientMag(z: ImpedanceResult, z0: number = Z0_SYSTEM): number {
+function reflectionCoefficientMag(z: ImpedanceResult, z0: number = Z0_SYSTEM): number {
   const numR = z.R - z0;
   const numX = z.X;
   const denR = z.R + z0;

--- a/src/store/antennaStore.ts
+++ b/src/store/antennaStore.ts
@@ -64,7 +64,6 @@ export {
   RIGHT_LEG_TAG,
   FEED_BRIDGE_TAG,
   FEEDLINE_SHIELD_TAG,
-  FEED_BRIDGE_LENGTH_M,
   DELTA_BASE_TAG,
   TERMINATED_DELTA_LEFT_BASE_TAG,
   TERMINATED_DELTA_RIGHT_BASE_TAG,
@@ -282,7 +281,7 @@ export interface AntennaState {
 }
 
 const INITIAL_FREQ = 7.1; // 40m band per user spec
-export const INITIAL_HEIGHT = 8; // metres
+const INITIAL_HEIGHT = 8; // metres
 const INITIAL_TYPE: AntennaType = 'dipole';
 const INITIAL_LENGTH = referenceLength(INITIAL_TYPE, INITIAL_FREQ); // resonant reference length
 


### PR DESCRIPTION
🎯 **What:**
- Removed `FEED_BRIDGE_LENGTH_M` from the re-export block in `src/store/antennaStore.ts`.
- Removed `export` modifier from `INITIAL_HEIGHT` in `src/store/antennaStore.ts`.
- Removed `export` modifier from `reflectionCoefficientMag` in `src/physics/impedance.ts`.

💡 **Why:**
These constants and functions were flagged as unused exports by `knip`. They are only used internally within their respective files, so removing the `export` keyword improves encapsulation and reduces the public API surface without altering functionality.

✅ **Verification:**
- Ran `npx knip` and manually `grep`ped the codebase to verify they are not used externally.
- `npm run lint` passes without errors.
- `npm run build` completed successfully.
- `npm run test` passed with 100% success rate on the test suite.

✨ **Result:**
Cleaner codebase with fewer unnecessary public exports and a reduced surface area.

---
*PR created automatically by Jules for task [2073168771794379664](https://jules.google.com/task/2073168771794379664) started by @2fst4u*