### PR TITLE
📚 Archivist: Update delta loop reference length in specs to match engine

### DIFF
--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -76,3 +76,7 @@
 ## 2026-06-12 - Dipole Model Spec Documentation Drift
 **Learning:** The documentation for the Dipole in `docs/antenna-model-spec.md` implied its feedpoint was strictly "Center-fed (split at the midpoint)." However, the application engine supports asymmetric/offset feedpoints (e.g., Off-Center Fed Dipoles). The documentation had drifted and failed to reflect this capability in the modeling spec, though it was noted in the implementation spec.
 **Action:** Updated `docs/antenna-model-spec.md` to accurately reflect that while center-fed by default, offset feedpoints are fully supported via asymmetric wire splitting.
+
+## 2026-06-13 - Delta Loop and Terminated Delta Reference Length Drift
+**Learning:** The documentation listed delta loop reference length as 1.03λ and terminated delta as 1.0λ, but the engine (`src/physics/constants.ts`) uses 1.02λ for both, based on the ARRL formula for full-wave HF loops.
+**Action:** `docs/antenna-spec.md` was updated to accurately reflect 1.02λ.

--- a/docs/antenna-spec.md
+++ b/docs/antenna-spec.md
@@ -146,7 +146,7 @@ This document defines the physical and mathematical model for all antenna types 
 
 - **Apex Location:** Highest point at $(0, 0, \text{height})$.
 - **Leg Count & Length:** 3 wires forming a triangle, total perimeter $L$.
-- **Reference Length:** $1.03\lambda$ (Resonance).
+- **Reference Length:** $1.02\lambda$ (Resonance).
 - **Angle/Slope:** Equilateral triangle in the vertical plane.
 - **Tips:** Bottom corners.
 - **Min Height:** Bottom wire must be $\ge 0.1$ m above ground.
@@ -185,7 +185,7 @@ This document defines the physical and mathematical model for all antenna types 
 
 - **Apex Location:** Highest point at $(0, 0, \text{height})$.
 - **Leg Count & Length:** 3 wires forming a triangle, total perimeter $L$. The bottom wire is split at the centre, so the structure is emitted as two top legs + two half-base wires + one bridge wire across the gap (when terminated).
-- **Reference Length:** $1.0\lambda$ canonical, but resonance is not the design goal: a properly bridged termination flattens impedance across an octave or more, so the antenna is used multi-band rather than at a single design frequency.
+- **Reference Length:** $1.02\lambda$ canonical, but resonance is not the design goal: a properly bridged termination flattens impedance across an octave or more, so the antenna is used multi-band rather than at a single design frequency.
 - **Angle/Slope:** Equilateral triangle in the vertical plane (flattens to isosceles when the mast height is below the equilateral height; perimeter preserved).
 - **Tips:** Bottom corners. The bottom wire is split at the centre with a gap (`TERMINATED_DELTA_CENTRE_GAP_M`).
 - **Min Height:** Bottom wire must be $\ge 0.1$ m above ground.


### PR DESCRIPTION
💡 Problem: `docs/antenna-spec.md` incorrectly claimed the reference length for a `delta-loop` was 1.03λ and `terminated-delta` was 1.0λ, but the physics constants in `src/physics/constants.ts` accurately model it as 1.02λ (based on the ARRL formula for full-wave HF loops).
🎯 Fix: Updated the reference length claims in `docs/antenna-spec.md` to 1.02λ to perfectly reflect the engine logic.
🧪 Verification: Read the source code `src/physics/constants.ts` to confirm 1.02λ logic is implemented and actively used by the store geometry builder.
🔎 Scope: Only modified the documentation specification file and the archivist journal. No application logic changed.

---
*PR created automatically by Jules for task [1059035014892749428](https://jules.google.com/task/1059035014892749428) started by @2fst4u*