### PR TITLE
📚 Archivist: Clarify Terminated Folded Dipole topology and fix capitalization

### DIFF
--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -80,3 +80,6 @@
 ## 2026-06-13 - Delta Loop and Terminated Delta Reference Length Drift
 **Learning:** The documentation listed delta loop reference length as 1.03λ and terminated delta as 1.0λ, but the engine (`src/physics/constants.ts`) uses 1.02λ for both, based on the ARRL formula for full-wave HF loops.
 **Action:** `docs/antenna-spec.md` was updated to accurately reflect 1.02λ.
+## 2026-06-15 - Terminated Folded Dipole Drift
+**Learning:** The Terminated Folded Dipole (TFD) termination topology was incorrectly described in `docs/antenna-spec.md` as a horizontal bridge wire, and it was entirely missing from the termination types overview in `docs/antenna-model-spec.md`. It actually uses a vertical bridge wire spanning the aperture between the top and bottom conductors.
+**Action:** Updated the specifications to accurately describe the TFD topology and its vertical termination bridge to match the implementation in `src/physics/constants.ts` and `src/store/antennaGeometry.ts`.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A 3D, responsive, physics-accurate visualiser for HF antenna radiation patterns,
 
 While this repository is fully open source and developers are welcome to fork or clone it to run locally, the primary way to use the application is via the hosted URL at **[www.gain.observer](https://www.gain.observer/)**.
 
-Current scope (Phase 1): horizontal dipoles, inverted Vs, sloping Vs, delta loops, Terminated Deltas, vertical whips, inverted Ls, and folded dipoles, 1.8–30 MHz, real-ground support, offset feed points, feedlines & baluns, comparison mode, SWR/polar cut charts, dark/light theming, metric/imperial toggle.
+Current scope (Phase 1): horizontal dipoles, inverted Vs, sloping Vs, delta loops, terminated deltas, vertical whips, inverted Ls, and folded dipoles, 1.8–30 MHz, real-ground support, offset feed points, feedlines & baluns, comparison mode, SWR/polar cut charts, dark/light theming, metric/imperial toggle.
 
 ## Keyboard Shortcuts
 

--- a/docs/antenna-model-spec.md
+++ b/docs/antenna-model-spec.md
@@ -103,14 +103,16 @@ We use the standard NEC-2 Cartesian coordinate system:
 A **terminated** antenna places a non-inductive resistive load somewhere on the radiating structure to absorb the wave that would otherwise reflect and form a standing wave. Two distinct families exist in this app, and they behave very differently:
 
 - **Asymmetric travelling-wave terminations** (Sloping V): the wave travels along a single asymmetric path, with the terminator at the far end. Result: cardioid pattern, broadband, unidirectional.
-- **Symmetric aperiodic loop terminations** (Terminated Delta, T2FD-style): the wave propagates around a closed loop from a symmetric feed point and is absorbed at a symmetric point opposite the feed via a single resistor _bridging the gap_ (not shunted to ground). Result: bidirectional/broadside-ish pattern, broadband flat impedance, **not** unidirectional. Trades efficiency for flat SWR across an octave.
+- **Symmetric aperiodic loop terminations** (Terminated Delta, Terminated Folded Dipole, T2FD-style): the wave propagates around a closed loop from a symmetric feed point and is absorbed at a symmetric point opposite the feed via a single resistor _bridging the gap_ (not shunted to ground). Result: bidirectional/broadside-ish pattern, broadband flat impedance, **not** unidirectional. Trades efficiency for flat SWR across an octave.
 
 ### 3.2 Termination Implementation
 
 - **Sloping V**: Termination consists of a resistor connected from the end of each leg to ground via a short stub wire. Typical value $300\text{--}600\,\Omega$ (matches the leg's characteristic impedance against ground).
 - **Terminated Delta**: Termination is a single resistor on a short horizontal _bridge wire_ spanning the gap at the centre of the base. Typical value $\sim 600\,\Omega$ (close to the loop wire's characteristic impedance over typical HF heights, $Z_0 \approx 60 \ln(2h/a) \approx 500\text{--}700\,\Omega$). **Not** two resistors to ground — that topology is symmetric but fails to terminate the loop, leaving large reactive feedpoint impedance and high leg current ripple.
+- **Terminated Folded Dipole**: Termination is a single resistor on a short vertical _bridge wire_ spanning the aperture between the centre of the top (un-fed) conductor and the centre of the bottom (fed) conductor. Typical value $\sim 390\text{--}600\,\Omega$. Like the terminated delta, this implements a proper TFD/traveling-wave topology by forcing current through the resistor across the gap.
 - **Effect (sloping V)**: converts a resonant bi-directional radiator into a broadband uni-directional travelling-wave radiator.
 - **Effect (terminated delta)**: converts a resonant narrowband loop into a broadband aperiodic loop. Pattern stays roughly delta-loop-shaped (broadside max, end-fire minimum). Multi-band usable with a 9:1 unun.
+- **Effect (terminated folded dipole)**: flattens SWR across a wide frequency range compared to a standard folded dipole, at the cost of radiation efficiency due to power dissipated in the termination.
 
 ### 3.3 Termination vs. Matching
 

--- a/docs/antenna-spec.md
+++ b/docs/antenna-spec.md
@@ -320,7 +320,7 @@ This document defines the physical and mathematical model for all antenna types 
 
 ### 8.3 Termination Definition
 
-- **Topology:** Optional. The opposite conductor is split into two halves at the centre. When terminated, a single `LD 4` resistor sits on a short horizontal bridge wire (`FOLDED_DIPOLE_TERM_BRIDGE_TAG`) that spans the gap between the two halves.
+- **Topology:** Optional. The opposite conductor is split into two halves at the centre. When terminated, a single `LD 4` resistor sits on a short vertical bridge wire (`FOLDED_DIPOLE_TERM_BRIDGE_TAG`) that spans the aperture from the centre junction of the un-fed (top) conductor down to the feed-bridge junction on the fed (bottom) conductor.
 - **Unterminated (`terminatingResistor = 0`):** A classic folded dipole — ~300 Ω, narrowband, dipole gain and pattern.
 - **Terminated (`terminatingResistor > 0`):** A terminated folded dipole (TFD). The resistor flattens SWR across a wide frequency range at the cost of efficiency (roughly half the power is dissipated). Typical value ~390–600 Ω. This is the straight-conductor cousin of the T2FD modelled under §5 as a terminated delta.
 


### PR DESCRIPTION
💡 Problem: The README.md contained inconsistent capitalization for "terminated deltas". Furthermore, the Terminated Folded Dipole (TFD) was missing from the "Terminated Antennas" overview in `docs/antenna-model-spec.md`, and its termination bridge wire was incorrectly described as "horizontal" instead of "vertical" in `docs/antenna-spec.md`.

🎯 Fix: 
- Changed "Terminated Deltas" to "terminated deltas" in `README.md` to match the comma-separated list convention.
- Added the Terminated Folded Dipole to the symmetric travelling-wave terminations in `docs/antenna-model-spec.md`.
- Corrected the TFD termination description in `docs/antenna-spec.md` to reflect that the resistor sits on a short vertical bridge wire spanning the aperture between the conductors.

🧪 Verification: Checked `src/physics/constants.ts` and `src/store/antennaGeometry.ts` to confirm the actual bridge wire orientation. Ran `npm run lint` and `npm run test` successfully.
🔎 Scope: Only documentation files (`README.md`, `docs/antenna-model-spec.md`, `docs/antenna-spec.md`, `.jules/archivist.md`) were modified.

---
*PR created automatically by Jules for task [6977583895994463411](https://jules.google.com/task/6977583895994463411) started by @2fst4u*