### PR TITLE
🧹 [fix] Add journal entry for false positive unused type import

### DIFF
--- a/.jules/sweep.md
+++ b/.jules/sweep.md
@@ -21,3 +21,6 @@
 ## $(date +%Y-%m-%d) - Un-exporting Internal Utilities and Constants
 **Learning:** `knip` correctly flagged `reflectionCoefficientMag`, `INITIAL_HEIGHT`, and `FEED_BRIDGE_LENGTH_M` (re-export) as unused outside their declaring files. When a function or constant is only used internally, it should not be exported, improving module encapsulation.
 **Action:** When cleaning up unused exports, simply remove the `export` keyword if the symbol is used locally. If it was re-exported in a centralized `export { ... }` block but unused outside, remove it from that block while keeping its import intact if it's used within the aggregator file. Always verify with `npm run build` and `npm run test` afterward.
+## 2024-05-18 - [False Positive on Unused Type Import]
+**Learning:** A static analysis tool incorrectly flagged a valid type import (`ComparisonSnapshot` in `src/components/Scene/AntennaScene.tsx`) as unused, when it was actually being used as a type for a property in an interface definition (`interface AntennaSceneProps`).
+**Action:** When investigating reported unused type imports, carefully examine the file to ensure the type isn't used within type signatures or interfaces. If verified as a false positive, do not remove the import, and instead note the false positive in the journal and close the task without making codebase changes.


### PR DESCRIPTION
🎯 **What:** Documented a false positive where a static analysis tool incorrectly flagged a valid type import (`ComparisonSnapshot` in `AntennaScene.tsx`) as unused.
💡 **Why:** It improves our understanding of tooling behavior. The import was actually used in an interface definition (`interface AntennaSceneProps`). Modifying the codebase to bypass this false positive (e.g., using inline dynamic imports) degrades readability and is an anti-pattern.
✅ **Verification:** Verified by confirming the type usage in the file and ensuring tests and build still pass with the original code intact.
✨ **Result:** Improved code health documentation without negatively impacting codebase quality.

---
*PR created automatically by Jules for task [14675008136641916915](https://jules.google.com/task/14675008136641916915) started by @2fst4u*