### PR TITLE
🧪 Spec: Add tests for buildVerticalWhipWires

### DIFF
--- a/.jules/spec.md
+++ b/.jules/spec.md
@@ -24,3 +24,6 @@
 ## 2024-06-09 - Added GeometryControl.test.tsx coverage test
 **Learning:** Adding a single focused UI unit test might sometimes slightly decrease global percentage coverage metrics due to the test file's own code expanding the denominator, if the logic it tests was already partially hit elsewhere.
 **Action:** Wrote test for setVAngle and adjusted thresholds to lock in progress.
+## 2024-06-16 - Add Tests for buildVerticalWhipWires
+**Learning:** In `src/store/antennaGeometry.ts`, the `buildVerticalWhipWires` function enforces a minimum whip length of 0.1m and a minimum base gap (`baseZ`) of `VERTICAL_WHIP_BASE_GAP_M` (0.01m). When `counterpoise` is true, it generates `VERTICAL_WHIP_RADIAL_COUNT` radials with a length of `λ * 0.25 * 0.95`.
+**Action:** Added targeted unit tests in `tests/antennaGeometry.test.ts` for this function ensuring that length bounds, gap enforcement, counterpoise radials, and segment generation are correctly validated.

--- a/tests/antennaGeometry.test.ts
+++ b/tests/antennaGeometry.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { gradedSegmentPlan, orientationVector, buildInvertedLWires } from '../src/store/antennaGeometry';
+import { gradedSegmentPlan, orientationVector, buildInvertedLWires, buildVerticalWhipWires } from '../src/store/antennaGeometry';
 import {
   INVERTED_L_VERTICAL_TAG,
   INVERTED_L_HORIZONTAL_TAG,
   INVERTED_L_RADIAL_TAG,
-  VERTICAL_WHIP_RADIAL_COUNT
+  VERTICAL_WHIP_RADIAL_COUNT,
+  VERTICAL_WHIP_TAG,
+  VERTICAL_WHIP_RADIAL_TAG
 } from '../src/physics/constants';
 
 describe('gradedSegmentPlan', () => {
@@ -149,5 +151,75 @@ describe('buildInvertedLWires', () => {
     const horizontal = wires.find(w => w.tag === INVERTED_L_HORIZONTAL_TAG);
     expect(horizontal).toBeDefined();
     expect(horizontal!.segments).toBeLessThanOrEqual(5);
+  });
+});
+
+describe('buildVerticalWhipWires', () => {
+  const baseParams = {
+    length: 10,
+    height: 0,
+    frequency: 14.15,
+    segments: 51,
+    wireRadius: 0.001,
+    counterpoise: false,
+  };
+
+  it('creates a single vertical wire with the correct tag', () => {
+    const wires = buildVerticalWhipWires(baseParams);
+    expect(wires).toHaveLength(1);
+
+    const vertical = wires[0];
+    expect(vertical.tag).toBe(VERTICAL_WHIP_TAG);
+    expect(vertical.start).toEqual([0, 0, 0.01]); // VERTICAL_WHIP_BASE_GAP_M is 0.01
+    expect(vertical.end).toEqual([0, 0, 10.01]); // 0.01 + 10
+  });
+
+  it('respects minimum length and height gap bounds', () => {
+    const smallParams = {
+      ...baseParams,
+      length: 0.05, // Should be max(0.1, length) = 0.1
+      height: 0.005, // Should be max(0.01, height) = 0.01
+    };
+    const wires = buildVerticalWhipWires(smallParams);
+    expect(wires).toHaveLength(1);
+
+    const vertical = wires[0];
+    expect(vertical.start).toEqual([0, 0, 0.01]);
+    expect(vertical.end[2]).toBeCloseTo(0.11); // 0.01 + 0.1
+  });
+
+  it('adds radials when counterpoise is true', () => {
+    const params = { ...baseParams, counterpoise: true };
+    const wires = buildVerticalWhipWires(params);
+
+    // 1 vertical wire + 4 radials
+    expect(wires).toHaveLength(1 + VERTICAL_WHIP_RADIAL_COUNT);
+
+    const radials = wires.filter(w => w.tag === VERTICAL_WHIP_RADIAL_TAG);
+    expect(radials).toHaveLength(VERTICAL_WHIP_RADIAL_COUNT);
+
+    // Radials should start at the baseZ
+    radials.forEach(radial => {
+      expect(radial.start).toEqual([0, 0, 0.01]);
+      expect(radial.end[2]).toBe(0.01);
+    });
+  });
+
+  it('calculates segment lengths based on frequency lambda bounds', () => {
+    const params = {
+      ...baseParams,
+      length: 20, // Long whip
+      segments: 5, // Request very few segments
+    };
+
+    // lambda ~ 21.2m
+    // minSegs = ceil((21 * 20) / 21.2) ~ 20.
+    // segments = min(200, max(1, 20, 5)) -> 20.
+
+    const wires = buildVerticalWhipWires(params);
+    expect(wires).toHaveLength(1);
+
+    const vertical = wires[0];
+    expect(vertical.segments).toBeGreaterThan(5); // Forced up by minSegs
   });
 });


### PR DESCRIPTION
🎯 **What:** The testing gap for `buildVerticalWhipWires` in `src/store/antennaGeometry.ts` was addressed by adding a dedicated `describe` block to `tests/antennaGeometry.test.ts`.
📊 **Coverage:** The new tests cover:
- Standard vertical wire creation without radials.
- Bounds checking for minimum length (`0.1`) and height gap (`VERTICAL_WHIP_BASE_GAP_M`).
- Generation of radials when `counterpoise: true`.
- Segment count calculations derived from wavelength limits.
✨ **Result:** Test coverage for `src/store/antennaGeometry.ts` improved. `npm run test` confirms that all existing and new tests (679 total) pass seamlessly.

---
*PR created automatically by Jules for task [14857278768714881323](https://jules.google.com/task/14857278768714881323) started by @2fst4u*