### PR TITLE
🧹 [false positive] SwrBand unused import in nec2Engine.ts

### DIFF
--- a/.jules/sweep.md
+++ b/.jules/sweep.md
@@ -27,3 +27,6 @@
 ## 2024-06-25 - False Positive on AntennaType Import
 **Learning:** The static analysis scanner incorrectly flagged `type AntennaType` in `src/components/Panel/GeometryControl.tsx` as an unused import. However, manual inspection verified it was used as a type parameter in definitions like `Record<AntennaType, string>`. Removing valid, in-use imports causes build failures and is an anti-pattern.
 **Action:** Closed the task without making changes to the codebase, strictly adhering to the Code Health Refactoring Pattern which dictates preserving valid code when confronted with false positives.
+## 2024-05-19 - [False Positive on Unused Type Import]
+**Learning:** A static analysis tool incorrectly flagged a valid type import (`SwrBand` in `src/physics/nec2Engine.ts`) as unused, when it was actually being used as a type annotation for function parameters (`bands: readonly SwrBand[]` and `b: SwrBand`). Removing it causes `tsc` build errors.
+**Action:** When investigating reported unused type imports, carefully examine the file to ensure the type isn't used within type signatures or interfaces. If verified as a false positive, do not remove the import, and instead note the false positive in the journal and close the task without making codebase changes.


### PR DESCRIPTION
🎯 **What:** Investigated the report that `SwrBand` was an unused import in `src/physics/nec2Engine.ts`.
💡 **Why:** It was discovered to be a false positive. `SwrBand` is validly used as a type annotation for function parameters (`bands: readonly SwrBand[]` and `b: SwrBand`). Removing it causes `tsc` build errors (`TS7006: Parameter implicitly has an 'any' type`).
✅ **Verification:** Verified by temporarily removing the type and running `npm run build`, which failed. The test suite and linting remain fully passing. Documented this quirk in `.jules/sweep.md`.
✨ **Result:** Prevented a destructive code change by logging the false positive instead of blindly following the static analysis tool.

---
*PR created automatically by Jules for task [8566255217779078012](https://jules.google.com/task/8566255217779078012) started by @2fst4u*