### PR TITLE
🧹 Code Health: Remove unused OrientationPreset import and re-export

### DIFF
--- a/.jules/sweep.md
+++ b/.jules/sweep.md
@@ -27,3 +27,7 @@
 ## 2024-06-25 - False Positive on AntennaType Import
 **Learning:** The static analysis scanner incorrectly flagged `type AntennaType` in `src/components/Panel/GeometryControl.tsx` as an unused import. However, manual inspection verified it was used as a type parameter in definitions like `Record<AntennaType, string>`. Removing valid, in-use imports causes build failures and is an anti-pattern.
 **Action:** Closed the task without making changes to the codebase, strictly adhering to the Code Health Refactoring Pattern which dictates preserving valid code when confronted with false positives.
+
+## 2024-05-19 - Removed unused OrientationPreset import and re-export in antennaStore.ts
+**Learning:** Found that `type OrientationPreset` was imported in `src/store/antennaStore.ts` just to be re-exported, causing an unused import warning by standard code health checks since it isn't used internally.
+**Action:** Removed the import and re-export of `OrientationPreset` in `src/store/antennaStore.ts` and updated the `GeometryControl.tsx` component to import it directly from `../../store/antennaGeometry` where it is defined, improving clarity and maintainability.

--- a/src/components/Panel/GeometryControl.tsx
+++ b/src/components/Panel/GeometryControl.tsx
@@ -7,10 +7,8 @@ import {
   fromDisplayLength,
   displayLengthUnit,
 } from '../../physics/units';
-import {
-  type OrientationPreset,
-  type AntennaType,
-} from '../../store/antennaStore';
+import { type AntennaType } from '../../store/antennaStore';
+import { type OrientationPreset } from '../../store/antennaGeometry';
 import { FOLDED_DIPOLE_MAX_APERTURE_M } from '../../physics/constants';
 import { TransformerControl } from './TransformerControl';
 

--- a/src/store/antennaStore.ts
+++ b/src/store/antennaStore.ts
@@ -86,13 +86,12 @@ import {
   buildInvertedLWires,
   buildFoldedAntennaWires,
   orientationVector,
-  type OrientationPreset,
   type Orientation,
 } from './antennaGeometry';
 
 // Re-export shared types for UI and geometry.
 export type { AntennaType };
-export type { OrientationPreset, Orientation };
+export type { Orientation };
 
 const FEEDLINE_SUPPORTED_TYPES = new Set<string>(['dipole', 'inverted-v', 'delta-loop', 'sloping-v', 'terminated-delta', 'folded-dipole']);
 


### PR DESCRIPTION
🎯 **What:** Removed the unused import and re-export of `type OrientationPreset` from `src/store/antennaStore.ts` and updated `src/components/Panel/GeometryControl.tsx` to import it directly from its source module `src/store/antennaGeometry.ts`.
💡 **Why:** A code health check flagged the import as unused since it wasn't referenced internally within `antennaStore.ts`. Removing the pass-through re-export and importing directly from the source module improves code clarity and maintainability.
✅ **Verification:** Verified by using `grep` to ensure no other files rely on the old export path, and by running the full test suite (`npm run test -- --coverage`), linters (`npm run lint`), and build process (`npm run build`). All passed seamlessly with no regressions.
✨ **Result:** A cleaner store module structure with one less intermediate type re-export, and zero code health flags.

---
*PR created automatically by Jules for task [16567333566252585087](https://jules.google.com/task/16567333566252585087) started by @2fst4u*