### PR TITLE
🔒 fix: Prevent Vite dev server exposure to local network

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -68,7 +68,6 @@ export default defineConfig({
   ],
   server: {
     port: 5173,
-    host: true,
   },
   worker: {
     format: 'iife',


### PR DESCRIPTION
🎯 **What:** Removed `host: true` from the Vite development server configuration.
⚠️ **Risk:** By setting `host: true`, the development server is exposed to all network interfaces on the local network. Anyone on the same network could access the development application, potentially intercepting unencrypted development traffic or interacting with experimental features in progress.
🛡️ **Solution:** By removing this option, Vite defaults to binding only to `localhost` (`127.0.0.1`), ensuring the dev server is only accessible from the developer's local machine, mitigating unauthorized local network access.

---
*PR created automatically by Jules for task [7426497373412941272](https://jules.google.com/task/7426497373412941272) started by @2fst4u*