### PR TITLE
🧹 Document AntennaWireProps false positive in static analysis

### DIFF
--- a/.jules/sweep.md
+++ b/.jules/sweep.md
@@ -27,3 +27,6 @@
 ## 2024-06-25 - False Positive on AntennaType Import
 **Learning:** The static analysis scanner incorrectly flagged `type AntennaType` in `src/components/Panel/GeometryControl.tsx` as an unused import. However, manual inspection verified it was used as a type parameter in definitions like `Record<AntennaType, string>`. Removing valid, in-use imports causes build failures and is an anti-pattern.
 **Action:** Closed the task without making changes to the codebase, strictly adhering to the Code Health Refactoring Pattern which dictates preserving valid code when confronted with false positives.
+## 2024-10-24 - False Positive on AntennaWireProps Import
+**Learning:** The static analysis scanner incorrectly flagged `type AntennaWireProps` in `src/components/Scene/AntennaWire.tsx` as an unused import. Manual inspection verified it was used as the type for the `props` argument in `export function AntennaWire(props: AntennaWireProps)`.
+**Action:** Closed the task without making changes to the codebase, preserving valid code.


### PR DESCRIPTION
🎯 **What:** The code health issue reported was an unused import of `AntennaWireProps` in `src/components/Scene/AntennaWire.tsx`.
💡 **Why:** This was verified to be a false positive. The type is actively used to define the `props` for the `AntennaWire` component (`export function AntennaWire(props: AntennaWireProps)`). Removing it would break type safety and the build. Following the Code Health Refactoring Pattern, no modifications were made to the source codebase to artificially "fix" this warning.
✅ **Verification:** Ran `npm run lint`, `npm run build`, and `npm run test -- --coverage` successfully to ensure baseline stability and verify no regressions occurred.
✨ **Result:** Appended a journal entry to `.jules/sweep.md` to document this false positive and inform future static analysis reviews, leaving the valid codebase cleanly intact.

---
*PR created automatically by Jules for task [5335513609131479760](https://jules.google.com/task/5335513609131479760) started by @2fst4u*