### PR TITLE
🔒 Fix ReDoS vulnerability in NEC warning parser

### DIFF
--- a/src/physics/necParser.ts
+++ b/src/physics/necParser.ts
@@ -242,7 +242,7 @@ export function parseNecOutput(
     notices.push('Radiation pattern block not found in NEC output.');
   }
   // Look for NEC-2 warning banners.
-  const warnMatch = text.match(/\*\*\*\*\*.*?WARNING.*?\*\*\*\*\*/g);
+  const warnMatch = text.match(/\*\*\*\*\*[^*\r\n]*WARNING[^*\r\n]*\*\*\*\*\*/g);
   if (warnMatch) notices.push(...warnMatch.map((s) => s.trim()));
 
   return {


### PR DESCRIPTION
🎯 **What:** The previous regex used for parsing NEC warnings (`/\*\*\*\*\*.*?WARNING.*?\*\*\*\*\*/g`) used overlapping lazy quantifiers (`.*?`). This was replaced with a more restrictive and robust regex (`/\*\*\*\*\*[^*\r\n]*WARNING[^*\r\n]*\*\*\*\*\*/g`) that avoids catastrophic backtracking by explicitly ignoring nested asterisks or newlines.

⚠️ **Risk:** An attacker or a malformed NEC-2 output string containing excessively long text lines missing closing elements could trigger catastrophic backtracking in the JavaScript RegEx engine, potentially leading to a Regular Expression Denial of Service (ReDoS) and crashing or hanging the parsing routine.

🛡️ **Solution:** Substituted the `.*?` matchers with a negated character class `[^*\r\n]*`. This allows the parser to swiftly ignore characters bounded by `*****` that do not contain further asterisks or newlines, immediately failing out of invalid match attempts and securing the parser against input-induced performance degradation.

---
*PR created automatically by Jules for task [18131880139488464309](https://jules.google.com/task/18131880139488464309) started by @2fst4u*