### PR TITLE
🧹 [refactor: simplify PropagationRadar function]

### DIFF
--- a/.jules/sweep.md
+++ b/.jules/sweep.md
@@ -42,3 +42,7 @@
 ## 2024-10-24 - False Positive on AntennaWireProps Import
 **Learning:** The static analysis scanner incorrectly flagged `type AntennaWireProps` in `src/components/Scene/AntennaWire.tsx` as an unused import. Manual inspection verified it was used as the type for the `props` argument in `export function AntennaWire(props: AntennaWireProps)`.
 **Action:** Closed the task without making changes to the codebase, preserving valid code.
+
+## 2024-06-17 - Complex function refactor PropagationRadar
+**Learning:** We refactored `PropagationRadar` in `src/components/Charts/PropagationRadar.tsx` by extracting complex logic into smaller helper functions (`calculateMaxRangeKm` and `buildAzimuthalWedges`), improving code readability and maintainability without changing behavior.
+**Action:** Identified the logic that could be extracted, created the pure helper functions, and verified no regressions by running tests.

--- a/src/components/Charts/PropagationRadar.tsx
+++ b/src/components/Charts/PropagationRadar.tsx
@@ -74,15 +74,15 @@ function buildAzimuthalWedges(
   cx: number,
   cy: number,
   kmToPx: number
-) {
+): JSX.Element[] {
   const wedges = [];
   for (let i = 0; i < az.length; i++) {
-    const aPoint = az[i];
+    const aPoint = az[i]!;
     const bPoint = az[(i + 1) % az.length]!;
     const rA = (aPoint.rangeKm[ringN - 1] ?? 0) * kmToPx;
     const rB = (bPoint.rangeKm[ringN - 1] ?? 0) * kmToPx;
-    const aRad = (((aPoint.phiDeg % 360) + 360) % 360 * Math.PI) / 180;
-    const bRad = (((bPoint.phiDeg % 360) + 360) % 360 * Math.PI) / 180;
+    const aRad = ((((aPoint.phiDeg % 360) + 360) % 360) * Math.PI) / 180;
+    const bRad = ((((bPoint.phiDeg % 360) + 360) % 360) * Math.PI) / 180;
     const ax = cx + rA * Math.sin(aRad);
     const ay = cy - rA * Math.cos(aRad);
     const bx = cx + rB * Math.sin(bRad);

--- a/src/components/Charts/PropagationRadar.tsx
+++ b/src/components/Charts/PropagationRadar.tsx
@@ -55,6 +55,60 @@ function worseQuality(a: 'useful' | 'weak' | 'unusable', b: 'useful' | 'weak' | 
   return rank[a] <= rank[b] ? a : b;
 }
 
+function calculateMaxRangeKm(prediction: PropagationPrediction): number {
+  let maxRangeKm = prediction.hops[prediction.hops.length - 1]?.rangeKm ?? 1;
+  if (prediction.azimuthalHops) {
+    for (const az of prediction.azimuthalHops) {
+      const lastRange = az.rangeKm[az.rangeKm.length - 1];
+      if (lastRange && lastRange > maxRangeKm) {
+        maxRangeKm = lastRange;
+      }
+    }
+  }
+  return maxRangeKm;
+}
+
+function buildAzimuthalWedges(
+  az: NonNullable<PropagationPrediction['azimuthalHops']>,
+  ringN: number,
+  cx: number,
+  cy: number,
+  kmToPx: number
+) {
+  const wedges = [];
+  for (let i = 0; i < az.length; i++) {
+    const aPoint = az[i];
+    const bPoint = az[(i + 1) % az.length]!;
+    const rA = (aPoint.rangeKm[ringN - 1] ?? 0) * kmToPx;
+    const rB = (bPoint.rangeKm[ringN - 1] ?? 0) * kmToPx;
+    const aRad = (((aPoint.phiDeg % 360) + 360) % 360 * Math.PI) / 180;
+    const bRad = (((bPoint.phiDeg % 360) + 360) % 360 * Math.PI) / 180;
+    const ax = cx + rA * Math.sin(aRad);
+    const ay = cy - rA * Math.cos(aRad);
+    const bx = cx + rB * Math.sin(bRad);
+    const by = cy - rB * Math.cos(bRad);
+    // Colour the wedge by the worse status / quality of its two
+    // bounding radials, so a closed bearing visually pulls the
+    // wedge into "closed" rather than borrowing colour from a
+    // neighbouring open bearing.
+    const status = worseStatus(aPoint.status, bPoint.status);
+    const linkQuality = worseQuality(aPoint.linkQuality, bPoint.linkQuality);
+    wedges.push(
+      <polygon
+        key={`${ringN}-${i}`}
+        points={`${cx},${cy} ${ax},${ay} ${bx},${by}`}
+        fill={statusFill(status)}
+        fillOpacity={qualityOpacity(linkQuality)}
+        stroke={statusFill(status)}
+        strokeOpacity={linkQuality === 'unusable' ? 0.25 : 0.6}
+        strokeWidth={1}
+        strokeDasharray={linkQuality === 'unusable' ? '4 3' : undefined}
+      />
+    );
+  }
+  return wedges;
+}
+
 export function PropagationRadar({
   prediction,
   units,
@@ -65,17 +119,7 @@ export function PropagationRadar({
   // Leave a margin for axis labels.
   const margin = 24;
 
-  // Find overall maximum range to scale the radar.
-  let maxRangeKm = prediction.hops[prediction.hops.length - 1]?.rangeKm ?? 1;
-  if (prediction.azimuthalHops) {
-    for (const az of prediction.azimuthalHops) {
-      const lastRange = az.rangeKm[az.rangeKm.length - 1];
-      if (lastRange && lastRange > maxRangeKm) {
-        maxRangeKm = lastRange;
-      }
-    }
-  }
-
+  const maxRangeKm = calculateMaxRangeKm(prediction);
   const maxRadiusPx = (size / 2) - margin;
   const kmToPx = maxRadiusPx / Math.max(1, maxRangeKm);
 
@@ -100,38 +144,7 @@ export function PropagationRadar({
   for (let k = rings.length - 1; k >= 0; k--) {
     const ring = rings[k];
     if (prediction.azimuthalHops && prediction.azimuthalHops.length > 1) {
-      const az = prediction.azimuthalHops;
-      const wedges = [];
-      for (let i = 0; i < az.length; i++) {
-        const aPoint = az[i];
-        const bPoint = az[(i + 1) % az.length]!;
-        const rA = (aPoint.rangeKm[ring.n - 1] ?? 0) * kmToPx;
-        const rB = (bPoint.rangeKm[ring.n - 1] ?? 0) * kmToPx;
-        const aRad = (((aPoint.phiDeg % 360) + 360) % 360 * Math.PI) / 180;
-        const bRad = (((bPoint.phiDeg % 360) + 360) % 360 * Math.PI) / 180;
-        const ax = cx + rA * Math.sin(aRad);
-        const ay = cy - rA * Math.cos(aRad);
-        const bx = cx + rB * Math.sin(bRad);
-        const by = cy - rB * Math.cos(bRad);
-        // Colour the wedge by the worse status / quality of its two
-        // bounding radials, so a closed bearing visually pulls the
-        // wedge into "closed" rather than borrowing colour from a
-        // neighbouring open bearing.
-        const status = worseStatus(aPoint.status, bPoint.status);
-        const linkQuality = worseQuality(aPoint.linkQuality, bPoint.linkQuality);
-        wedges.push(
-          <polygon
-            key={`${ring.n}-${i}`}
-            points={`${cx},${cy} ${ax},${ay} ${bx},${by}`}
-            fill={statusFill(status)}
-            fillOpacity={qualityOpacity(linkQuality)}
-            stroke={statusFill(status)}
-            strokeOpacity={linkQuality === 'unusable' ? 0.25 : 0.6}
-            strokeWidth={1}
-            strokeDasharray={linkQuality === 'unusable' ? '4 3' : undefined}
-          />
-        );
-      }
+      const wedges = buildAzimuthalWedges(prediction.azimuthalHops, ring.n, cx, cy, kmToPx);
       hopRings.push(<g key={ring.n}>{wedges}</g>);
     } else {
       hopRings.push(

--- a/src/components/Charts/PropagationRadar.tsx
+++ b/src/components/Charts/PropagationRadar.tsx
@@ -11,6 +11,7 @@
 //   - SVG is easy to make theme-responsive (CSS variables work directly);
 //   - it keeps the bundle small.
 
+import type { JSX } from 'react';
 import type { PropagationPrediction } from '../../physics/propagation';
 import type { UnitSystem } from '../../physics/units';
 


### PR DESCRIPTION
🎯 **What:** Extracted `calculateMaxRangeKm` and `buildAzimuthalWedges` from the `PropagationRadar` component in `src/components/Charts/PropagationRadar.tsx`.
💡 **Why:** To improve the maintainability and readability of the codebase by simplifying a complex React component (>170 lines) into smaller, more focused helper functions.
✅ **Verification:** Ran the full test suite (`npm run test -- --run`) and format/lint checks (`npm run lint`), all of which passed successfully. Confirmed via Code Review tool that changes are functionally identical and safe.
✨ **Result:** A much simpler main component block that is easier to reason about, with no changed logic or broken behavior.

---
*PR created automatically by Jules for task [10119448806106926915](https://jules.google.com/task/10119448806106926915) started by @2fst4u*