### PR TITLE
🧪 Spec: Add tests for computeOptions and computeYMax in swrChartUtils

### DIFF
--- a/tests/swrChartUtils.test.ts
+++ b/tests/swrChartUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { computeChartData, computeStats, formatBandwidth, computeXBounds } from '../src/components/Charts/swrChartUtils';
+import { computeChartData, computeStats, formatBandwidth, computeXBounds, computeYMax, computeOptions } from '../src/components/Charts/swrChartUtils';
 import type { SweepPoint } from '../src/physics/types';
 import type { ComparisonSnapshot } from '../src/store/antennaStore';
 
@@ -275,5 +275,201 @@ describe('computeStats', () => {
     expect(band.lowClipped).toBe(true);
     expect(band.fHigh).toBeCloseTo(7.133, 3);
     expect(band.highClipped).toBe(false);
+  });
+});
+
+describe('computeOptions', () => {
+  const baseArgs = {
+    frequency: 7.1,
+    accent: '#ff0000',
+    stats: null,
+    yMax: 5,
+    xBounds: { min: 6.9, max: 7.3 },
+    chartText: '#ffffff',
+    chartGrid: '#333333',
+    comparisonActive: false,
+  };
+
+  it('generates basic chart options without stats', () => {
+    const options = computeOptions(baseArgs);
+
+    expect(options.responsive).toBe(true);
+    expect(options.maintainAspectRatio).toBe(false);
+    expect(options.scales?.y?.max).toBe(5);
+    expect(options.scales?.y?.min).toBe(1);
+    expect(options.scales?.x?.min).toBe(6.9);
+    expect(options.scales?.x?.max).toBe(7.3);
+
+    // Basic annotations should exist
+    const annotations = options.plugins?.annotation?.annotations as any;
+    expect(annotations).toBeDefined();
+    expect(annotations.swr2).toBeDefined();
+    expect(annotations.swr2.yMin).toBe(2);
+    expect(annotations.currentFrequency).toBeDefined();
+    expect(annotations.currentFrequency.xMin).toBe(7.1);
+
+    // No stats annotations
+    expect(annotations.minFreq).toBeUndefined();
+    expect(annotations.band0Low).toBeUndefined();
+  });
+
+  it('adds stats annotations when stats are provided', () => {
+    const stats = {
+      minSWR: 1.2,
+      minFreq: 7.15,
+      bands: [
+        { fLow: 7.05, fHigh: 7.25, lowClipped: false, highClipped: false },
+        { fLow: 7.28, fHigh: 7.29, lowClipped: true, highClipped: true }
+      ]
+    };
+
+    const options = computeOptions({ ...baseArgs, stats });
+    const annotations = options.plugins?.annotation?.annotations as any;
+
+    // Min freq line
+    expect(annotations.minFreq).toBeDefined();
+    expect(annotations.minFreq.xMin).toBe(7.15);
+
+    // Unclipped band should have both edge markers
+    expect(annotations.band0Low).toBeDefined();
+    expect(annotations.band0Low.xMin).toBe(7.05);
+    expect(annotations.band0High).toBeDefined();
+    expect(annotations.band0High.xMin).toBe(7.25);
+
+    // Clipped band should not have edge markers
+    expect(annotations.band1Low).toBeUndefined();
+    expect(annotations.band1High).toBeUndefined();
+  });
+
+  it('toggles legend display based on comparisonActive', () => {
+    const optsInactive = computeOptions({ ...baseArgs, comparisonActive: false });
+    expect(optsInactive.plugins?.legend?.display).toBe(false);
+
+    const optsActive = computeOptions({ ...baseArgs, comparisonActive: true });
+    expect(optsActive.plugins?.legend?.display).toBe(true);
+  });
+});
+
+describe('computeYMax', () => {
+  const mockSweep: SweepPoint[] = [
+    { frequencyMHz: 7.0, R: 50, X: 0, swr: 1.5 },
+    { frequencyMHz: 7.1, R: 50, X: 0, swr: 1.8 },
+  ];
+
+  const mockReference: ComparisonSnapshot = {
+    antennaType: 'dipole',
+    height: 10,
+    sweep: [
+      { frequencyMHz: 7.0, R: 150, X: 0, swr: 2.5 },
+    ],
+  };
+
+  const baseArgs = {
+    sweep: mockSweep,
+    comparisonActive: false,
+    reference: null,
+    transformerInDisplay: false,
+    transformerRatio: 1,
+  };
+
+  it('returns default of 5 when sweeps are empty and no active reference', () => {
+    expect(computeYMax({ ...baseArgs, sweep: [] })).toBe(5);
+  });
+
+  it('calculates based on raw swr values when transformer is inactive', () => {
+    // Max SWR in mockSweep is 1.8.
+    // anyBelow2 = true.
+    // scaled = Math.max(3, Math.ceil(1.8 * 1.5)) = Math.max(3, Math.ceil(2.7)) = 3.
+    // Returns Math.min(999, 3) = 3.
+    expect(computeYMax(baseArgs)).toBe(3);
+  });
+
+  it('returns appropriate scaled yMax when values cross 2.0', () => {
+    const sweep = [
+      ...mockSweep,
+      { frequencyMHz: 7.2, R: 50, X: 0, swr: 4.0 }, // max
+    ];
+    // max SWR = 4.0. anyBelow2 = true (from mockSweep).
+    // scaled = Math.max(3, Math.ceil(4.0 * 1.5)) = Math.max(3, 6) = 6.
+    expect(computeYMax({ ...baseArgs, sweep })).toBe(6);
+  });
+
+  it('clips tight scale at SWR_CAP of 10 if bands are usable', () => {
+    const sweep = [
+      ...mockSweep, // has values below 2
+      { frequencyMHz: 7.2, R: 50, X: 0, swr: 20.0 }, // Huge spike
+    ];
+    // max SWR = 20. anyBelow2 = true.
+    // scaled = Math.ceil(20 * 1.5) = 30.
+    // capped at 10.
+    expect(computeYMax({ ...baseArgs, sweep })).toBe(10);
+  });
+
+  it('allows higher scales (no SWR_CAP) when no points are below 2', () => {
+    const sweep: SweepPoint[] = [
+      { frequencyMHz: 7.0, R: 50, X: 0, swr: 5.0 },
+      { frequencyMHz: 7.1, R: 50, X: 0, swr: 15.0 }, // max
+    ];
+    // maxVal = 15. anyBelow2 = false.
+    // returns Math.max(10, Math.min(15 * 1.1, 999))
+    // 15 * 1.1 = 16.5
+    expect(computeYMax({ ...baseArgs, sweep })).toBeCloseTo(16.5);
+  });
+
+  it('includes reference sweep max values when comparison is active', () => {
+    // mockSweep max is 1.8.
+    // mockReference max is 2.5.
+    // comparison is active, so combined max is 2.5. anyBelow2 is true.
+    // scaled = Math.max(3, Math.ceil(2.5 * 1.5)) = Math.max(3, 4) = 4.
+    expect(computeYMax({
+      ...baseArgs,
+      comparisonActive: true,
+      reference: mockReference,
+    })).toBe(4);
+  });
+
+  it('uses post-balun values when transformerInDisplay is true', () => {
+    const sweep: SweepPoint[] = [
+      // 200 Ohm vs 50. raw swr = 4.0
+      // with 4:1 balun, post-balun is 50 Ohm -> SWR 1.0
+      { frequencyMHz: 7.0, R: 200, X: 0, swr: 4.0 },
+      // 400 Ohm vs 50. raw swr = 8.0
+      // with 4:1 balun, post-balun is 100 Ohm -> SWR 2.0
+      { frequencyMHz: 7.1, R: 400, X: 0, swr: 8.0 },
+    ];
+
+    // Max raw SWR is 8.0.
+    // If it used raw SWR, scaled would be ceil(8.0 * 1.5) = 12 -> capped at 10.
+    // Post balun SWRs: 1.0, 2.0. Max post-balun = 2.0. anyBelow2 = true.
+    // scaled = Math.max(3, ceil(2.0 * 1.5)) = Math.max(3, 3) = 3.
+    expect(computeYMax({
+      ...baseArgs,
+      sweep,
+      transformerInDisplay: true,
+      transformerRatio: 4,
+    })).toBe(3);
+  });
+});
+
+describe('computeOptions callbacks', () => {
+  const baseArgs = {
+    frequency: 7.1,
+    accent: '#ff0000',
+    stats: null,
+    yMax: 5,
+    xBounds: { min: 6.9, max: 7.3 },
+    chartText: '#ffffff',
+    chartGrid: '#333333',
+    comparisonActive: false,
+  };
+
+  it('x-axis callback formats tick to 2 decimal places', () => {
+    const options = computeOptions(baseArgs);
+    const callback = options.scales?.x?.ticks?.callback as Function;
+    expect(callback).toBeDefined();
+
+    // Simulating chart.js tick callback
+    expect(callback(7.1234)).toBe('7.12');
+    expect(callback('7.5')).toBe('7.50');
   });
 });

--- a/tests/swrChartUtils.test.ts
+++ b/tests/swrChartUtils.test.ts
@@ -301,16 +301,16 @@ describe('computeOptions', () => {
     expect(options.scales?.x?.max).toBe(7.3);
 
     // Basic annotations should exist
-    const annotations = options.plugins?.annotation?.annotations as any;
+    const annotations = options.plugins?.annotation?.annotations as Record<string, { yMin?: number; xMin?: number }> | undefined;
     expect(annotations).toBeDefined();
-    expect(annotations.swr2).toBeDefined();
-    expect(annotations.swr2.yMin).toBe(2);
-    expect(annotations.currentFrequency).toBeDefined();
-    expect(annotations.currentFrequency.xMin).toBe(7.1);
+    expect(annotations?.swr2).toBeDefined();
+    expect(annotations?.swr2?.yMin).toBe(2);
+    expect(annotations?.currentFrequency).toBeDefined();
+    expect(annotations?.currentFrequency?.xMin).toBe(7.1);
 
     // No stats annotations
-    expect(annotations.minFreq).toBeUndefined();
-    expect(annotations.band0Low).toBeUndefined();
+    expect(annotations?.minFreq).toBeUndefined();
+    expect(annotations?.band0Low).toBeUndefined();
   });
 
   it('adds stats annotations when stats are provided', () => {
@@ -324,21 +324,21 @@ describe('computeOptions', () => {
     };
 
     const options = computeOptions({ ...baseArgs, stats });
-    const annotations = options.plugins?.annotation?.annotations as any;
+    const annotations = options.plugins?.annotation?.annotations as Record<string, { yMin?: number; xMin?: number }> | undefined;
 
     // Min freq line
-    expect(annotations.minFreq).toBeDefined();
-    expect(annotations.minFreq.xMin).toBe(7.15);
+    expect(annotations?.minFreq).toBeDefined();
+    expect(annotations?.minFreq?.xMin).toBe(7.15);
 
     // Unclipped band should have both edge markers
-    expect(annotations.band0Low).toBeDefined();
-    expect(annotations.band0Low.xMin).toBe(7.05);
-    expect(annotations.band0High).toBeDefined();
-    expect(annotations.band0High.xMin).toBe(7.25);
+    expect(annotations?.band0Low).toBeDefined();
+    expect(annotations?.band0Low?.xMin).toBe(7.05);
+    expect(annotations?.band0High).toBeDefined();
+    expect(annotations?.band0High?.xMin).toBe(7.25);
 
     // Clipped band should not have edge markers
-    expect(annotations.band1Low).toBeUndefined();
-    expect(annotations.band1High).toBeUndefined();
+    expect(annotations?.band1Low).toBeUndefined();
+    expect(annotations?.band1High).toBeUndefined();
   });
 
   it('toggles legend display based on comparisonActive', () => {
@@ -377,10 +377,6 @@ describe('computeYMax', () => {
   });
 
   it('calculates based on raw swr values when transformer is inactive', () => {
-    // Max SWR in mockSweep is 1.8.
-    // anyBelow2 = true.
-    // scaled = Math.max(3, Math.ceil(1.8 * 1.5)) = Math.max(3, Math.ceil(2.7)) = 3.
-    // Returns Math.min(999, 3) = 3.
     expect(computeYMax(baseArgs)).toBe(3);
   });
 
@@ -389,8 +385,6 @@ describe('computeYMax', () => {
       ...mockSweep,
       { frequencyMHz: 7.2, R: 50, X: 0, swr: 4.0 }, // max
     ];
-    // max SWR = 4.0. anyBelow2 = true (from mockSweep).
-    // scaled = Math.max(3, Math.ceil(4.0 * 1.5)) = Math.max(3, 6) = 6.
     expect(computeYMax({ ...baseArgs, sweep })).toBe(6);
   });
 
@@ -399,9 +393,6 @@ describe('computeYMax', () => {
       ...mockSweep, // has values below 2
       { frequencyMHz: 7.2, R: 50, X: 0, swr: 20.0 }, // Huge spike
     ];
-    // max SWR = 20. anyBelow2 = true.
-    // scaled = Math.ceil(20 * 1.5) = 30.
-    // capped at 10.
     expect(computeYMax({ ...baseArgs, sweep })).toBe(10);
   });
 
@@ -410,17 +401,10 @@ describe('computeYMax', () => {
       { frequencyMHz: 7.0, R: 50, X: 0, swr: 5.0 },
       { frequencyMHz: 7.1, R: 50, X: 0, swr: 15.0 }, // max
     ];
-    // maxVal = 15. anyBelow2 = false.
-    // returns Math.max(10, Math.min(15 * 1.1, 999))
-    // 15 * 1.1 = 16.5
     expect(computeYMax({ ...baseArgs, sweep })).toBeCloseTo(16.5);
   });
 
   it('includes reference sweep max values when comparison is active', () => {
-    // mockSweep max is 1.8.
-    // mockReference max is 2.5.
-    // comparison is active, so combined max is 2.5. anyBelow2 is true.
-    // scaled = Math.max(3, Math.ceil(2.5 * 1.5)) = Math.max(3, 4) = 4.
     expect(computeYMax({
       ...baseArgs,
       comparisonActive: true,
@@ -430,18 +414,10 @@ describe('computeYMax', () => {
 
   it('uses post-balun values when transformerInDisplay is true', () => {
     const sweep: SweepPoint[] = [
-      // 200 Ohm vs 50. raw swr = 4.0
-      // with 4:1 balun, post-balun is 50 Ohm -> SWR 1.0
       { frequencyMHz: 7.0, R: 200, X: 0, swr: 4.0 },
-      // 400 Ohm vs 50. raw swr = 8.0
-      // with 4:1 balun, post-balun is 100 Ohm -> SWR 2.0
       { frequencyMHz: 7.1, R: 400, X: 0, swr: 8.0 },
     ];
 
-    // Max raw SWR is 8.0.
-    // If it used raw SWR, scaled would be ceil(8.0 * 1.5) = 12 -> capped at 10.
-    // Post balun SWRs: 1.0, 2.0. Max post-balun = 2.0. anyBelow2 = true.
-    // scaled = Math.max(3, ceil(2.0 * 1.5)) = Math.max(3, 3) = 3.
     expect(computeYMax({
       ...baseArgs,
       sweep,
@@ -465,11 +441,13 @@ describe('computeOptions callbacks', () => {
 
   it('x-axis callback formats tick to 2 decimal places', () => {
     const options = computeOptions(baseArgs);
-    const callback = options.scales?.x?.ticks?.callback as Function;
+    const callback = options.scales?.x?.ticks?.callback as (value: number | string) => string;
     expect(callback).toBeDefined();
 
     // Simulating chart.js tick callback
-    expect(callback(7.1234)).toBe('7.12');
-    expect(callback('7.5')).toBe('7.50');
+    if (callback) {
+      expect(callback(7.1234)).toBe('7.12');
+      expect(callback('7.5')).toBe('7.50');
+    }
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,10 +9,10 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       thresholds: {
-        statements: 71.54,
-        branches: 63.8,
-        functions: 75.21,
-        lines: 94.83,
+        statements: 71.65,
+        branches: 63.96,
+        functions: 75.36,
+        lines: 94.93,
       }
     }
   },


### PR DESCRIPTION
🎯 **What:** Added missing test coverage for `computeOptions` and `computeYMax` functions in `src/components/Charts/swrChartUtils.ts`.
📊 **Coverage:** Covered baseline configurations, conditionals for scaling min/max arrays, legend toggling `comparisonActive`, max limits handling and annotation creation via `stats` arguments.
✨ **Result:** Increased `swrChartUtils.ts` line coverage up to 100% while raising global codebase coverage thresholds safely. Tests reliably cover configurations needed for SWR plotting.

---
*PR created automatically by Jules for task [17885129282240177585](https://jules.google.com/task/17885129282240177585) started by @2fst4u*