### PR TITLE
🧹 [Refactor FeedlineControl component for improved maintainability]

### DIFF
--- a/.jules/sweep.md
+++ b/.jules/sweep.md
@@ -50,3 +50,7 @@
 ## 2024-06-17 - Extract PolarPlotPanel to Reduce Component Complexity
 **Learning:** Large React components rendering multiple instances of heavily configured sub-components (like Chart.js instances) can obscure their core structure. Extracting these configurations into a stateless sub-component locally within the same file dramatically improves readability while preserving scope and minimizing hook overhead.
 **Action:** Refactored the `PolarPlots` component by extracting the repetitive Chart.js `<Radar />` setup into a local `PolarPlotPanel` sub-component.
+
+## 2024-06-17 - [Extract Component Details]
+**Learning:** Extracting component details into smaller subcomponents within the same file can help maintainability and readability without creating unnecessary files for localized components.
+**Action:** Extracted `<FeedlineOffsetControl>` and `<AtuControl>` into the same `src/components/Panel/FeedlineControl.tsx` file, and created a reusable `<StatRow>` component.

--- a/src/components/Panel/FeedlineControl.tsx
+++ b/src/components/Panel/FeedlineControl.tsx
@@ -12,6 +12,7 @@ import {
   displayLengthUnit,
 } from '../../physics/units';
 import type { AntennaType } from '../../physics/types';
+import { StatRow } from '../UI/StatRow';
 
 // vertical-whip is intentionally excluded — this panel does not apply to it
 const SUPPORTED_ANTENNA_TYPES: ReadonlySet<AntennaType> = new Set([
@@ -77,16 +78,7 @@ export function FeedlineControl() {
     }
   }
 
-  const dispMainLen = toDisplayLength(atuMainFeedlineLength, units);
-  const [localMainLen, setLocalMainLen] = useState(dispMainLen.toFixed(2));
-  const [mainFocused, setMainFocused] = useState(false);
-  const [prevDispMainLen, setPrevDispMainLen] = useState(dispMainLen);
-  if (dispMainLen !== prevDispMainLen) {
-    setPrevDispMainLen(dispMainLen);
-    if (!mainFocused) {
-      setLocalMainLen(dispMainLen.toFixed(2));
-    }
-  }
+
 
   if (!SUPPORTED_ANTENNA_TYPES.has(antennaType)) return null;
 
@@ -142,103 +134,177 @@ export function FeedlineControl() {
           />
 
           {antennaType === 'dipole' && (
-            <>
-              <label htmlFor="feedline-offset" style={{ marginTop: 10 }}>
-                Attachment offset from centre ({unit}) — {dispOffset.toFixed(2)}
-              </label>
-              <div className="row">
-                <input
-                  id="feedline-offset"
-                  type="range"
-                  min={-dispOffsetLimit}
-                  max={dispOffsetLimit}
-                  step={units === 'metric' ? 0.05 : 0.25}
-                  value={dispOffset}
-                  aria-label="Feedline attachment offset"
-                  aria-describedby="feedline-offset-hint"
-                  onChange={(e) => {
-                    const val = parseFloat(e.target.value);
-                    if (!isNaN(val)) setFeedlineOffset(fromDisplayLength(val, units));
-                  }}
-                />
-                <button
-                  onClick={() => setFeedlineOffset(0)}
-                  disabled={Math.abs(feedlineOffset) < 1e-6}
-                  title={Math.abs(feedlineOffset) < 1e-6 ? 'Feedpoint is already centred' : 'Centre feedpoint'}
-                  aria-label="Centre feedpoint offset"
-                  style={{ flex: '0 0 auto' }}
-                >
-                  Centre
-                </button>
-              </div>
-              <div id="feedline-offset-hint" aria-live="polite" style={{ marginTop: 4, fontSize: 11, color: 'var(--text-muted)' }}>
-                {Math.abs(feedlineOffset) < 1e-6
-                  ? 'Centred (perfectly balanced — no common-mode current).'
-                  : `Shifted ${Math.abs(dispOffset).toFixed(2)} ${unit} ${feedlineOffset > 0 ? '+ axis' : '− axis'}; common-mode current will flow on the shield.`}
-              </div>
-            </>
+            <FeedlineOffsetControl
+              units={units}
+              unit={unit}
+              dispOffset={dispOffset}
+              dispOffsetLimit={dispOffsetLimit}
+              feedlineOffset={feedlineOffset}
+              setFeedlineOffset={setFeedlineOffset}
+            />
           )}
 
-          <div className="stat" style={{ marginTop: 10 }}>
-            <span className="stat-label">Z₀ / VF</span>
-            <span className="stat-value">{preset.z0.toFixed(0)} Ω · {preset.velocityFactor.toFixed(2)}</span>
-          </div>
-          <div className="stat">
-            <span className="stat-label">Cable loss @ {frequency.toFixed(2)} MHz</span>
-            <span className="stat-value">{lossDb.toFixed(2)} dB</span>
-          </div>
+          <StatRow
+            style={{ marginTop: 10 }}
+            label="Z₀ / VF"
+            value={`${preset.z0.toFixed(0)} Ω · ${preset.velocityFactor.toFixed(2)}`}
+          />
+          <StatRow
+            label={`Cable loss @ ${frequency.toFixed(2)} MHz`}
+            value={`${lossDb.toFixed(2)} dB`}
+          />
 
-          <div style={{ marginTop: 12, borderTop: '1px solid var(--border)', paddingTop: 10 }}>
-            <label
-              htmlFor="atu-enable"
-              style={{ display: 'flex', alignItems: 'center', gap: 6, textTransform: 'none', letterSpacing: 0, margin: 0, fontSize: 12 }}
-            >
-              <input
-                id="atu-enable"
-                type="checkbox"
-                checked={atuEnabled}
-                onChange={(e) => setAtuEnabled(e.target.checked)}
-              />
-              ATU at the base of the mast
-            </label>
-
-            {atuEnabled && (
-              <>
-                <label htmlFor="atu-main-length" style={{ marginTop: 10 }}>
-                  Main run, ATU → shack ({unit})
-                </label>
-                <input
-                  id="atu-main-length"
-                  type="number"
-                  min={0}
-                  max={units === 'metric' ? 300 : 984}
-                  step={units === 'metric' ? 0.5 : 1}
-                  value={localMainLen}
-                  aria-describedby="atu-hint"
-                  onFocus={() => setMainFocused(true)}
-                  onChange={(e) => {
-                    const s = e.target.value;
-                    setLocalMainLen(s);
-                    const val = parseFloat(s);
-                    if (!isNaN(val)) setAtuMainFeedlineLength(fromDisplayLength(val, units));
-                  }}
-                  onBlur={() => {
-                    setMainFocused(false);
-                    setLocalMainLen(dispMainLen.toFixed(2));
-                  }}
-                />
-                <div id="atu-hint" aria-live="polite" style={{ marginTop: 6, fontSize: 11, color: 'var(--text-muted)', lineHeight: 1.4 }}>
-                  The feedline above becomes the short up-mast run (carries the antenna's native SWR);
-                  the tuner conjugate-matches at the base, so this main run to the shack stays ~1:1
-                  (matched loss {mainRunLossDb.toFixed(2)} dB). Realized gain keeps the up-mast loss
-                  under SWR, this main-run loss, and a Q-based tuner loss — but a tuner cannot recover
-                  ohmic/termination (efficiency) loss.
-                </div>
-              </>
-            )}
-          </div>
+          <AtuControl
+            units={units}
+            unit={unit}
+            atuEnabled={atuEnabled}
+            setAtuEnabled={setAtuEnabled}
+            atuMainFeedlineLength={atuMainFeedlineLength}
+            setAtuMainFeedlineLength={setAtuMainFeedlineLength}
+            mainRunLossDb={mainRunLossDb}
+          />
         </>
       )}
     </section>
+  );
+}
+
+interface FeedlineOffsetControlProps {
+  units: 'metric' | 'imperial';
+  unit: string;
+  dispOffset: number;
+  dispOffsetLimit: number;
+  feedlineOffset: number;
+  setFeedlineOffset: (offset: number) => void;
+}
+
+function FeedlineOffsetControl({
+  units,
+  unit,
+  dispOffset,
+  dispOffsetLimit,
+  feedlineOffset,
+  setFeedlineOffset,
+}: FeedlineOffsetControlProps) {
+  return (
+    <>
+      <label htmlFor="feedline-offset" style={{ marginTop: 10 }}>
+        Attachment offset from centre ({unit}) — {dispOffset.toFixed(2)}
+      </label>
+      <div className="row">
+        <input
+          id="feedline-offset"
+          type="range"
+          min={-dispOffsetLimit}
+          max={dispOffsetLimit}
+          step={units === 'metric' ? 0.05 : 0.25}
+          value={dispOffset}
+          aria-label="Feedline attachment offset"
+          aria-describedby="feedline-offset-hint"
+          onChange={(e) => {
+            const val = parseFloat(e.target.value);
+            if (!isNaN(val)) setFeedlineOffset(fromDisplayLength(val, units));
+          }}
+        />
+        <button
+          onClick={() => setFeedlineOffset(0)}
+          disabled={Math.abs(feedlineOffset) < 1e-6}
+          title={Math.abs(feedlineOffset) < 1e-6 ? 'Feedpoint is already centred' : 'Centre feedpoint'}
+          aria-label="Centre feedpoint offset"
+          style={{ flex: '0 0 auto' }}
+        >
+          Centre
+        </button>
+      </div>
+      <div id="feedline-offset-hint" aria-live="polite" style={{ marginTop: 4, fontSize: 11, color: 'var(--text-muted)' }}>
+        {Math.abs(feedlineOffset) < 1e-6
+          ? 'Centred (perfectly balanced — no common-mode current).'
+          : `Shifted ${Math.abs(dispOffset).toFixed(2)} ${unit} ${feedlineOffset > 0 ? '+ axis' : '− axis'}; common-mode current will flow on the shield.`}
+      </div>
+    </>
+  );
+}
+
+interface AtuControlProps {
+  units: 'metric' | 'imperial';
+  unit: string;
+  atuEnabled: boolean;
+  setAtuEnabled: (enabled: boolean) => void;
+  atuMainFeedlineLength: number;
+  setAtuMainFeedlineLength: (length: number) => void;
+  mainRunLossDb: number;
+}
+
+function AtuControl({
+  units,
+  unit,
+  atuEnabled,
+  setAtuEnabled,
+  atuMainFeedlineLength,
+  setAtuMainFeedlineLength,
+  mainRunLossDb,
+}: AtuControlProps) {
+  const dispMainLen = toDisplayLength(atuMainFeedlineLength, units);
+  const [localMainLen, setLocalMainLen] = useState(dispMainLen.toFixed(2));
+  const [mainFocused, setMainFocused] = useState(false);
+  const [prevDispMainLen, setPrevDispMainLen] = useState(dispMainLen);
+
+  if (dispMainLen !== prevDispMainLen) {
+    setPrevDispMainLen(dispMainLen);
+    if (!mainFocused) {
+      setLocalMainLen(dispMainLen.toFixed(2));
+    }
+  }
+
+  return (
+    <div style={{ marginTop: 12, borderTop: '1px solid var(--border)', paddingTop: 10 }}>
+      <label
+        htmlFor="atu-enable"
+        style={{ display: 'flex', alignItems: 'center', gap: 6, textTransform: 'none', letterSpacing: 0, margin: 0, fontSize: 12 }}
+      >
+        <input
+          id="atu-enable"
+          type="checkbox"
+          checked={atuEnabled}
+          onChange={(e) => setAtuEnabled(e.target.checked)}
+        />
+        ATU at the base of the mast
+      </label>
+
+      {atuEnabled && (
+        <>
+          <label htmlFor="atu-main-length" style={{ marginTop: 10 }}>
+            Main run, ATU → shack ({unit})
+          </label>
+          <input
+            id="atu-main-length"
+            type="number"
+            min={0}
+            max={units === 'metric' ? 300 : 984}
+            step={units === 'metric' ? 0.5 : 1}
+            value={localMainLen}
+            aria-describedby="atu-hint"
+            onFocus={() => setMainFocused(true)}
+            onChange={(e) => {
+              const s = e.target.value;
+              setLocalMainLen(s);
+              const val = parseFloat(s);
+              if (!isNaN(val)) setAtuMainFeedlineLength(fromDisplayLength(val, units));
+            }}
+            onBlur={() => {
+              setMainFocused(false);
+              setLocalMainLen(dispMainLen.toFixed(2));
+            }}
+          />
+          <div id="atu-hint" aria-live="polite" style={{ marginTop: 6, fontSize: 11, color: 'var(--text-muted)', lineHeight: 1.4 }}>
+            The feedline above becomes the short up-mast run (carries the antenna's native SWR);
+            the tuner conjugate-matches at the base, so this main run to the shack stays ~1:1
+            (matched loss {mainRunLossDb.toFixed(2)} dB). Realized gain keeps the up-mast loss
+            under SWR, this main-run loss, and a Q-based tuner loss — but a tuner cannot recover
+            ohmic/termination (efficiency) loss.
+          </div>
+        </>
+      )}
+    </div>
   );
 }

--- a/src/components/Panel/FeedlineControl.tsx
+++ b/src/components/Panel/FeedlineControl.tsx
@@ -78,8 +78,6 @@ export function FeedlineControl() {
     }
   }
 
-
-
   if (!SUPPORTED_ANTENNA_TYPES.has(antennaType)) return null;
 
   const offsetLimit = Math.max(0, dipoleLength / 2 - 0.05);

--- a/src/components/UI/StatRow.tsx
+++ b/src/components/UI/StatRow.tsx
@@ -4,6 +4,7 @@ export interface StatRowProps {
   label: ReactNode;
   value: ReactNode;
   title?: string;
+  labelClassName?: string;
   valueClassName?: string;
   style?: CSSProperties;
   labelStyle?: CSSProperties;
@@ -14,6 +15,7 @@ export function StatRow({
   label,
   value,
   title,
+  labelClassName = 'stat-label',
   valueClassName = 'stat-value',
   style,
   labelStyle,
@@ -21,7 +23,7 @@ export function StatRow({
 }: StatRowProps) {
   return (
     <div className="stat" style={style} title={title}>
-      <span className="stat-label" style={labelStyle}>
+      <span className={labelClassName} style={labelStyle}>
         {label}
       </span>
       <span className={valueClassName} style={valueStyle}>

--- a/src/components/UI/StatRow.tsx
+++ b/src/components/UI/StatRow.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+export interface StatRowProps {
+  label: React.ReactNode;
+  value: React.ReactNode;
+  title?: string;
+  valueClassName?: string;
+  style?: React.CSSProperties;
+  labelStyle?: React.CSSProperties;
+  valueStyle?: React.CSSProperties;
+}
+
+export function StatRow({
+  label,
+  value,
+  title,
+  valueClassName = 'stat-value',
+  style,
+  labelStyle,
+  valueStyle,
+}: StatRowProps) {
+  return (
+    <div className="stat" style={style} title={title}>
+      <span className="stat-label" style={labelStyle}>
+        {label}
+      </span>
+      <span className={valueClassName} style={valueStyle}>
+        {value}
+      </span>
+    </div>
+  );
+}

--- a/src/components/UI/StatRow.tsx
+++ b/src/components/UI/StatRow.tsx
@@ -1,13 +1,13 @@
-import React from 'react';
+import type { CSSProperties, ReactNode } from 'react';
 
 export interface StatRowProps {
-  label: React.ReactNode;
-  value: React.ReactNode;
+  label: ReactNode;
+  value: ReactNode;
   title?: string;
   valueClassName?: string;
-  style?: React.CSSProperties;
-  labelStyle?: React.CSSProperties;
-  valueStyle?: React.CSSProperties;
+  style?: CSSProperties;
+  labelStyle?: CSSProperties;
+  valueStyle?: CSSProperties;
 }
 
 export function StatRow({


### PR DESCRIPTION
🎯 **What:** The `FeedlineControl` component was refactored. The complex monolithic function was split into three pieces: a main `FeedlineControl` component, a `FeedlineOffsetControl` subcomponent for dipole specific rendering, and an `AtuControl` subcomponent. A reusable `StatRow` component was also introduced to replace repeated `div.stat` blocks.
💡 **Why:** `FeedlineControl` was becoming large and hard to maintain. Extracting subcomponents encapsulates localized logic and state, reducing hook allocation overhead and improving overall readability and code organization.
✅ **Verification:** Verified by running the entire test suite `npm run test -- --run` and linter `npm run lint`. All tests continue to pass and no visual/functional change was introduced.
✨ **Result:** A more robust, composable `FeedlineControl` component structure and a reusable `StatRow` UI component.

---
*PR created automatically by Jules for task [15073176913213593668](https://jules.google.com/task/15073176913213593668) started by @2fst4u*