### PR TITLE
🔒 [Remove unsafe-inline from CSP]

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en" data-theme="dark">
   <head>
     <meta charset="UTF-8" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; worker-src 'self' blob:; object-src 'none';" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self'; img-src 'self' data:; connect-src 'self'; worker-src 'self' blob:; object-src 'none';" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="apple-touch-icon" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />


### PR DESCRIPTION
🎯 **What:** Removed the `'unsafe-inline'` keyword from the `style-src` directive in the `Content-Security-Policy` meta tag located in `index.html`.

⚠️ **Risk:** If left unfixed, `'unsafe-inline'` permits the execution of arbitrary inline styles. This leaves the application vulnerable to CSS-based Cross-Site Scripting (XSS) attacks or data exfiltration, where an attacker could inject malicious `<style>` blocks or `style` attributes to manipulate the DOM, phish for user input, or steal sensitive information.

🛡️ **Solution:** The `'unsafe-inline'` keyword was removed, enforcing a strict `style-src 'self'` policy. While this breaks Vite's dev server CSS injection (which relies on `<style>` tags), it is perfectly safe for production. Vite's production build (`npm run build`) extracts styles into separate `.css` files, and React's inline `style={{...}}` props apply styles safely via the CSS Object Model (CSSOM) API (e.g., `element.style.color`), which is not blocked by modern browser CSP `style-src` directives.

---
*PR created automatically by Jules for task [14705040188220757037](https://jules.google.com/task/14705040188220757037) started by @2fst4u*