### PR TITLE
Replace SWR auto-zoom with manual zoom/pan and on-demand resampling

### DIFF
--- a/src/components/Charts/SWRChart.tsx
+++ b/src/components/Charts/SWRChart.tsx
@@ -11,12 +11,11 @@ import {
   Filler,
 } from 'chart.js';
 import annotationPlugin from 'chartjs-plugin-annotation';
-import { useAntennaStore } from '../../store/antennaStore';
+import { useAntennaStore, selectSwrWindow } from '../../store/antennaStore';
 import { useShallow } from 'zustand/react/shallow';
-import { useMemo } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   computeChartData,
-  computeXBounds,
   computeStats,
   computeYMax,
   computeOptions,
@@ -49,6 +48,8 @@ export function SWRChart() {
     transformerEnabled,
     transformerRatio,
     feedlineId,
+    swrViewCenterMHz,
+    swrViewSpanMHz,
   } = useAntennaStore(useShallow((s) => ({
     result: s.result,
     sweep: s.sweep,
@@ -59,6 +60,8 @@ export function SWRChart() {
     transformerEnabled: s.transformerEnabled,
     transformerRatio: s.transformerRatio,
     feedlineId: s.feedlineId,
+    swrViewCenterMHz: s.swrViewCenterMHz,
+    swrViewSpanMHz: s.swrViewSpanMHz,
   })));
 
   // Transformer location:
@@ -91,9 +94,15 @@ export function SWRChart() {
     [accent, comparisonActive, currentFill, reference, referenceFill, sweep, transformerInDisplay, transformerRatio]
   );
 
+  // X bounds come straight from the user-controlled view window — there is no
+  // auto-zoom. The sweep is sampled across exactly this range, so the curve
+  // always fills the plot at the current zoom/pan.
   const xBounds = useMemo(
-    () => computeXBounds({ sweep, comparisonActive, reference, frequency }),
-    [comparisonActive, frequency, reference, sweep]
+    () => {
+      const { startMHz, endMHz } = selectSwrWindow({ swrViewCenterMHz, swrViewSpanMHz });
+      return { min: startMHz, max: endMHz };
+    },
+    [swrViewCenterMHz, swrViewSpanMHz]
   );
 
   const stats = useMemo(
@@ -128,6 +137,8 @@ export function SWRChart() {
     [accent, chartGrid, chartText, comparisonActive, frequency, xBounds, yMax, stats]
   );
 
+  const { wrapperRef, chartRef, onPointerDown, dragging } = useSwrViewGestures();
+
   if (!result || sweep.length === 0) {
     return (
       <section className="panel-section" style={{ minHeight: 220 }}>
@@ -144,11 +155,110 @@ export function SWRChart() {
     <section className="panel-section" style={{ minHeight: 220 }}>
       {/* SEO: Use sequential heading tags (H2) to follow document outline initiated by H1 */}
       <h2>SWR sweep</h2>
-      <div style={{ height: 130 }}>
-        <Line data={data} options={options} />
+      <div
+        ref={wrapperRef}
+        onPointerDown={onPointerDown}
+        style={{ height: 130, touchAction: 'none', cursor: dragging ? 'grabbing' : 'grab' }}
+      >
+        <Line ref={chartRef} data={data} options={options} />
       </div>
+      <SWRZoomControls />
       {stats && <SWRChartStats stats={stats} />}
     </section>
+  );
+}
+
+/**
+ * Wheel-to-zoom (centred on the cursor frequency) and drag-to-pan for the SWR
+ * chart. Both update the store's view window, which re-samples the sweep over
+ * the new range — so zooming in reveals finer detail rather than upscaling a
+ * fixed dataset.
+ */
+function useSwrViewGestures() {
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
+  const chartRef = useRef<ChartJS<'line'> | null>(null);
+  const dragRef = useRef<{ startX: number; mhzPerPixel: number; startCenter: number } | null>(null);
+  const [dragging, setDragging] = useState(false);
+
+  const zoomSwrView = useAntennaStore((s) => s.zoomSwrView);
+  const panSwrViewByMHz = useAntennaStore((s) => s.panSwrViewByMHz);
+
+  // Non-passive wheel listener so we can preventDefault and stop the panel
+  // scrolling while zooming the chart.
+  useEffect(() => {
+    const el = wrapperRef.current;
+    if (!el) return;
+    const onWheel = (e: WheelEvent) => {
+      const chart = chartRef.current;
+      if (!chart) return;
+      e.preventDefault();
+      const rect = chart.canvas.getBoundingClientRect();
+      const xScale = chart.scales.x;
+      const pivot = xScale ? Number(xScale.getValueForPixel(e.clientX - rect.left)) : undefined;
+      // Wheel up (deltaY < 0) zooms in (narrower span).
+      const factor = e.deltaY < 0 ? 0.85 : 1 / 0.85;
+      zoomSwrView(factor, Number.isFinite(pivot) ? pivot : undefined);
+    };
+    el.addEventListener('wheel', onWheel, { passive: false });
+    return () => el.removeEventListener('wheel', onWheel);
+  }, [zoomSwrView]);
+
+  const onPointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (e.button !== 0) return; // primary button only
+    const chart = chartRef.current;
+    if (!chart || !chart.chartArea) return;
+    const span = useAntennaStore.getState().swrViewSpanMHz;
+    const width = chart.chartArea.right - chart.chartArea.left;
+    if (width <= 0) return;
+    // Capture a fixed reference frame at grab time so panning maps pixel travel
+    // to MHz against the pre-drag scale (avoids feedback as the axis shifts).
+    dragRef.current = {
+      startX: e.clientX,
+      mhzPerPixel: span / width,
+      startCenter: useAntennaStore.getState().swrViewCenterMHz,
+    };
+    setDragging(true);
+
+    const onMove = (ev: PointerEvent) => {
+      const drag = dragRef.current;
+      if (!drag) return;
+      const deltaMHz = -(ev.clientX - drag.startX) * drag.mhzPerPixel;
+      const targetCenter = drag.startCenter + deltaMHz;
+      panSwrViewByMHz(targetCenter - useAntennaStore.getState().swrViewCenterMHz);
+    };
+    const onUp = () => {
+      dragRef.current = null;
+      setDragging(false);
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onUp);
+    };
+    window.addEventListener('pointermove', onMove);
+    window.addEventListener('pointerup', onUp);
+  };
+
+  return { wrapperRef, chartRef, onPointerDown, dragging };
+}
+
+function SWRZoomControls() {
+  const { zoomSwrView, panSwrView, resetSwrView } = useAntennaStore(useShallow((s) => ({
+    zoomSwrView: s.zoomSwrView,
+    panSwrView: s.panSwrView,
+    resetSwrView: s.resetSwrView,
+  })));
+
+  return (
+    <div
+      className="button-group"
+      role="group"
+      aria-label="SWR chart zoom and pan"
+      style={{ marginTop: 8, justifyContent: 'center' }}
+    >
+      <button type="button" onClick={() => panSwrView(-0.3)} title="Pan left (lower frequency)" aria-label="Pan to lower frequency">◀</button>
+      <button type="button" onClick={() => zoomSwrView(1 / 0.6)} title="Zoom out (wider span)" aria-label="Zoom out">−</button>
+      <button type="button" onClick={resetSwrView} title="Reset zoom to default around the operating frequency" aria-label="Reset zoom">⟳</button>
+      <button type="button" onClick={() => zoomSwrView(0.6)} title="Zoom in (narrower span)" aria-label="Zoom in">+</button>
+      <button type="button" onClick={() => panSwrView(0.3)} title="Pan right (higher frequency)" aria-label="Pan to higher frequency">▶</button>
+    </div>
   );
 }
 

--- a/src/components/Charts/swrChartUtils.ts
+++ b/src/components/Charts/swrChartUtils.ts
@@ -123,38 +123,6 @@ export function computeChartData({
   return { datasets };
 }
 
-export interface ComputeXBoundsArgs {
-  sweep: readonly SweepPoint[];
-  comparisonActive: boolean;
-  reference: ComparisonSnapshot | null;
-  frequency: number;
-}
-
-export function computeXBounds({ sweep, comparisonActive, reference, frequency }: ComputeXBoundsArgs) {
-  if (sweep.length === 0 && (!comparisonActive || !reference || reference.sweep.length === 0)) {
-    return { min: frequency * 0.95, max: frequency * 1.05 };
-  }
-
-  let min = Infinity;
-  let max = -Infinity;
-
-  for (let i = 0; i < sweep.length; i++) {
-    const freq = sweep[i].frequencyMHz;
-    if (freq < min) min = freq;
-    if (freq > max) max = freq;
-  }
-
-  if (comparisonActive && reference) {
-    for (let i = 0; i < reference.sweep.length; i++) {
-      const freq = reference.sweep[i].frequencyMHz;
-      if (freq < min) min = freq;
-      if (freq > max) max = freq;
-    }
-  }
-
-  return { min, max };
-}
-
 export interface SWRStats {
   minSWR: number;
   minFreq: number;
@@ -230,7 +198,6 @@ export function computeYMax({
   }
 
   let maxVal = -Infinity;
-  let anyBelow2 = false;
 
   for (let i = 0; i < sweep.length; i++) {
     // When the transformer is active we only render the post-balun curve,
@@ -240,11 +207,9 @@ export function computeYMax({
     if (transformerInDisplay) {
       const v2 = computeSwr({ R: sweep[i].R / transformerRatio, X: sweep[i].X / transformerRatio });
       if (v2 > maxVal) maxVal = v2;
-      if (v2 <= 2) anyBelow2 = true;
     } else {
       const v = sweep[i].swr;
       if (v > maxVal) maxVal = v;
-      if (v <= 2) anyBelow2 = true;
     }
   }
 
@@ -252,27 +217,26 @@ export function computeYMax({
     for (let i = 0; i < reference.sweep.length; i++) {
       const v = reference.sweep[i].swr;
       if (v > maxVal) maxVal = v;
-      if (v <= 2) anyBelow2 = true;
     }
   }
 
   if (maxVal === -Infinity) return 5;
 
-  if (!anyBelow2) {
-    return Math.max(10, Math.min(maxVal * 1.1, 999));
-  }
-
-  // Usable bands are present. Scale tightly around the actual data:
+  // The y-axis is a FIXED reference frame — it never zooms vertically. Only the
+  // lateral (frequency) axis is user-controllable, so the y-scale must stay
+  // stable as the user pans/zooms across the sweep. Very high SWR is clipped at
+  // SWR_CAP: its exact magnitude is irrelevant, all that matters is where the
+  // curve sits at the low (well-matched) values.
   //
-  //  • 1.2× multiplier leaves ~17 % headroom above the highest SWR point.
+  //  • 1.5× multiplier leaves headroom above the highest in-frame SWR point.
   //  • Floor of 3 keeps the 2:1 reference line visible (≥ 33 % of chart height)
   //    even when the antenna is extremely well-matched.
-  //  • Cap of 10 prevents inter-band spikes (20–50:1) from compressing
-  //    the in-band region to an invisible sliver; values above the cap
-  //    are clipped at the top — a clear "very high SWR here" signal.
+  //  • Cap of 10 prevents tall spikes (20–50:1, or an all-mismatched window)
+  //    from compressing the low-SWR region to an invisible sliver; values
+  //    above the cap are clipped at the top — a clear "very high SWR" signal.
   const SWR_CAP = 10;
   const scaled = Math.max(3, Math.ceil(maxVal * 1.5));
-  return Math.min(Math.min(999, scaled), SWR_CAP);
+  return Math.min(scaled, SWR_CAP);
 }
 
 export interface ComputeOptionsArgs {

--- a/src/hooks/usePhysicsEngine.ts
+++ b/src/hooks/usePhysicsEngine.ts
@@ -3,7 +3,7 @@
 
 import { useEffect, useRef } from 'react';
 import type { WorkerRequest, WorkerResponse } from '../workers/physicsWorker';
-import { useAntennaStore, selectSimulationInput } from '../store/antennaStore';
+import { useAntennaStore, selectSimulationInput, selectSwrWindow } from '../store/antennaStore';
 import type { SimulationResult } from '../physics/types';
 import { detectLODLevel, LOD_TABLE } from './useAdaptiveLOD';
 
@@ -38,7 +38,14 @@ export function usePhysicsEngine(opts: UsePhysicsEngineOptions = {}): void {
   const workerRef = useRef<Worker | null>(null);
   const nextIdRef = useRef(0);
   const latestIdRef = useRef(0);
+  // True while a full simulate is in flight. Used to upgrade a sweep-only
+  // (zoom/pan) request to a full one when a pattern solve hasn't landed yet,
+  // so the in-flight pattern result isn't discarded as stale.
+  const fullPendingRef = useRef(false);
   const timerRef = useRef<number | null>(null);
+  // Highest-priority work requested during the current debounce window:
+  // 'full' (geometry/frequency changed) wins over 'sweep' (view window only).
+  const pendingKindRef = useRef<'full' | 'sweep' | null>(null);
 
   useEffect(() => {
     // Vite handles this URL pattern natively for workers.
@@ -54,12 +61,17 @@ export function usePhysicsEngine(opts: UsePhysicsEngineOptions = {}): void {
       // Discard stale results: only the latest request's response is accepted.
       if (msg.type === 'result') {
         if (msg.id !== latestIdRef.current) return;
+        fullPendingRef.current = false;
         useAntennaStore.getState()._setSimulationData(
           msg.result as SimulationResult,
           msg.sweep,
         );
+      } else if (msg.type === 'sweep') {
+        if (msg.id !== latestIdRef.current) return;
+        useAntennaStore.getState()._setSweep(msg.sweep);
       } else if (msg.type === 'error') {
         if (msg.id !== latestIdRef.current && msg.id !== -1) return;
+        fullPendingRef.current = false;
         useAntennaStore.getState()._setError(msg.message);
       }
     };
@@ -87,54 +99,87 @@ export function usePhysicsEngine(opts: UsePhysicsEngineOptions = {}): void {
 
   // Subscribe to input-relevant slices of state so we only trigger on real changes.
   useEffect(() => {
-    const schedule = () => {
-      if (timerRef.current !== null) window.clearTimeout(timerRef.current);
-      timerRef.current = window.setTimeout(() => {
-        const worker = workerRef.current;
-        if (!worker) return;
-        const state = useAntennaStore.getState();
-        // Override the store's hardcoded pattern resolution with the
-        // LOD-appropriate one: coarser on slow devices → fewer NEC-2 RP
-        // evaluations → significantly faster solve on low-power hardware.
-        const input = {
-          ...selectSimulationInput(state),
-          patternResolution: LOD_CONFIG.patternResolution,
-        };
-        const id = ++nextIdRef.current;
-        latestIdRef.current = id;
-        state._setLoading(true);
+    const flush = () => {
+      const worker = workerRef.current;
+      if (!worker) return;
+      const requested = pendingKindRef.current ?? 'full';
+      pendingKindRef.current = null;
+      const state = useAntennaStore.getState();
+      // Override the store's hardcoded pattern resolution with the
+      // LOD-appropriate one: coarser on slow devices → fewer NEC-2 RP
+      // evaluations → significantly faster solve on low-power hardware.
+      const input = {
+        ...selectSimulationInput(state),
+        patternResolution: LOD_CONFIG.patternResolution,
+      };
+      const window = selectSwrWindow(state);
+      const displayRatio = displayTransformerRatio(state);
+      const id = ++nextIdRef.current;
+      latestIdRef.current = id;
+      state._setLoading(true);
+
+      // Only the view window changed → re-sweep alone, but upgrade to a full
+      // solve if a pattern result is still pending (otherwise it would be
+      // discarded as stale, leaving the radiation pattern out of date).
+      const kind = requested === 'sweep' && !fullPendingRef.current ? 'sweep' : 'full';
+      if (kind === 'sweep') {
         const msg: WorkerRequest = {
           id,
-          type: 'simulate',
+          type: 'sweep',
           input,
-          displayRatio: displayTransformerRatio(state),
+          displayRatio,
           sweepPoints: LOD_CONFIG.sweepPoints,
-          charPoints: LOD_CONFIG.charPoints,
-          maxAdaptiveIter: LOD_CONFIG.maxAdaptiveIter,
-          skipBroadScan: LOD_CONFIG.skipBroadScan,
+          window,
         };
         worker.postMessage(msg);
-      }, debounceMs);
+        return;
+      }
+
+      fullPendingRef.current = true;
+      const msg: WorkerRequest = {
+        id,
+        type: 'simulate',
+        input,
+        displayRatio,
+        sweepPoints: LOD_CONFIG.sweepPoints,
+        window,
+      };
+      worker.postMessage(msg);
     };
 
-    // Initial run.
-    schedule();
+    const schedule = (kind: 'full' | 'sweep') => {
+      // 'full' always wins over a pending 'sweep' in the same debounce window.
+      if (kind === 'full' || pendingKindRef.current === null) {
+        pendingKindRef.current = kind;
+      }
+      if (timerRef.current !== null) window.clearTimeout(timerRef.current);
+      timerRef.current = window.setTimeout(flush, debounceMs);
+    };
+
+    // Initial run (full solve).
+    schedule('full');
 
     const unsub = useAntennaStore.subscribe((state, prev) => {
-      // Re-run only when something affecting the simulation changed.
+      // Re-run a full solve when something affecting the NEC simulation changed.
       // JSON.stringify is intentional: selectSimulationInput returns freshly-allocated
       // arrays and object literals on every call, so shallow reference equality (Object.keys
       // + !==) would always fire. At ~3μs per call and ≤100 events/s this is negligible.
       const a = selectSimulationInput(state);
       const b = selectSimulationInput(prev);
-      // Also re-sweep when the display-only balun ratio changes: it doesn't
-      // alter the NEC input but it does change the SWR curve the adaptive
-      // sweep frames its window around.
+      // Also re-solve when the display-only balun ratio changes: it doesn't
+      // alter the NEC input but it does change the SWR curve the user sees.
       if (
         JSON.stringify(a) !== JSON.stringify(b) ||
         displayTransformerRatio(state) !== displayTransformerRatio(prev)
       ) {
-        schedule();
+        schedule('full');
+        return;
+      }
+      // Only the SWR view window changed (zoom/pan) → cheap sweep-only recompute.
+      const w = selectSwrWindow(state);
+      const pw = selectSwrWindow(prev);
+      if (w.startMHz !== pw.startMHz || w.endMHz !== pw.endMHz) {
+        schedule('sweep');
       }
     });
 

--- a/src/physics/nec2Engine.ts
+++ b/src/physics/nec2Engine.ts
@@ -103,6 +103,14 @@ export interface SweepOptions {
    * fills the chart for both narrowband and broadband antennas.
    */
   spanFraction?: number;
+  /**
+   * Explicit absolute frequency window [startMHz, endMHz]. Takes precedence
+   * over `spanFraction` and the adaptive framing. Used by the interactive
+   * zoom/pan SWR view: the sweep samples exactly this window so zooming in
+   * resamples a narrower span at full point density (efficient recompute).
+   * Clamped to the engine's HF sweep limits.
+   */
+  window?: { startMHz: number; endMHz: number };
   /** Number of sample points across the (final) sweep. Default 15. */
   points?: number;
   /**
@@ -305,6 +313,16 @@ export class Nec2Engine implements Engine {
 
   async sweepImpedance(input: SimulationInput, opts: SweepOptions = {}): Promise<SweepPoint[]> {
     const points = Math.max(3, Math.round(opts.points ?? 15));
+    // Explicit window → fixed single-pass sweep over exactly that range. This
+    // is the interactive zoom/pan path: the caller owns the framing, so no
+    // auto-zoom is applied.
+    if (opts.window) {
+      const lo = Math.min(opts.window.startMHz, opts.window.endMHz);
+      const hi = Math.max(opts.window.startMHz, opts.window.endMHz);
+      const start = Math.max(Nec2Engine.F_MIN_MHZ, lo);
+      const end = Math.min(Nec2Engine.F_MAX_MHZ, hi);
+      return this.runScan(input, start, end, points);
+    }
     // Explicit spanFraction → fixed single-pass sweep (back-compat for tests
     // and callers that want a specific window).
     if (opts.spanFraction !== undefined) {

--- a/src/store/antennaStore.ts
+++ b/src/store/antennaStore.ts
@@ -213,6 +213,13 @@ export interface AntennaState {
   utcHourOverride: number | null;
   geolocationStatus: 'idle' | 'requesting' | 'granted' | 'denied' | 'unsupported' | 'error';
 
+  // SWR sweep view window (user-controlled zoom/pan, MHz). The sweep is
+  // sampled across exactly [center - span/2, center + span/2] so zooming in
+  // resamples a narrower span at full point density rather than upscaling
+  // a fixed dataset.
+  swrViewCenterMHz: number;
+  swrViewSpanMHz: number;
+
   // Solver output
   result: SimulationResult | null;
   sweep: SweepPoint[];
@@ -259,6 +266,17 @@ export interface AntennaState {
   setShowPolarCuts(v: boolean): void;
   setTransformerEnabled(enabled: boolean): void;
   setTransformerRatio(ratio: number): void;
+
+  // SWR sweep zoom / pan (lateral only — the y-axis is intentionally fixed).
+  /** Multiply the view span by `factor` (<1 zooms in, >1 zooms out), keeping
+   *  `pivotMHz` (default: window centre) fixed on screen. */
+  zoomSwrView(factor: number, pivotMHz?: number): void;
+  /** Shift the view centre laterally by `fraction` of the current span. */
+  panSwrView(fraction: number): void;
+  /** Shift the view centre by an absolute number of MHz (for drag-to-pan). */
+  panSwrViewByMHz(deltaMHz: number): void;
+  /** Re-centre on the operating frequency at the default span. */
+  resetSwrView(): void;
   setAtuEnabled(enabled: boolean): void;
   setAtuMainFeedlineLength(meters: number): void;
   captureComparisonReference(): void;
@@ -274,6 +292,9 @@ export interface AntennaState {
 
   // Actions — internal (used by hooks/workers only, prefixed with _)
   _setSimulationData(r: SimulationResult, sweep: readonly SweepPoint[]): void;
+  /** Replace only the SWR sweep (efficient zoom/pan recompute — leaves the
+   *  radiation pattern result untouched). */
+  _setSweep(sweep: readonly SweepPoint[]): void;
   _setError(msg: string | null): void;
   _setLoading(v: boolean): void;
   _setEngineReady(v: boolean): void;
@@ -283,6 +304,39 @@ const INITIAL_FREQ = 7.1; // 40m band per user spec
 const INITIAL_HEIGHT = 8; // metres
 const INITIAL_TYPE: AntennaType = 'dipole';
 const INITIAL_LENGTH = referenceLength(INITIAL_TYPE, INITIAL_FREQ); // resonant reference length
+
+// SWR sweep view-window bounds (MHz). The window is always clamped inside this
+// range, which matches the engine's sweep limits (Nec2Engine.F_MIN/F_MAX_MHZ).
+export const SWR_VIEW_F_MIN_MHZ = 1.0;
+export const SWR_VIEW_F_MAX_MHZ = 30;
+// Tightest span the user can zoom to (kHz-scale detail) and the default span as
+// a fraction of the operating frequency (the "logical default zoom").
+const SWR_VIEW_MIN_SPAN_MHZ = 0.05;
+const DEFAULT_SWR_VIEW_SPAN_FRACTION = 0.2;
+
+/** Clamp a (centre, span) pair so the whole window stays within the HF limits. */
+function clampSwrView(centerMHz: number, spanMHz: number): { center: number; span: number } {
+  const fullSpan = SWR_VIEW_F_MAX_MHZ - SWR_VIEW_F_MIN_MHZ;
+  const span = Math.min(fullSpan, Math.max(SWR_VIEW_MIN_SPAN_MHZ, spanMHz));
+  const half = span / 2;
+  const center = Math.min(SWR_VIEW_F_MAX_MHZ - half, Math.max(SWR_VIEW_F_MIN_MHZ + half, centerMHz));
+  return { center, span };
+}
+
+/** Default view span (MHz) framed around the operating frequency. */
+function defaultSwrSpan(frequencyMHz: number): number {
+  return clampSwrView(frequencyMHz, frequencyMHz * DEFAULT_SWR_VIEW_SPAN_FRACTION).span;
+}
+
+const INITIAL_SWR_VIEW = clampSwrView(INITIAL_FREQ, defaultSwrSpan(INITIAL_FREQ));
+
+/** The absolute [start, end] frequency window the SWR sweep is sampled over. */
+export function selectSwrWindow(
+  state: Pick<AntennaState, 'swrViewCenterMHz' | 'swrViewSpanMHz'>,
+): { startMHz: number; endMHz: number } {
+  const { center, span } = clampSwrView(state.swrViewCenterMHz, state.swrViewSpanMHz);
+  return { startMHz: center - span / 2, endMHz: center + span / 2 };
+}
 
 export const useAntennaStore = create<AntennaState>()(
   subscribeWithSelector(
@@ -320,6 +374,9 @@ export const useAntennaStore = create<AntennaState>()(
       showPolarCuts: true,
       transformerEnabled: false,
       transformerRatio: 9,
+
+      swrViewCenterMHz: INITIAL_SWR_VIEW.center,
+      swrViewSpanMHz: INITIAL_SWR_VIEW.span,
 
       atuEnabled: false,
       atuMainFeedlineLength: DEFAULT_ATU_MAIN_FEEDLINE_LENGTH_M,
@@ -438,7 +495,14 @@ export const useAntennaStore = create<AntennaState>()(
         if (s.feedlineOffset > limit) s.feedlineOffset = limit;
         if (s.feedlineOffset < -limit) s.feedlineOffset = -limit;
       }),
-      setFrequency: (mhz) => set((s) => { s.frequency = clampFreq(mhz); }),
+      setFrequency: (mhz) => set((s) => {
+        s.frequency = clampFreq(mhz);
+        // Re-centre the SWR view on the new operating frequency (keeping the
+        // current span) so the marker stays in frame after a band change.
+        const { center, span } = clampSwrView(s.frequency, s.swrViewSpanMHz);
+        s.swrViewCenterMHz = center;
+        s.swrViewSpanMHz = span;
+      }),
       setLength: (meters) => set((s) => {
         if (!Number.isFinite(meters)) return;
         s.length = Math.max(0.1, meters);
@@ -567,6 +631,34 @@ export const useAntennaStore = create<AntennaState>()(
         if (!Number.isFinite(ratio) || ratio <= 0) return;
         s.transformerRatio = Math.max(1, ratio);
       }),
+      zoomSwrView: (factor, pivotMHz) => set((s) => {
+        if (!Number.isFinite(factor) || factor <= 0) return;
+        const oldSpan = s.swrViewSpanMHz;
+        const pivot = pivotMHz !== undefined && Number.isFinite(pivotMHz) ? pivotMHz : s.swrViewCenterMHz;
+        const newSpanRaw = oldSpan * factor;
+        // Keep the pivot frequency anchored at the same screen position.
+        const newCenterRaw = pivot + (s.swrViewCenterMHz - pivot) * (newSpanRaw / oldSpan);
+        const { center, span } = clampSwrView(newCenterRaw, newSpanRaw);
+        s.swrViewCenterMHz = center;
+        s.swrViewSpanMHz = span;
+      }),
+      panSwrView: (fraction) => set((s) => {
+        if (!Number.isFinite(fraction)) return;
+        const { center, span } = clampSwrView(s.swrViewCenterMHz + fraction * s.swrViewSpanMHz, s.swrViewSpanMHz);
+        s.swrViewCenterMHz = center;
+        s.swrViewSpanMHz = span;
+      }),
+      panSwrViewByMHz: (deltaMHz) => set((s) => {
+        if (!Number.isFinite(deltaMHz)) return;
+        const { center, span } = clampSwrView(s.swrViewCenterMHz + deltaMHz, s.swrViewSpanMHz);
+        s.swrViewCenterMHz = center;
+        s.swrViewSpanMHz = span;
+      }),
+      resetSwrView: () => set((s) => {
+        const { center, span } = clampSwrView(s.frequency, defaultSwrSpan(s.frequency));
+        s.swrViewCenterMHz = center;
+        s.swrViewSpanMHz = span;
+      }),
       setAtuEnabled: (enabled) => set((s) => { s.atuEnabled = !!enabled; }),
       setAtuMainFeedlineLength: (meters) => set((s) => {
         if (!Number.isFinite(meters)) return;
@@ -609,6 +701,11 @@ export const useAntennaStore = create<AntennaState>()(
 
       _setSimulationData: (r, sweep) => set((s) => {
         s.result = r;
+        s.sweep = [...sweep];
+        s.loading = false;
+        s.error = null;
+      }),
+      _setSweep: (sweep) => set((s) => {
         s.sweep = [...sweep];
         s.loading = false;
         s.error = null;

--- a/src/workers/physicsWorker.ts
+++ b/src/workers/physicsWorker.ts
@@ -12,6 +12,12 @@
 import { Nec2Engine } from '../physics/nec2Engine';
 import type { SimulationInput, SimulationResult, SweepPoint } from '../physics/types';
 
+/** Absolute frequency window the SWR sweep samples across. */
+export interface SweepWindow {
+  startMHz: number;
+  endMHz: number;
+}
+
 export type WorkerRequest =
   | {
       id: number;
@@ -19,14 +25,24 @@ export type WorkerRequest =
       input: SimulationInput;
       displayRatio?: number;
       sweepPoints?: number;
-      charPoints?: number;
-      maxAdaptiveIter?: number;
-      skipBroadScan?: boolean;
+      window?: SweepWindow;
+    }
+  // Sweep-only recompute: re-runs just the impedance sweep over a new window
+  // (zoom/pan) without recomputing the radiation pattern. Much cheaper than a
+  // full simulate when only the SWR view window changed.
+  | {
+      id: number;
+      type: 'sweep';
+      input: SimulationInput;
+      displayRatio?: number;
+      sweepPoints?: number;
+      window: SweepWindow;
     };
 
 export type WorkerResponse =
   | { type: 'ready' }
   | { id: number; type: 'result'; result: SimulationResult; sweep: readonly SweepPoint[] }
+  | { id: number; type: 'sweep'; sweep: readonly SweepPoint[] }
   | { id: number; type: 'error'; message: string };
 
 const ctx = self as unknown as DedicatedWorkerGlobalScope;
@@ -68,13 +84,28 @@ ctx.addEventListener('message', (ev: MessageEvent<WorkerRequest>) => {
       engine.sweepImpedance(msg.input, {
         points: msg.sweepPoints,
         displayRatio: msg.displayRatio,
-        charPoints: msg.charPoints,
-        maxIter: msg.maxAdaptiveIter,
-        skipBroadScan: msg.skipBroadScan,
+        window: msg.window,
       }),
     ])
       .then(([result, sweep]) => {
         ctx.postMessage({ id: msg.id, type: 'result', result, sweep } satisfies WorkerResponse);
+      })
+      .catch((err: unknown) => {
+        ctx.postMessage({
+          id: msg.id,
+          type: 'error',
+          message: err instanceof Error ? err.message : String(err),
+        } satisfies WorkerResponse);
+      });
+  } else if (msg.type === 'sweep') {
+    engine
+      .sweepImpedance(msg.input, {
+        points: msg.sweepPoints,
+        displayRatio: msg.displayRatio,
+        window: msg.window,
+      })
+      .then((sweep) => {
+        ctx.postMessage({ id: msg.id, type: 'sweep', sweep } satisfies WorkerResponse);
       })
       .catch((err: unknown) => {
         ctx.postMessage({

--- a/tests/antennaStore.test.ts
+++ b/tests/antennaStore.test.ts
@@ -4,9 +4,12 @@ import {
   buildWires,
   selectSimulationInput,
   selectAtuConfig,
+  selectSwrWindow,
   computeEffectiveSlope,
   legMultipleFromLength,
   computeOptimalVAngleDeg,
+  SWR_VIEW_F_MIN_MHZ,
+  SWR_VIEW_F_MAX_MHZ,
   LEFT_LEG_TAG,
   RIGHT_LEG_TAG,
   DELTA_BASE_TAG,
@@ -1501,6 +1504,96 @@ describe("antennaStore actions", () => {
         lambda * 0.25 * 0.95,
         4,
       );
+    });
+  });
+
+  describe("SWR view window (zoom / pan)", () => {
+    const center = () => useAntennaStore.getState().swrViewCenterMHz;
+    const span = () => useAntennaStore.getState().swrViewSpanMHz;
+
+    it("starts framed around the operating frequency at the default span", () => {
+      const store = useAntennaStore.getState();
+      store.setFrequency(7.1);
+      store.resetSwrView();
+      expect(center()).toBeCloseTo(7.1, 6);
+      // Default span is 20% of the operating frequency.
+      expect(span()).toBeCloseTo(7.1 * 0.2, 6);
+      const win = selectSwrWindow(useAntennaStore.getState());
+      expect(win.startMHz).toBeCloseTo(7.1 - (7.1 * 0.2) / 2, 6);
+      expect(win.endMHz).toBeCloseTo(7.1 + (7.1 * 0.2) / 2, 6);
+    });
+
+    it("zooms in (factor < 1) and out (factor > 1) about the centre", () => {
+      const store = useAntennaStore.getState();
+      store.setFrequency(14.0);
+      store.resetSwrView();
+      const span0 = span();
+      store.zoomSwrView(0.5);
+      expect(span()).toBeCloseTo(span0 * 0.5, 6);
+      expect(center()).toBeCloseTo(14.0, 6); // centre unchanged with no pivot
+      store.zoomSwrView(2);
+      expect(span()).toBeCloseTo(span0, 6);
+    });
+
+    it("keeps the pivot frequency anchored when zooming about a cursor", () => {
+      const store = useAntennaStore.getState();
+      store.setFrequency(14.0);
+      store.resetSwrView();
+      const pivot = center() + span() / 4; // somewhere right of centre
+      const winBefore = selectSwrWindow(useAntennaStore.getState());
+      const fracBefore = (pivot - winBefore.startMHz) / (winBefore.endMHz - winBefore.startMHz);
+      store.zoomSwrView(0.5, pivot);
+      const winAfter = selectSwrWindow(useAntennaStore.getState());
+      const fracAfter = (pivot - winAfter.startMHz) / (winAfter.endMHz - winAfter.startMHz);
+      // The pivot stays at the same relative position within the window.
+      expect(fracAfter).toBeCloseTo(fracBefore, 6);
+    });
+
+    it("pans laterally by a fraction of the span", () => {
+      const store = useAntennaStore.getState();
+      store.setFrequency(14.0);
+      store.resetSwrView();
+      const c0 = center();
+      const s0 = span();
+      store.panSwrView(0.5);
+      expect(center()).toBeCloseTo(c0 + 0.5 * s0, 6);
+      expect(span()).toBeCloseTo(s0, 6); // pan never changes the span
+    });
+
+    it("pans by an absolute number of MHz (drag-to-pan)", () => {
+      const store = useAntennaStore.getState();
+      store.setFrequency(14.0);
+      store.resetSwrView();
+      const c0 = center();
+      store.panSwrViewByMHz(-0.3);
+      expect(center()).toBeCloseTo(c0 - 0.3, 6);
+    });
+
+    it("clamps the window inside the HF sweep limits", () => {
+      const store = useAntennaStore.getState();
+      store.setFrequency(2.0);
+      store.resetSwrView();
+      // Pan hard against the low edge.
+      store.panSwrView(-100);
+      const win = selectSwrWindow(useAntennaStore.getState());
+      expect(win.startMHz).toBeGreaterThanOrEqual(SWR_VIEW_F_MIN_MHZ - 1e-9);
+      // Zoom way out — the span saturates at the full HF range.
+      store.zoomSwrView(1000);
+      const full = selectSwrWindow(useAntennaStore.getState());
+      expect(full.startMHz).toBeCloseTo(SWR_VIEW_F_MIN_MHZ, 6);
+      expect(full.endMHz).toBeCloseTo(SWR_VIEW_F_MAX_MHZ, 6);
+    });
+
+    it("re-centres on the operating frequency when the band changes", () => {
+      const store = useAntennaStore.getState();
+      store.setFrequency(7.1);
+      store.resetSwrView();
+      store.zoomSwrView(0.3); // narrow the view
+      const narrowed = span();
+      store.setFrequency(21.0);
+      // Re-centred on the new band, keeping the (clamped) span.
+      expect(center()).toBeCloseTo(21.0, 6);
+      expect(span()).toBeCloseTo(narrowed, 6);
     });
   });
 });

--- a/tests/nec2Engine.sweep.test.ts
+++ b/tests/nec2Engine.sweep.test.ts
@@ -56,6 +56,37 @@ describe('sweepImpedance with default store input', () => {
   }, 60_000);
 });
 
+describe('sweepImpedance with an explicit window (interactive zoom/pan)', () => {
+  it('samples exactly across the requested window and clamps to HF limits', async () => {
+    const engine = new Nec2Engine({ baseUrl: wasmUrl });
+    await engine.init();
+    const input = selectSimulationInput(useAntennaStore.getState());
+
+    const sweep = await engine.sweepImpedance(input, {
+      points: 9,
+      window: { startMHz: 6.8, endMHz: 7.4 },
+    });
+
+    expect(sweep).toHaveLength(9);
+    expect(sweep[0]!.frequencyMHz).toBeCloseTo(6.8, 6);
+    expect(sweep[sweep.length - 1]!.frequencyMHz).toBeCloseTo(7.4, 6);
+  }, 60_000);
+
+  it('resamples a narrower window at finer resolution (zoom in)', async () => {
+    const engine = new Nec2Engine({ baseUrl: wasmUrl });
+    await engine.init();
+    const input = selectSimulationInput(useAntennaStore.getState());
+
+    const wide = await engine.sweepImpedance(input, { points: 9, window: { startMHz: 6.0, endMHz: 8.0 } });
+    const zoomed = await engine.sweepImpedance(input, { points: 9, window: { startMHz: 7.0, endMHz: 7.2 } });
+
+    const wideSpacing = wide[1]!.frequencyMHz - wide[0]!.frequencyMHz;
+    const zoomedSpacing = zoomed[1]!.frequencyMHz - zoomed[0]!.frequencyMHz;
+    // Same point count over a 10× narrower span → ~10× finer sample spacing.
+    expect(zoomedSpacing).toBeLessThan(wideSpacing);
+  }, 60_000);
+});
+
 describe('adaptive sweep framing (no spanFraction)', () => {
   const FREQ = 7.1;
 

--- a/tests/swrBands.test.ts
+++ b/tests/swrBands.test.ts
@@ -107,12 +107,14 @@ describe('computeYMax', () => {
     expect(yMax).toBe(10); // capped — inter-band 40:1 does not inflate the scale
   });
 
-  it('does not cap when there are no usable bands (SWR always > 2)', () => {
+  it('caps at 10 even when there are no usable bands (SWR always > 2)', () => {
+    // The y-axis never zooms vertically: an all-mismatched window is clipped at
+    // the cap rather than inflating the scale.
     const sweep = [
       { frequencyMHz: 7.0, R: 500, X: 0, swr: 10.0 },
       { frequencyMHz: 8.0, R: 400, X: 0, swr: 8.0 },
     ];
     const yMax = computeYMax({ ...base, sweep });
-    expect(yMax).toBeGreaterThanOrEqual(11); // no cap — no usable band found
+    expect(yMax).toBe(10);
   });
 });

--- a/tests/swrChartUtils.test.ts
+++ b/tests/swrChartUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { computeChartData, computeStats, formatBandwidth, computeXBounds, computeYMax, computeOptions } from '../src/components/Charts/swrChartUtils';
+import { computeChartData, computeStats, formatBandwidth, computeYMax, computeOptions } from '../src/components/Charts/swrChartUtils';
 import type { SweepPoint } from '../src/physics/types';
 import type { ComparisonSnapshot } from '../src/store/antennaStore';
 
@@ -136,77 +136,6 @@ describe('formatBandwidth', () => {
     expect(formatBandwidth(1.555)).toBe('1.55 MHz');
     expect(formatBandwidth(1.556)).toBe('1.56 MHz');
     expect(formatBandwidth(10)).toBe('10.00 MHz');
-  });
-});
-
-describe('computeXBounds', () => {
-  const mockSweep = [
-    { frequencyMHz: 7.0, R: 50, X: 0, swr: 1.0 },
-    { frequencyMHz: 7.2, R: 100, X: 0, swr: 2.0 },
-  ];
-
-  const mockReference = {
-    antennaType: 'dipole' as const,
-    height: 10,
-    sweep: [
-      { frequencyMHz: 6.9, R: 150, X: 0, swr: 3.0 },
-      { frequencyMHz: 7.3, R: 200, X: 0, swr: 4.0 },
-    ],
-  };
-
-  it('returns default bounds when sweeps are empty', () => {
-    const result = computeXBounds({
-      sweep: [],
-      comparisonActive: false,
-      reference: null,
-      frequency: 7.0,
-    });
-    expect(result.min).toBeCloseTo(7.0 * 0.95);
-    expect(result.max).toBeCloseTo(7.0 * 1.05);
-  });
-
-  it('returns default bounds when main sweep is empty and reference sweep is empty', () => {
-    const result = computeXBounds({
-      sweep: [],
-      comparisonActive: true,
-      reference: { ...mockReference, sweep: [] },
-      frequency: 7.0,
-    });
-    expect(result.min).toBeCloseTo(7.0 * 0.95);
-    expect(result.max).toBeCloseTo(7.0 * 1.05);
-  });
-
-  it('returns bounds based only on main sweep when comparison is inactive', () => {
-    const result = computeXBounds({
-      sweep: mockSweep,
-      comparisonActive: false,
-      reference: mockReference,
-      frequency: 7.0,
-    });
-    expect(result.min).toBe(7.0);
-    expect(result.max).toBe(7.2);
-  });
-
-  it('returns bounds across both sweeps when comparison is active', () => {
-    const result = computeXBounds({
-      sweep: mockSweep,
-      comparisonActive: true,
-      reference: mockReference,
-      frequency: 7.0,
-    });
-    expect(result.min).toBe(6.9);
-    expect(result.max).toBe(7.3);
-  });
-
-  it('returns bounds based on reference sweep when main sweep is empty but comparison is active', () => {
-    const result = computeXBounds({
-      sweep: [],
-      comparisonActive: true,
-      reference: mockReference,
-      frequency: 7.0,
-    });
-    expect(result.min).toBe(6.9);
-    expect(result.max).toBe(7.3);
   });
 });
 
@@ -396,12 +325,14 @@ describe('computeYMax', () => {
     expect(computeYMax({ ...baseArgs, sweep })).toBe(10);
   });
 
-  it('allows higher scales (no SWR_CAP) when no points are below 2', () => {
+  it('clips at SWR_CAP of 10 even when no points are below 2', () => {
+    // The y-axis is a fixed reference frame; an all-mismatched window must not
+    // balloon the vertical scale.
     const sweep: SweepPoint[] = [
       { frequencyMHz: 7.0, R: 50, X: 0, swr: 5.0 },
       { frequencyMHz: 7.1, R: 50, X: 0, swr: 15.0 }, // max
     ];
-    expect(computeYMax({ ...baseArgs, sweep })).toBeCloseTo(16.5);
+    expect(computeYMax({ ...baseArgs, sweep })).toBe(10);
   });
 
   it('includes reference sweep max values when comparison is active', () => {

--- a/tests/usePhysicsEngine.test.tsx
+++ b/tests/usePhysicsEngine.test.tsx
@@ -181,6 +181,66 @@ describe('usePhysicsEngine', () => {
     expect(useAntennaStore.getState().error).toBe('Init Error');
   });
 
+  it('sends a sweep-only message when only the SWR view window changes', () => {
+    renderHook(() => usePhysicsEngine({ debounceMs: 100 }));
+    const worker = workerInstances[0] as MockWorker;
+    const messageHandler = worker.addEventListener.mock.calls.find(
+      (call: unknown[]) => call[0] === 'message'
+    )![1];
+
+    // Initial full solve.
+    act(() => { vi.advanceTimersByTime(100); });
+    const initial = worker.postMessage.mock.calls[0][0];
+    expect(initial.type).toBe('simulate');
+    expect(initial.window).toEqual(expect.objectContaining({
+      startMHz: expect.any(Number),
+      endMHz: expect.any(Number),
+    }));
+
+    // Resolve it so no full solve is in flight.
+    act(() => {
+      messageHandler({ data: { id: initial.id, type: 'result', result: { test: true }, sweep: [] } });
+    });
+
+    // Pure zoom/pan → cheap sweep-only recompute (no pattern re-solve).
+    worker.postMessage.mockClear();
+    act(() => { useAntennaStore.getState().panSwrView(0.25); });
+    act(() => { vi.advanceTimersByTime(100); });
+
+    expect(worker.postMessage).toHaveBeenCalledTimes(1);
+    const msg = worker.postMessage.mock.calls[0][0];
+    expect(msg.type).toBe('sweep');
+    expect(msg.window).toEqual(expect.objectContaining({
+      startMHz: expect.any(Number),
+      endMHz: expect.any(Number),
+    }));
+
+    // A sweep result updates the sweep without touching the pattern result.
+    act(() => {
+      messageHandler({ data: { id: msg.id, type: 'sweep', sweep: [{ frequencyMHz: 7, R: 50, X: 0, swr: 1.1 }] } });
+    });
+    expect(useAntennaStore.getState().sweep).toHaveLength(1);
+    expect(useAntennaStore.getState().result).toEqual({ test: true });
+  });
+
+  it('upgrades a zoom to a full solve while a pattern solve is still in flight', () => {
+    renderHook(() => usePhysicsEngine({ debounceMs: 100 }));
+    const worker = workerInstances[0] as MockWorker;
+
+    // Initial full solve dispatched but NOT yet resolved (pattern still pending).
+    act(() => { vi.advanceTimersByTime(100); });
+    expect(worker.postMessage.mock.calls[0][0].type).toBe('simulate');
+
+    // Zoom before the pattern lands → must re-solve fully, else the in-flight
+    // pattern result would be discarded as stale.
+    worker.postMessage.mockClear();
+    act(() => { useAntennaStore.getState().zoomSwrView(0.5); });
+    act(() => { vi.advanceTimersByTime(100); });
+
+    expect(worker.postMessage).toHaveBeenCalledTimes(1);
+    expect(worker.postMessage.mock.calls[0][0].type).toBe('simulate');
+  });
+
   it('handles worker errors properly', () => {
     renderHook(() => usePhysicsEngine({ debounceMs: 100 }));
     const worker = workerInstances[0] as MockWorker;


### PR DESCRIPTION
## What & why

The SWR sweep used to **auto-zoom**: the engine's adaptive sweep auto-framed the frequency window around the antenna's 2:1 bandwidth, and the chart auto-fit its x-axis to whatever data came back. This replaces that with a **user-controlled view window** and a logical default, plus interactive zoom/pan. Crucially, the sweep **resamples** on zoom rather than upscaling a fixed dataset — zooming in over a narrower span gives finer frequency resolution.

## Behaviour

- **Logical default zoom**: operating frequency ±10% (20% span). Re-centres on the operating frequency when you change bands.
- **Zoom in/out + lateral pan** via:
  - a button group under the chart (◀ − ⟳ + ▶),
  - mouse wheel (zoom, centred on the cursor frequency),
  - click-drag (pan).
- **No vertical zoom**: the y-axis is a fixed reference frame capped at 10:1. Very high SWR is clipped — its exact magnitude doesn't matter, only where the curve sits at the low (well-matched) values. This keeps the y-scale stable while panning/zooming laterally.

## Efficiency

Zoom/pan triggers a **sweep-only** worker message that recomputes just the impedance sweep over the new window — the radiation-pattern solve (which doesn't depend on the sweep window) is skipped. A view change is upgraded to a full solve only when a pattern solve is still in flight, so an in-flight pattern result is never discarded as stale.

## Key changes

| Area | Change |
|------|--------|
| `store/antennaStore.ts` | `swrViewCenterMHz` / `swrViewSpanMHz` state; `zoomSwrView` / `panSwrView` / `panSwrViewByMHz` / `resetSwrView` actions (clamped to HF limits); `selectSwrWindow` selector |
| `physics/nec2Engine.ts` | `sweepImpedance` accepts an explicit `window` that samples exactly that range. Adaptive sweep kept for back-compat/tests but no longer used by the app |
| `workers/physicsWorker.ts` | new `sweep` message type for sweep-only recompute |
| `hooks/usePhysicsEngine.ts` | routes view-window changes to the cheap sweep path, full solve otherwise |
| `components/Charts/SWRChart.tsx` | x-axis from the view window; wheel/drag gestures; zoom/pan controls |
| `components/Charts/swrChartUtils.ts` | removed auto-fit `computeXBounds`; `computeYMax` now always clips at the 10:1 cap |

## Testing

- `npx vitest run` — **747 passed** (11 new: store zoom/pan/clamp, engine window option + zoom-resamples-finer, worker sweep-only path + in-flight upgrade)
- `tsc -b`, `eslint .`, and `vite build` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ebgy2A8UZB59DD7BYfTSmc)_