### PR TITLE
Update GitHub source link text in sidebar footer

### DIFF
--- a/src/components/Panel/ControlPanel.tsx
+++ b/src/components/Panel/ControlPanel.tsx
@@ -67,7 +67,7 @@ export function ControlPanel() {
           onMouseOver={(e) => (e.currentTarget.style.textDecoration = 'underline')}
           onMouseOut={(e) => (e.currentTarget.style.textDecoration = 'none')}
         >
-          View source on GitHub
+          Source code on GitHub
         </a>
         </footer>
       </aside>

--- a/tests/ControlPanel.test.tsx
+++ b/tests/ControlPanel.test.tsx
@@ -13,7 +13,7 @@ describe('ControlPanel', () => {
 
     // Act
     const heading = screen.getByRole('heading', { name: /HF GAIN VISUALIZER/i });
-    const footerLink = screen.getByRole('link', { name: /View source on GitHub/i });
+    const footerLink = screen.getByRole('link', { name: /Source code on GitHub/i });
 
     // Assert
     expect(heading).toBeTruthy();
@@ -24,7 +24,7 @@ describe('ControlPanel', () => {
   it('handles hover events on the footer link correctly', () => {
     // Arrange
     render(<ControlPanel />);
-    const footerLink = screen.getByRole('link', { name: /View source on GitHub/i });
+    const footerLink = screen.getByRole('link', { name: /Source code on GitHub/i });
 
     // Act - Hover
     fireEvent.mouseOver(footerLink);


### PR DESCRIPTION
Updated the GitHub link text in the sidebar footer to "Source code on GitHub" for better clarity and alignment with the requested feature. Verified the change visually via Playwright screenshots and ensured the full test suite passes with updated expectations.

Fixes #399

---
*PR created automatically by Jules for task [7149046292687051768](https://jules.google.com/task/7149046292687051768) started by @2fst4u*