### PR TITLE
🧪 [Missing Error Path Test: Untrusted Protocol]

### DIFF
--- a/tests/nec2Engine.protocol.test.ts
+++ b/tests/nec2Engine.protocol.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { Nec2Engine } from '../src/physics/nec2Engine';
+
+describe('Nec2Engine untrusted protocol', () => {
+  it('throws untrusted protocol error on init', async () => {
+    const engine = new Nec2Engine({ baseUrl: 'ftp://localhost/' });
+    await expect(engine.init()).rejects.toThrow('Untrusted protocol: ftp:');
+  });
+
+  it('throws untrusted protocol error on simulate', async () => {
+    const engine = new Nec2Engine({ baseUrl: 'ftp://localhost/' });
+    const dummyInput = {
+      wires: [{ start: [0, 0, 1] as [number, number, number], end: [0, 0, 2] as [number, number, number], radius: 0.001, segments: 11, tag: 1 }],
+      frequencyMHz: 14,
+      ground: { type: 'free' as const },
+      excitation: { wireTag: 1, segment: 6 },
+      patternResolution: { thetaSteps: 5, phiSteps: 8 },
+    };
+    await expect(engine.simulate(dummyInput)).rejects.toThrow('Untrusted protocol: ftp:');
+  });
+});


### PR DESCRIPTION
🎯 **What:** Adds missing error path tests for `Nec2Engine` in `src/physics/nec2Engine.ts` to verify it throws an error when instantiated with an untrusted protocol (e.g. `ftp:`).
📊 **Coverage:** Now tests the untrusted protocol check inside both the `init()` and `simulate()` public methods, ensuring robust error handling is exercised.
✨ **Result:** Test coverage for `src/physics/nec2Engine.ts` and overall robustness against invalid configurations are improved.

---
*PR created automatically by Jules for task [17622747732892447532](https://jules.google.com/task/17622747732892447532) started by @2fst4u*