### PR TITLE
🧪 [Testing] Add missing error test for NEC-2 simulation pattern parsing

### DIFF
--- a/tests/nec2Engine.error.test.ts
+++ b/tests/nec2Engine.error.test.ts
@@ -41,4 +41,37 @@ describe('Nec2Engine error handling', () => {
       'nec2c exited with status 1. Fatal error: geometry invalid | Segmentation fault'
     );
   });
+
+  it('throws an error if NEC completes but produces no radiation pattern', async () => {
+    const engine = new Nec2Engine({ baseUrl: '/' });
+
+    // Mock the init promise to bypass actual wasm loading
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (engine as any).ready = true;
+
+    const mockInstance = {
+      FS: {
+        writeFile: vi.fn(),
+        // Return dummy text that lacks pattern data
+        readFile: vi.fn().mockReturnValue(new TextEncoder().encode('DUMMY OUTPUT\nNO PATTERN HERE')),
+      },
+      callMain: vi.fn().mockReturnValue(0), // return 0 for success
+    };
+
+    // Inject a mock factory
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (engine as any).factory = async () => mockInstance;
+
+    const dummyInput: SimulationInput = {
+      wires: [{ start: [0, 0, 1], end: [0, 0, 2], radius: 0.001, segments: 11, tag: 1 }],
+      frequencyMHz: 14,
+      ground: { type: 'free' },
+      excitation: { wireTag: 1, segment: 6 },
+      patternResolution: { thetaSteps: 5, phiSteps: 8 },
+    };
+
+    await expect(engine.simulate(dummyInput)).rejects.toThrow(
+      'NEC-2 did not produce a radiation pattern. Notices: (none)'
+    );
+  });
 });


### PR DESCRIPTION
🎯 **What:** Added a missing error path unit test for `Nec2Engine.simulate()` when the NEC-2 engine runs but produces output without a radiation pattern.
📊 **Coverage:** Now tests the specific branch `if (!parsed.pattern)` when parsing NEC-2 output.
✨ **Result:** Improved test coverage and explicit verification of error handling behavior for malformed or unexpectedly blank `nec2c` engine outputs.

---
*PR created automatically by Jules for task [10846428743158185750](https://jules.google.com/task/10846428743158185750) started by @2fst4u*