### PR TITLE
🧪 [nec2Engine testing] Add missing pattern error path test

### DIFF
--- a/tests/nec2Engine.error.test.ts
+++ b/tests/nec2Engine.error.test.ts
@@ -41,4 +41,44 @@ describe('Nec2Engine error handling', () => {
       'nec2c exited with status 1. Fatal error: geometry invalid | Segmentation fault'
     );
   });
+
+  it('throws an error if NEC-2 did not produce a radiation pattern', async () => {
+    const engine = new Nec2Engine({ baseUrl: '/' });
+
+    // Mock the init promise to bypass actual wasm loading
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (engine as any).ready = true;
+
+    const dummyOutput = `
+                                  - - - IMPEDANCE DATA - - -
+FREQ =  14.0000 MHZ
+VOLTAGE =  1.00000E+00
+CURRENT =  1.00000E+00
+IMPEDANCE =  50.0000 + J 0.0000
+    `;
+
+    const mockInstance = {
+      FS: {
+        writeFile: vi.fn(),
+        readFile: vi.fn().mockReturnValue(new TextEncoder().encode(dummyOutput)),
+      },
+      callMain: vi.fn().mockReturnValue(0), // return zero status
+    };
+
+    // Inject a mock factory
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (engine as any).factory = async () => mockInstance;
+
+    const dummyInput: SimulationInput = {
+      wires: [{ start: [0, 0, 1], end: [0, 0, 2], radius: 0.001, segments: 11, tag: 1 }],
+      frequencyMHz: 14,
+      ground: { type: 'free' },
+      excitation: { wireTag: 1, segment: 6 },
+      patternResolution: { thetaSteps: 5, phiSteps: 8 },
+    };
+
+    await expect(engine.simulate(dummyInput)).rejects.toThrow(
+      'NEC-2 did not produce a radiation pattern.'
+    );
+  });
 });


### PR DESCRIPTION
🎯 **What:** The "missing pattern" error path in `nec2Engine.ts` was not covered by tests.
📊 **Coverage:** Added test covering the condition where `parsed.pattern` is undefined after `nec2Engine` processing.
✨ **Result:** Improved robustness by verifying the proper Error is thrown when Wasm NEC-2 execution behaves unexpectedly and lacks pattern output.

---
*PR created automatically by Jules for task [95090162469353936](https://jules.google.com/task/95090162469353936) started by @2fst4u*