### PR TITLE
🎨 Palette: Add aria-valuetext to range sliders

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-15 - ARIA Region on Loading States
 **Learning:** In React components that render placeholder text (like "Computing…") during async operations, failing to include `role="status"` and `aria-live="polite"` means screen readers remain completely silent during long calculations, leading to confusion.
 **Action:** Always add `role="status"` and `aria-live="polite"` to loading/computing placeholder `<div>` elements.
+## 2024-05-16 - aria-valuetext on Range Inputs
+**Learning:** Range inputs (`<input type="range">`) announce only their raw numeric value to screen readers by default. In a highly technical app with mixed units (meters, feet, degrees, dB), this lacks context.
+**Action:** Always provide an `aria-valuetext` attribute on range sliders that includes both the formatted value and its specific unit (e.g., `aria-valuetext="10.0 m"`).

--- a/src/components/Panel/DisplayControl.tsx
+++ b/src/components/Panel/DisplayControl.tsx
@@ -59,6 +59,7 @@ export function DisplayControl() {
         type="range" min={10} max={50} step={1}
         value={dbRange}
         aria-label="Dynamic range in dB"
+        aria-valuetext={`${dbRange} dB`}
         onChange={(e) => setDbRange(parseInt(e.target.value, 10))}
       />
 
@@ -68,6 +69,7 @@ export function DisplayControl() {
         type="range" min={-20} max={30} step={1}
         value={colorMaxDb}
         aria-label="Color max in dBi"
+        aria-valuetext={`${colorMaxDb} dBi`}
         onChange={(e) => setColorMaxDb(parseInt(e.target.value, 10))}
       />
 
@@ -77,6 +79,7 @@ export function DisplayControl() {
         type="range" min={0.3} max={3} step={0.1}
         value={patternScale}
         aria-label="Pattern scale multiplier"
+        aria-valuetext={`${patternScale.toFixed(2)}×`}
         onChange={(e) => setPatternScale(parseFloat(e.target.value))}
       />
 

--- a/src/components/Panel/FeedlineControl.tsx
+++ b/src/components/Panel/FeedlineControl.tsx
@@ -123,6 +123,7 @@ function DipoleOffsetControl({
           step={units === 'metric' ? 0.05 : 0.25}
           value={dispOffset}
           aria-label="Feedline attachment offset"
+          aria-valuetext={`${dispOffset.toFixed(2)} ${unit}`}
           aria-describedby="feedline-offset-hint"
           onChange={(e) => {
             const val = parseFloat(e.target.value);

--- a/src/components/Panel/GeometryControl.tsx
+++ b/src/components/Panel/GeometryControl.tsx
@@ -398,6 +398,7 @@ function HeightControl() {
         step={units === 'metric' ? 0.5 : 1}
         value={dispHeight}
         aria-label={isVerticalWhip ? 'Base height above ground' : isInvertedL ? 'Mast / bend-point height' : isFoldedDipole ? 'Bottom conductor height / feedpoint' : 'Height above ground'}
+        aria-valuetext={`${dispHeight.toFixed(1)} ${unit}`}
         onChange={(e) => {
           const val = parseFloat(e.target.value);
           if (!isNaN(val)) setHeight(fromDisplayLength(val, units));
@@ -429,6 +430,7 @@ function VAngleControl() {
         step={1}
         value={vAngle}
         aria-label="V opening angle in degrees"
+        aria-valuetext={`${vAngle}°`}
         onChange={(e) => {
           const val = parseFloat(e.target.value);
           if (!isNaN(val)) setVAngle(val);
@@ -470,6 +472,7 @@ function ApertureControl() {
         step={units === 'metric' ? 0.01 : 0.05}
         value={dispAperture}
         aria-label="Folded dipole conductor spacing"
+        aria-valuetext={`${dispAperture.toFixed(2)} ${unit}`}
         aria-describedby="folded-dipole-aperture-hint"
         onChange={(e) => {
           const val = parseFloat(e.target.value);


### PR DESCRIPTION
💡 **What:** Added `aria-valuetext` attributes to `<input type="range">` elements throughout the control panels (`DisplayControl`, `GeometryControl`, and `FeedlineControl`).
🎯 **Why:** When screen reader users interact with range sliders, they typically only hear the raw numeric value (e.g., "10", "45"). Adding `aria-valuetext` provides crucial units and context (e.g., "10.0 m", "45°", "20 decibels") so users don't have to navigate away from the slider to understand what the value represents.
📸 **Before/After:** No visual changes.
♿ **Accessibility:** Improves WCAG 4.1.2 Name, Role, Value compliance by ensuring the announced value is meaningful and contextualized.

---
*PR created automatically by Jules for task [5522984388402397494](https://jules.google.com/task/5522984388402397494) started by @2fst4u*