### PR TITLE
Make inverted-V clamp warning consistent with the V opening angle control

### DIFF
--- a/src/components/Panel/GeometryStatus.tsx
+++ b/src/components/Panel/GeometryStatus.tsx
@@ -54,7 +54,11 @@ export function GeometryStatus() {
     );
   }
 
-  // Inverted V: slope is derived from vAngle and may be clamped by mast height.
+  // Inverted V: the per-leg slope is derived from the V opening angle and may
+  // be clamped by mast height. Surface everything in terms of the opening angle
+  // so it lines up with the "V opening angle" control the user adjusts.
+  // (slope = (180 − openingAngle) / 2, so a maximum slope maps to a minimum
+  // opening angle.)
   const half = length / 2;
   const maxSin = half > 0 ? (height - SLOPING_V_MIN_TIP_Z_M) / half : 0;
   const maxSlopeRad = Math.asin(Math.max(0, Math.min(1, maxSin)));
@@ -65,6 +69,11 @@ export function GeometryStatus() {
   const effectiveSlopeRad = (effectiveSlopeDeg * Math.PI) / 180;
   const tipZ = height - half * Math.sin(effectiveSlopeRad);
   const isClamped = requestedSlopeDeg > maxSlopeDeg + 0.1;
+
+  // The narrowest opening angle allowed before the tips would drop below the
+  // ground floor, and the opening angle actually used after clamping.
+  const minOpeningDeg = 180 - 2 * maxSlopeDeg;
+  const effectiveOpeningDeg = 180 - 2 * effectiveSlopeDeg;
 
   return (
     <section
@@ -84,12 +93,12 @@ export function GeometryStatus() {
         {isClamped ? '⚠️ Geometry Clamped' : 'Geometry Status'}
       </h3>
       <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '4px 12px' }}>
-        <span style={{ color: 'var(--text-muted)' }}>Max slope:</span>
-        <span>{maxSlopeDeg.toFixed(1)}°</span>
+        <span style={{ color: 'var(--text-muted)' }}>Min opening angle:</span>
+        <span>{minOpeningDeg.toFixed(1)}°</span>
 
-        <span style={{ color: 'var(--text-muted)' }}>Effective slope:</span>
+        <span style={{ color: 'var(--text-muted)' }}>Effective opening:</span>
         <span style={{ color: isClamped ? '#ff6b6b' : 'inherit', fontWeight: isClamped ? 600 : 400 }}>
-          {effectiveSlopeDeg.toFixed(1)}°
+          {effectiveOpeningDeg.toFixed(1)}°
         </span>
 
         <span style={{ color: 'var(--text-muted)' }}>Tip height:</span>
@@ -97,7 +106,7 @@ export function GeometryStatus() {
       </div>
       {isClamped && (
         <div style={{ marginTop: 6, fontSize: 11, fontStyle: 'italic', lineHeight: 1.3 }}>
-          Slope reduced to keep tips at least {toDisplayLength(SLOPING_V_MIN_TIP_Z_M, units).toFixed(2)} {unit} above ground.
+          Opening angle widened to keep tips at least {toDisplayLength(SLOPING_V_MIN_TIP_Z_M, units).toFixed(2)} {unit} above ground.
         </div>
       )}
     </section>

--- a/tests/GeometryStatus.test.tsx
+++ b/tests/GeometryStatus.test.tsx
@@ -34,7 +34,7 @@ describe('GeometryStatus', () => {
 
     render(<GeometryStatus />);
     expect(screen.getByText(/Geometry Clamped/i)).toBeTruthy();
-    expect(screen.getByText(/Slope reduced to keep tips/i)).toBeTruthy();
+    expect(screen.getByText(/Opening angle widened to keep tips/i)).toBeTruthy();
   });
 
   it('renders normal message for inverted-v when not clamped', () => {


### PR DESCRIPTION
## Problem

For an Inverted V antenna, the **Geometry Clamped** status panel reported the clamp in terms of **single-leg slope** ("Max slope" / "Effective slope", e.g. 22.1°). But the control the user actually adjusts is the **V opening angle** (e.g. 120°). These are different quantities — per-leg slope from horizontal vs. the internal opening angle between the two legs — so the warning didn't line up with the setting being changed.

## Fix

The panel now expresses the clamp in terms of the V opening angle, matching the slider:

- **Min opening angle** — the narrowest opening the mast height allows (`180 − 2·maxSlope`)
- **Effective opening** — the opening angle actually used after clamping
- Message changed from *"Slope reduced to keep tips…"* to *"Opening angle widened to keep tips at least X above ground."*

The underlying clamp math is unchanged; only the user-facing quantities are converted from slope to opening angle (`slope = (180 − openingAngle) / 2`).

## Tests

Updated `tests/GeometryStatus.test.tsx` for the new message wording. All GeometryStatus tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011sBM1tuPc5vm8VwZwrWRAq)_