### PR TITLE
🧹 Sweep: Remove unused exports from usePhysicsEngine

### DIFF
--- a/.jules/sweep.md
+++ b/.jules/sweep.md
@@ -81,3 +81,6 @@
 ## 2026-06-20 - False Positive Bug Report Comment
 **Learning:** Found a comment `// The 1.5λ dipole from the bug report: high gain, severe mismatch.` in `tests/impedance.test.ts:25`. The comment refers to a "bug report" for context on a test case, it is not an active bug or TODO marker that needs fixing in the code.
 **Action:** Closed the task without making changes to the source codebase, strictly adhering to the Code Health Refactoring Pattern which dictates preserving valid code when confronted with false positives.
+## 2025-02-13 - Removed unused exports from usePhysicsEngine
+**Learning:** Functions that are only used internally within their module should not be exported, as it bloats the public API and triggers unused export warnings in static analysis tools (like Knip).
+**Action:** Removed the `export` keyword from `handleWorkerMessage`, `buildWorkerRequest`, `useWorkerLifecycle`, and `usePhysicsScheduler` in `src/hooks/usePhysicsEngine.ts` to keep them local to the module.

--- a/src/hooks/usePhysicsEngine.ts
+++ b/src/hooks/usePhysicsEngine.ts
@@ -33,7 +33,7 @@ function displayTransformerRatio(s: TransformerState): number {
   return inDisplay ? s.transformerRatio : 1;
 }
 
-export function handleWorkerMessage(
+function handleWorkerMessage(
   msg: WorkerResponse,
   latestId: number,
   setFullPending: (val: boolean) => void
@@ -60,7 +60,7 @@ export function handleWorkerMessage(
   }
 }
 
-export function buildWorkerRequest(
+function buildWorkerRequest(
   requestedKind: 'full' | 'sweep',
   fullPending: boolean,
   state: ReturnType<typeof useAntennaStore.getState>,
@@ -99,7 +99,7 @@ export function buildWorkerRequest(
   };
 }
 
-export function useWorkerLifecycle(
+function useWorkerLifecycle(
   workerRef: React.MutableRefObject<Worker | null>,
   latestIdRef: React.MutableRefObject<number>,
   fullPendingRef: React.MutableRefObject<boolean>,
@@ -139,7 +139,7 @@ export function useWorkerLifecycle(
   }, [latestIdRef, fullPendingRef, workerRef, timerRef]);
 }
 
-export function usePhysicsScheduler(
+function usePhysicsScheduler(
   workerRef: React.MutableRefObject<Worker | null>,
   nextIdRef: React.MutableRefObject<number>,
   latestIdRef: React.MutableRefObject<number>,


### PR DESCRIPTION
💡 What: Removed `export` from `handleWorkerMessage`, `buildWorkerRequest`, `useWorkerLifecycle`, and `usePhysicsScheduler` in `src/hooks/usePhysicsEngine.ts`.
🎯 Why: These functions were flagged by `knip` as unused exports. Since they are only used internally by the `usePhysicsEngine` hook in the same file, keeping them local to the module reduces the public API surface and correctly resolves the static analysis warnings without altering any functionality.
🔬 Verification: Ran `npx knip` to verify the unused export warnings were resolved. Tested with `vitest` to ensure no runtime breakages, and ran `npm run lint` & `npm run build` which passed successfully.

---
*PR created automatically by Jules for task [8539113493272832699](https://jules.google.com/task/8539113493272832699) started by @2fst4u*