### PR TITLE
Fix transformer Match suggestion drifting/flapping on re-solve

### DIFF
--- a/src/components/Panel/TransformerControl.tsx
+++ b/src/components/Panel/TransformerControl.tsx
@@ -84,8 +84,10 @@ function TransformerRatioInput({
  * Calculates the optimal transformer ratio for the current antenna.
  * Derived from the raw antenna feedpoint impedance, recovered from the NEC
  * source reading by de-embedding the feedline when one is present.
- * This is stable — it does not depend on the ratio currently applied —
- * so clicking Match never oscillates.
+ * With a feedline the NEC reading itself bakes in the applied ratio, so the
+ * recovered impedance only settles to a stable value once it is matched;
+ * `suggestedTransformerRatio` applies a hysteresis dead-band so clicking Match
+ * converges to a single value instead of oscillating by ±1 each re-solve.
  */
 function calculateOptimalRatio(
   result: SimulationResult | null,

--- a/src/components/Panel/TransformerControl.tsx
+++ b/src/components/Panel/TransformerControl.tsx
@@ -1,9 +1,9 @@
 import { useState } from 'react';
 import { useAntennaStore } from '../../store/antennaStore';
 import { useShallow } from 'zustand/react/shallow';
-import { TRANSFORMER_INSERTION_LOSS_DB, findFeedlinePreset } from '../../physics/constants';
-import { suggestedTransformerRatio } from '../../physics/impedance';
-import type { SimulationResult } from '../../physics/types';
+import { TRANSFORMER_INSERTION_LOSS_DB, Z0_SYSTEM, findFeedlinePreset } from '../../physics/constants';
+import { matchRatioForFeedpoint, suggestedTransformerRatio } from '../../physics/impedance';
+import type { ImpedanceResult, SimulationResult } from '../../physics/types';
 
 interface TransformerRatioInputProps {
   transformerRatio: number;
@@ -82,30 +82,38 @@ function TransformerRatioInput({
 
 /**
  * Calculates the optimal transformer ratio for the current antenna.
- * Derived from the raw antenna feedpoint impedance, recovered from the NEC
- * source reading by de-embedding the feedline when one is present.
- * With a feedline the NEC reading itself bakes in the applied ratio, so the
- * recovered impedance only settles to a stable value once it is matched;
- * `suggestedTransformerRatio` applies a hysteresis dead-band so clicking Match
- * converges to a single value instead of oscillating by ±1 each re-solve.
+ *
+ * The suggestion must be ONE value regardless of which transformer is currently
+ * fitted. How the antenna feedpoint is obtained differs by configuration:
+ *
+ *   • No feedline → the transformer is display-only (NEC never sees it), so
+ *     `result.impedance` already is the bare antenna feedpoint. Match it to the
+ *     50 Ω system impedance.
+ *   • Feedline present → the transformer is baked into the NEC model, so the
+ *     rig-end `result.impedance` depends on the fitted ratio *and* is polluted
+ *     by shield common-mode current — back-solving it makes the suggestion drift
+ *     every time it is applied. Instead match the separately-solved bare antenna
+ *     feedpoint (`feedpointImpedance`, transformer/feedline stripped) to the
+ *     feedline's characteristic impedance. That reference doesn't move when the
+ *     ratio changes, so the suggestion is stable.
  */
 function calculateOptimalRatio(
   result: SimulationResult | null,
+  feedpointImpedance: ImpedanceResult | null,
   feedlineActive: boolean,
   feedlineId: string,
-  feedlineLength: number,
-  frequency: number,
   transformerRatio: number
 ): number | null {
   if (!result) return null;
   if (!feedlineActive) {
     return suggestedTransformerRatio(result.impedance, transformerRatio);
   }
+  // Need the transformer-independent reference; until it arrives, offer nothing
+  // rather than a value derived from the ratio-dependent rig-end reading.
+  if (!feedpointImpedance) return null;
   const preset = findFeedlinePreset(feedlineId);
-  const electricalLengthM = feedlineLength / Math.max(0.05, preset.velocityFactor);
-  const lambdaVacuumM = 299.792458 / frequency;
-  const lengthLambdas = electricalLengthM / lambdaVacuumM;
-  return suggestedTransformerRatio(result.impedance, transformerRatio, preset.z0, lengthLambdas);
+  const target = preset.z0 > 0 ? preset.z0 : Z0_SYSTEM;
+  return matchRatioForFeedpoint(feedpointImpedance.R, target);
 }
 
 /**
@@ -124,18 +132,16 @@ export function TransformerControl() {
     transformerEnabled,
     transformerRatio,
     feedlineId,
-    feedlineLength,
-    frequency,
     result,
+    feedpointImpedance,
     setTransformerEnabled,
     setTransformerRatio,
   } = useAntennaStore(useShallow((s) => ({
     transformerEnabled: s.transformerEnabled,
     transformerRatio: s.transformerRatio,
     feedlineId: s.feedlineId,
-    feedlineLength: s.feedlineLength,
-    frequency: s.frequency,
     result: s.result,
+    feedpointImpedance: s.feedpointImpedance,
     setTransformerEnabled: s.setTransformerEnabled,
     setTransformerRatio: s.setTransformerRatio,
   })));
@@ -143,10 +149,9 @@ export function TransformerControl() {
   const feedlineActive = feedlineId !== 'none';
   const optimalRatio = calculateOptimalRatio(
     result,
+    feedpointImpedance,
     feedlineActive,
     feedlineId,
-    feedlineLength,
-    frequency,
     transformerRatio
   );
 

--- a/src/hooks/usePhysicsEngine.ts
+++ b/src/hooks/usePhysicsEngine.ts
@@ -49,6 +49,7 @@ function handleWorkerMessage(
     useAntennaStore.getState()._setSimulationData(
       msg.result as SimulationResult,
       msg.sweep,
+      msg.feedpointImpedance ?? null,
     );
   } else if (msg.type === 'sweep') {
     if (msg.id !== latestId) return;
@@ -73,6 +74,16 @@ function buildWorkerRequest(
   const window = selectSwrWindow(state);
   const displayRatio = displayTransformerRatio(state);
 
+  // When a transformer is fitted over a feedline, the main solve bakes the
+  // transformer into the NEC model, so its rig-end impedance depends on the
+  // applied ratio and can't be back-solved into a stable Match suggestion.
+  // Solve the bare antenna feedpoint (feedline + transformer stripped) so the
+  // suggestion has a transformer-independent reference to match to the line.
+  const feedpointInput =
+    state.transformerEnabled && state.feedlineId !== 'none'
+      ? selectSimulationInput({ ...state, feedlineId: 'none', transformerEnabled: false })
+      : undefined;
+
   // Only the view window changed → re-sweep alone, but upgrade to a full
   // solve if a pattern result is still pending (otherwise it would be
   // discarded as stale, leaving the radiation pattern out of date).
@@ -93,6 +104,7 @@ function buildWorkerRequest(
     id,
     type: 'simulate',
     input,
+    feedpointInput,
     displayRatio,
     sweepPoints: LOD_CONFIG.sweepPoints,
     window,

--- a/src/physics/impedance.ts
+++ b/src/physics/impedance.ts
@@ -377,20 +377,16 @@ export function deembedThroughLine(
  *     optimal ratio matches that to the line's own characteristic impedance,
  *     flattening the line: round(R / z0Line).
  *
- * In exact algebra the recovered feedpoint R does not depend on the current
- * ratio (the de-embed inverts the line exactly and the ×ratio undoes the NT
- * card). In the live solver it is only *approximately* invariant: the line
- * de-embed is very sensitive near quarter-wave line lengths and the shield
- * choke never perfectly zeroes residual common-mode current, so each re-solve
- * recovers a slightly different R. Rounding that to an integer would otherwise
- * flip the suggestion by ±1 every time it is applied — the "Match n:1" button
- * visibly flapping. A hysteresis dead-band fixes this: whenever the continuous
- * ideal ratio sits within a full step of the currently applied ratio, the
- * applied ratio is kept. Once `round(ideal)` is applied, re-solving reproduces
- * ~the same ideal, so the suggestion settles to a single stable value instead
- * of chasing its own tail.
+ * NOTE: with a feedline present this is only *approximately* stable — it has to
+ * back the antenna feedpoint out of the rig-end reading, which (because the
+ * source sits on the radiating shield) is contaminated by common-mode current
+ * that does not divide by the ratio, so applying the suggestion and re-solving
+ * can drift the value. Prefer `matchRatioForFeedpoint` against a bare-antenna
+ * feedpoint (solved with the transformer/feedline stripped) when one is
+ * available; this de-embed form is retained for the no-feedline case and as a
+ * fallback.
  *
- * Returns an integer ≥ 1 (or the applied ratio when held within the dead-band).
+ * Returns an integer ≥ 1.
  */
 export function suggestedTransformerRatio(
   zSrcReportedByNec: ImpedanceResult,
@@ -408,17 +404,19 @@ export function suggestedTransformerRatio(
     antennaR = currentRatio > 1 ? zLoad.R * currentRatio : zLoad.R;
     target = z0Line;
   }
+  return matchRatioForFeedpoint(antennaR, target);
+}
+
+/**
+ * Integer impedance-transformer ratio that best matches a real feedpoint
+ * resistance to a target impedance: round(R / target), clamped to ≥ 1.
+ *
+ * Fed a *transformer-independent* antenna feedpoint R (and the target = the
+ * feedline's characteristic impedance, or 50 Ω with no feedline), this yields a
+ * single stable suggestion that does not move when the suggestion is applied —
+ * because the bare feedpoint does not depend on the fitted transformer at all.
+ */
+export function matchRatioForFeedpoint(antennaR: number, target: number): number {
   if (!Number.isFinite(antennaR) || antennaR <= 0 || target <= 0) return 1;
-  const ideal = antennaR / target;
-  // Hysteresis: hold the applied ratio while the ideal is less than one integer
-  // step away, so a small solve-to-solve wobble in the recovered R doesn't keep
-  // re-rounding to a neighbouring integer (the source of the flapping).
-  if (
-    Number.isFinite(currentRatio) &&
-    currentRatio >= 1 &&
-    Math.abs(ideal - currentRatio) < 1
-  ) {
-    return currentRatio;
-  }
-  return Math.max(1, Math.round(ideal));
+  return Math.max(1, Math.round(antennaR / target));
 }

--- a/src/physics/impedance.ts
+++ b/src/physics/impedance.ts
@@ -377,12 +377,20 @@ export function deembedThroughLine(
  *     optimal ratio matches that to the line's own characteristic impedance,
  *     flattening the line: round(R / z0Line).
  *
- * Because the recovered feedpoint R does not depend on the current ratio
- * (the de-embed inverts the line exactly and the ×ratio undoes the NT card),
- * the suggestion is stable: applying it and re-simulating yields the same
- * value rather than chasing its own tail.
+ * In exact algebra the recovered feedpoint R does not depend on the current
+ * ratio (the de-embed inverts the line exactly and the ×ratio undoes the NT
+ * card). In the live solver it is only *approximately* invariant: the line
+ * de-embed is very sensitive near quarter-wave line lengths and the shield
+ * choke never perfectly zeroes residual common-mode current, so each re-solve
+ * recovers a slightly different R. Rounding that to an integer would otherwise
+ * flip the suggestion by ±1 every time it is applied — the "Match n:1" button
+ * visibly flapping. A hysteresis dead-band fixes this: whenever the continuous
+ * ideal ratio sits within a full step of the currently applied ratio, the
+ * applied ratio is kept. Once `round(ideal)` is applied, re-solving reproduces
+ * ~the same ideal, so the suggestion settles to a single stable value instead
+ * of chasing its own tail.
  *
- * Returns an integer ≥ 1.
+ * Returns an integer ≥ 1 (or the applied ratio when held within the dead-band).
  */
 export function suggestedTransformerRatio(
   zSrcReportedByNec: ImpedanceResult,
@@ -401,5 +409,16 @@ export function suggestedTransformerRatio(
     target = z0Line;
   }
   if (!Number.isFinite(antennaR) || antennaR <= 0 || target <= 0) return 1;
-  return Math.max(1, Math.round(antennaR / target));
+  const ideal = antennaR / target;
+  // Hysteresis: hold the applied ratio while the ideal is less than one integer
+  // step away, so a small solve-to-solve wobble in the recovered R doesn't keep
+  // re-rounding to a neighbouring integer (the source of the flapping).
+  if (
+    Number.isFinite(currentRatio) &&
+    currentRatio >= 1 &&
+    Math.abs(ideal - currentRatio) < 1
+  ) {
+    return currentRatio;
+  }
+  return Math.max(1, Math.round(ideal));
 }

--- a/src/physics/nec2Engine.ts
+++ b/src/physics/nec2Engine.ts
@@ -311,6 +311,22 @@ export class Nec2Engine implements Engine {
     }
   }
 
+  /**
+   * Single-frequency feedpoint impedance with no radiation pattern — far
+   * cheaper than a full simulate(). Used to obtain a *transformer-independent*
+   * antenna feedpoint (caller passes the bare antenna, no feedline/transformer)
+   * for the Match suggestion, so the suggested ratio is one stable value
+   * regardless of which transformer is currently fitted.
+   */
+  async feedpointImpedance(input: SimulationInput): Promise<ImpedanceResult> {
+    const results = await this.solveImpedanceSweep(input, 1, input.frequencyMHz, 0);
+    const z = results[0]?.impedance;
+    if (!z) {
+      throw new Error('NEC-2 did not produce a feedpoint impedance result.');
+    }
+    return z;
+  }
+
   async sweepImpedance(input: SimulationInput, opts: SweepOptions = {}): Promise<SweepPoint[]> {
     const points = Math.max(3, Math.round(opts.points ?? 15));
     // Explicit window → fixed single-pass sweep over exactly that range. This

--- a/src/store/antennaStore.ts
+++ b/src/store/antennaStore.ts
@@ -13,6 +13,7 @@ import { immer } from 'zustand/middleware/immer';
 import type {
   SimulationInput,
   SimulationResult,
+  ImpedanceResult,
   GroundParams,
   SweepPoint,
   Wire,
@@ -222,6 +223,14 @@ export interface AntennaState {
 
   // Solver output
   result: SimulationResult | null;
+  /**
+   * Bare antenna feedpoint impedance (no feedline, no transformer), solved
+   * alongside `result` only when a transformer is fitted over a feedline. It is
+   * the transformer-independent reference the Match suggestion matches to the
+   * feedline impedance, so the suggested ratio is stable no matter which
+   * transformer is currently fitted. Null when not applicable / not yet solved.
+   */
+  feedpointImpedance: ImpedanceResult | null;
   sweep: SweepPoint[];
   error: string | null;
   loading: boolean;
@@ -291,7 +300,11 @@ export interface AntennaState {
   setGeolocationStatus(s: AntennaState['geolocationStatus']): void;
 
   // Actions — internal (used by hooks/workers only, prefixed with _)
-  _setSimulationData(r: SimulationResult, sweep: readonly SweepPoint[]): void;
+  _setSimulationData(
+    r: SimulationResult,
+    sweep: readonly SweepPoint[],
+    feedpointImpedance?: ImpedanceResult | null,
+  ): void;
   /** Replace only the SWR sweep (efficient zoom/pan recompute — leaves the
    *  radiation pattern result untouched). */
   _setSweep(sweep: readonly SweepPoint[]): void;
@@ -389,6 +402,7 @@ export const useAntennaStore = create<AntennaState>()(
       geolocationStatus: 'idle',
 
       result: null,
+      feedpointImpedance: null,
       sweep: [],
       error: null,
       loading: false,
@@ -699,9 +713,10 @@ export const useAntennaStore = create<AntennaState>()(
       }),
       setGeolocationStatus: (st) => set((s) => { s.geolocationStatus = st; }),
 
-      _setSimulationData: (r, sweep) => set((s) => {
+      _setSimulationData: (r, sweep, feedpointImpedance) => set((s) => {
         s.result = r;
         s.sweep = [...sweep];
+        s.feedpointImpedance = feedpointImpedance ?? null;
         s.loading = false;
         s.error = null;
       }),

--- a/src/workers/physicsWorker.ts
+++ b/src/workers/physicsWorker.ts
@@ -10,7 +10,7 @@
 /// <reference lib="webworker" />
 
 import { Nec2Engine } from '../physics/nec2Engine';
-import type { SimulationInput, SimulationResult, SweepPoint } from '../physics/types';
+import type { SimulationInput, SimulationResult, SweepPoint, ImpedanceResult } from '../physics/types';
 
 /** Absolute frequency window the SWR sweep samples across. */
 export interface SweepWindow {
@@ -23,6 +23,13 @@ export type WorkerRequest =
       id: number;
       type: 'simulate';
       input: SimulationInput;
+      /**
+       * Optional bare-antenna input (no feedline/transformer) whose feedpoint
+       * impedance is solved alongside the main result. It gives the Match
+       * suggestion a transformer-independent reference so the suggested ratio
+       * doesn't drift each time it is applied.
+       */
+      feedpointInput?: SimulationInput;
       displayRatio?: number;
       sweepPoints?: number;
       window?: SweepWindow;
@@ -41,7 +48,14 @@ export type WorkerRequest =
 
 export type WorkerResponse =
   | { type: 'ready' }
-  | { id: number; type: 'result'; result: SimulationResult; sweep: readonly SweepPoint[] }
+  | {
+      id: number;
+      type: 'result';
+      result: SimulationResult;
+      sweep: readonly SweepPoint[];
+      /** Bare-antenna feedpoint impedance, present when `feedpointInput` was sent. */
+      feedpointImpedance?: ImpedanceResult;
+    }
   | { id: number; type: 'sweep'; sweep: readonly SweepPoint[] }
   | { id: number; type: 'error'; message: string };
 
@@ -79,6 +93,7 @@ engine
 ctx.addEventListener('message', (ev: MessageEvent<WorkerRequest>) => {
   const msg = ev.data;
   if (msg.type === 'simulate') {
+    const feedpointInput = msg.feedpointInput;
     Promise.all([
       engine.simulate(msg.input),
       engine.sweepImpedance(msg.input, {
@@ -86,9 +101,18 @@ ctx.addEventListener('message', (ev: MessageEvent<WorkerRequest>) => {
         displayRatio: msg.displayRatio,
         window: msg.window,
       }),
+      feedpointInput
+        ? engine.feedpointImpedance(feedpointInput)
+        : Promise.resolve(undefined),
     ])
-      .then(([result, sweep]) => {
-        ctx.postMessage({ id: msg.id, type: 'result', result, sweep } satisfies WorkerResponse);
+      .then(([result, sweep, feedpointImpedance]) => {
+        ctx.postMessage({
+          id: msg.id,
+          type: 'result',
+          result,
+          sweep,
+          feedpointImpedance,
+        } satisfies WorkerResponse);
       })
       .catch((err: unknown) => {
         ctx.postMessage({

--- a/tests/TransformerControl.test.tsx
+++ b/tests/TransformerControl.test.tsx
@@ -12,6 +12,7 @@ describe('TransformerControl', () => {
       transformerEnabled: false,
       transformerRatio: 9,
       result: null,
+      feedpointImpedance: null,
     });
   });
 
@@ -116,17 +117,34 @@ describe('TransformerControl', () => {
     expect(useAntennaStore.getState().transformerRatio).toBe(2);
   });
 
-  it('suggests optimal ratio considering feedline if active', () => {
+  it('suggests optimal ratio from the bare feedpoint when a feedline is active', () => {
     useAntennaStore.setState({
       transformerEnabled: true,
       transformerRatio: 1,
       feedlineId: 'rg58',
       feedlineLength: 0,
       frequency: 14.1,
-      result: { impedance: { R: 200, X: 0 } } as unknown as SimulationResult
+      // Rig-end reading (ratio-dependent, common-mode polluted) — must NOT be used.
+      result: { impedance: { R: 999, X: 0 } } as unknown as SimulationResult,
+      // Bare antenna feedpoint (transformer-independent) → round(200/50) = 4:1.
+      feedpointImpedance: { R: 200, X: 0 },
     });
     const { getByRole } = render(<TransformerControl />);
-    expect(getByRole('button', { name: /Match/i })).not.toBeNull();
+    const button = getByRole('button', { name: /Match transformer ratio to 4:1/i });
+    expect(button).not.toBeNull();
+    expect(button.textContent).toContain('Match 4:1');
+  });
+
+  it('offers no feedline match until the bare feedpoint reference has arrived', () => {
+    useAntennaStore.setState({
+      transformerEnabled: true,
+      transformerRatio: 1,
+      feedlineId: 'rg58',
+      result: { impedance: { R: 200, X: 0 } } as unknown as SimulationResult,
+      feedpointImpedance: null,
+    });
+    const { queryByRole } = render(<TransformerControl />);
+    expect(queryByRole('button', { name: /Match/i })).toBeNull();
   });
 
   it('updates localRatio from store when not focused', async () => {

--- a/tests/impedance.test.ts
+++ b/tests/impedance.test.ts
@@ -481,6 +481,24 @@ describe('suggestedTransformerRatio', () => {
     expect(suggestedTransformerRatio({ R: 0, X: 0 }, 1)).toBe(1);
     expect(suggestedTransformerRatio({ R: -5, X: 0 }, 1)).toBe(1);
   });
+
+  it('hysteresis: holds the applied ratio when the ideal is within one step (no ±1 flap)', () => {
+    // Ideal = 330/50 = 6.6 → would naively round to 7. But while the user is
+    // already at 6:1, a small solve-to-solve wobble must not bump the suggestion
+    // to 7 (and then back to 6 on the next solve) — the reported flapping.
+    expect(suggestedTransformerRatio({ R: 330, X: 0 }, 6)).toBe(6);
+    expect(suggestedTransformerRatio({ R: 320, X: 0 }, 6)).toBe(6); // ideal 6.4
+    // From a ratio more than a full step away it still proposes the real optimum.
+    expect(suggestedTransformerRatio({ R: 330, X: 0 }, 1)).toBe(7);
+  });
+
+  it('hysteresis: applying the rounded suggestion makes it a stable fixed point', () => {
+    // Start far from optimal: ideal 6.0, current 1 → suggests 6.
+    const first = suggestedTransformerRatio({ R: 300, X: 0 }, 1);
+    expect(first).toBe(6);
+    // Now at 6:1, even a wobble that drifts the ideal up to ~6.9 holds at 6.
+    expect(suggestedTransformerRatio({ R: 345, X: 0 }, first)).toBe(6);
+  });
 });
 
 describe('transformThroughLine edge cases', () => {

--- a/tests/impedance.test.ts
+++ b/tests/impedance.test.ts
@@ -1,6 +1,6 @@
 import { vi } from "vitest";
 import { describe, expect, it } from 'vitest';
-import { swr, mismatchLossFactor, transformImpedance, deembedThroughLine, transformThroughLine, transformWithTransformerAtAntenna, realizedGainWithTransformer, suggestedTransformerRatio, displayedFeedMetrics, atuLossDb, feedlineLossUnderSwrDb } from '../src/physics/impedance';
+import { swr, mismatchLossFactor, transformImpedance, deembedThroughLine, transformThroughLine, transformWithTransformerAtAntenna, realizedGainWithTransformer, suggestedTransformerRatio, matchRatioForFeedpoint, displayedFeedMetrics, atuLossDb, feedlineLossUnderSwrDb } from '../src/physics/impedance';
 import { TRANSFORMER_INSERTION_LOSS_DB, ATU_COMPONENT_Q, feedlineLossDb, findFeedlinePreset } from '../src/physics/constants';
 import type { SimulationResult } from '../src/physics/types';
 
@@ -482,22 +482,32 @@ describe('suggestedTransformerRatio', () => {
     expect(suggestedTransformerRatio({ R: -5, X: 0 }, 1)).toBe(1);
   });
 
-  it('hysteresis: holds the applied ratio when the ideal is within one step (no ±1 flap)', () => {
-    // Ideal = 330/50 = 6.6 → would naively round to 7. But while the user is
-    // already at 6:1, a small solve-to-solve wobble must not bump the suggestion
-    // to 7 (and then back to 6 on the next solve) — the reported flapping.
-    expect(suggestedTransformerRatio({ R: 330, X: 0 }, 6)).toBe(6);
-    expect(suggestedTransformerRatio({ R: 320, X: 0 }, 6)).toBe(6); // ideal 6.4
-    // From a ratio more than a full step away it still proposes the real optimum.
-    expect(suggestedTransformerRatio({ R: 330, X: 0 }, 1)).toBe(7);
+});
+
+describe('matchRatioForFeedpoint', () => {
+  it('rounds R/target to the nearest integer ratio', () => {
+    expect(matchRatioForFeedpoint(73, 50)).toBe(1);   // dipole → 50 Ω
+    expect(matchRatioForFeedpoint(300, 50)).toBe(6);  // folded dipole → 50 Ω
+    expect(matchRatioForFeedpoint(450, 50)).toBe(9);
+    expect(matchRatioForFeedpoint(300, 450)).toBe(1); // 300 Ω feedpoint → 450 Ω line
   });
 
-  it('hysteresis: applying the rounded suggestion makes it a stable fixed point', () => {
-    // Start far from optimal: ideal 6.0, current 1 → suggests 6.
-    const first = suggestedTransformerRatio({ R: 300, X: 0 }, 1);
-    expect(first).toBe(6);
-    // Now at 6:1, even a wobble that drifts the ideal up to ~6.9 holds at 6.
-    expect(suggestedTransformerRatio({ R: 345, X: 0 }, first)).toBe(6);
+  it('is independent of any fitted transformer (the value never moves once applied)', () => {
+    // The bare feedpoint R is the same no matter which ratio is currently fitted,
+    // so re-evaluating after applying the suggestion yields the same number —
+    // this is what stops the 6 → 9 → 13 runaway.
+    const ra = 300; // bare antenna feedpoint, transformer-independent
+    const r1 = matchRatioForFeedpoint(ra, 50);
+    const r2 = matchRatioForFeedpoint(ra, 50); // "after applying r1 and re-solving"
+    expect(r1).toBe(6);
+    expect(r2).toBe(6);
+  });
+
+  it('clamps to ≥ 1 and guards degenerate inputs', () => {
+    expect(matchRatioForFeedpoint(10, 50)).toBe(1);  // round(0.2) → 1
+    expect(matchRatioForFeedpoint(0, 50)).toBe(1);
+    expect(matchRatioForFeedpoint(-5, 50)).toBe(1);
+    expect(matchRatioForFeedpoint(300, 0)).toBe(1);
   });
 });
 


### PR DESCRIPTION
## Problem

The transformer **Match n:1** suggestion isn't stable: with a feedline fitted, clicking Match applies the ratio, the model re-solves, and the button comes back with a *different, larger* value — e.g. 6 → 9 → 13, climbing on every click.

## Root cause

This is specific to the **feedline-present** case:

1. When a feedline is active, the transformer ratio is baked into the NEC model as an `NT` card, and the excitation source sits at the **bottom of the shield wire** — which is modelled as a real radiating conductor (deliberately, to capture common-mode/pattern effects).
2. So `result.impedance` is the differential line input **in parallel with the shield's common-mode (monopole) impedance**. The differential part scales as `Ra/ratio` and shrinks as you match better; the common-mode part is roughly **constant** and does **not** divide by the ratio.
3. The old suggestion de-embedded the line and multiplied back by the applied ratio to recover the antenna feedpoint. Once you're reasonably matched, the constant common-mode part dominates the reading, so `de-embed(...)` stays ≈ constant and multiplying by `currentRatio` makes the suggestion grow every time it's applied — the 6 → 9 → 13 runaway.

(The first commit's hysteresis dead-band only absorbed ±1 wobble and did not address this positive-feedback divergence — it has been reverted.)

## Fix

Base the suggestion on a **transformer-independent** reference. Alongside the main solve, run a cheap **impedance-only** NEC pass of the **bare antenna** (feedline *and* transformer stripped) to get its true feedpoint `Ra`, then suggest `round(Ra / z0_line)`. The bare feedpoint doesn't depend on the fitted transformer at all, so the suggested ratio is a single stable value that doesn't move when applied.

The `NT` card stays baked into the main solve, so the radiation pattern's common-mode behaviour is unchanged — only the *suggestion* uses the clean reference.

### Changes
- `nec2Engine`: add `feedpointImpedance()` — single-frequency, no radiation pattern (much cheaper than a full solve).
- `physicsWorker`: optional `feedpointInput` on the `simulate` request; returns `feedpointImpedance`.
- `antennaStore`: carry `feedpointImpedance`; `usePhysicsEngine` sends the stripped input only when a transformer is fitted over a feedline.
- `impedance`: extract `matchRatioForFeedpoint(R, target)`; revert the hysteresis band-aid.
- `TransformerControl`: use the bare feedpoint for the feedline case (no-feedline case was already stable).

## Testing
- `npx vitest run` — 786 passed
- `tsc -p tsconfig.app.json --noEmit`, `eslint`, and `npm run build` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)