### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability via unsafe-inline styles

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,7 @@
 **Vulnerability:** The `resolveAsset` method in `Nec2Engine` dynamically constructed absolute URLs for assets but lacked validation, potentially allowing arbitrary protocol execution (e.g., `data:` or `blob:`) if `baseUrl` or `path` were manipulated.
 **Learning:** Even internal utility functions that dynamically construct resource URLs must explicitly validate protocols to prevent SSRF or unsafe code execution, ensuring defense in depth.
 **Prevention:** Always validate the `protocol` of dynamically generated `URL` objects against a strict allowlist (e.g., `['http:', 'https:', 'file:']`) before returning or using them for asset fetching.
+## 2025-02-14 - Remove Unsafe Inline Styles in CSP
+**Vulnerability:** The `style-src` directive in the Content-Security-Policy included `'unsafe-inline'`, which could allow attackers to inject malicious CSS or exploit cross-site scripting (XSS) vulnerabilities.
+**Learning:** Vite relies on injecting `<style>` tags during development (`npm run dev`), which necessitates `'unsafe-inline'` to prevent CSP violations. However, the production build (`npm run build`) correctly extracts CSS into separate files and React's inline styles apply via CSSOM, which complies with `style-src 'self'`.
+**Prevention:** Remove `'unsafe-inline'` from `style-src` in production headers (e.g., `public/_headers` and `index.html`) to maintain strict CSP and enforce secure style delivery, relying on Vite's asset extraction for production.

--- a/public/_headers
+++ b/public/_headers
@@ -10,7 +10,7 @@
   # Opt-out of FLoC and restricts sensitive APIs, acting as a defense-in-depth measure
   Permissions-Policy: accelerometer=(), camera=(), geolocation=(self), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=(), interest-cohort=()
   # Content Security Policy to enforce secure content delivery and prevent XSS
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; worker-src 'self' blob:; object-src 'none';
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self'; img-src 'self' data:; connect-src 'self'; worker-src 'self' blob:; object-src 'none';
   # Isolate the browsing context to same-origin to prevent cross-origin info leaks
   Cross-Origin-Opener-Policy: same-origin
   # Prevent cross-origin resource embedding for WASM isolation


### PR DESCRIPTION
🛡️ Sentinel: Improve Content Security Policy

🚨 Severity: HIGH
💡 Vulnerability: The `style-src` directive in the CSP included `'unsafe-inline'`, increasing the risk of Cross-Site Scripting (XSS) via injected malicious CSS.
🎯 Impact: Attackers could inject arbitrary CSS to exfiltrate data (e.g., via CSS keyloggers) or deface the application.
🔧 Fix: Removed `'unsafe-inline'` from the production `public/_headers` file.
✅ Verification: Ran `npm run build` and verified the generated `dist/` headers enforce the stricter policy, and ran tests.

---
*PR created automatically by Jules for task [9430796260011756754](https://jules.google.com/task/9430796260011756754) started by @2fst4u*