### PR TITLE
⚡ Bolt: Optimize colormap CSS gradient generation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -175,3 +175,7 @@
 ## 2026-06-19 - Group React hooks using Zustand's useShallow
 **Learning:** Using multiple separate `useAntennaStore((s) => s.property)` selector calls within a single component (like in `ColormapLegend.tsx`) incurs excess React hook allocation and store listener overhead, dragging down performance during high-frequency global state updates.
 **Action:** Group multiple related Zustand store property selections into a single `useAntennaStore(useShallow(...))` hook block. This optimizes component re-rendering and mitigates lifecycle bottlenecks.
+
+## 2026-06-24 - Avoid Array.prototype.map() in Colormap Legend
+**Learning:** In React UI components that render frequently (e.g. dynamic visualization colormaps based on varying settings), mapping over large colormap tables using `Array.prototype.map()` creates unnecessary GC pressure and functional allocation overhead.
+**Action:** Replaced `.map()` with a pre-allocated array (`new Array(len)`) and a standard `for` loop in `getColormapCssGradient` within `src/utils/colormap.ts` to measurably improve performance and reduce callback overhead.

--- a/src/utils/colormap.ts
+++ b/src/utils/colormap.ts
@@ -111,13 +111,16 @@ export function sampleColormapFast(table: readonly RGB[], t: number, out: Float3
  */
 export function getColormapCssGradient(name: ColormapName): string {
   const table = pickTable(name);
-  const stops = table.map((rgb, index) => {
-    const percentage = (index / (table.length - 1)) * 100;
+  const len = table.length;
+  const stops = new Array(len);
+  for (let index = 0; index < len; index++) {
+    const rgb = table[index];
+    const percentage = (index / (len - 1)) * 100;
     const r = Math.round(rgb[0] * 255);
     const g = Math.round(rgb[1] * 255);
     const b = Math.round(rgb[2] * 255);
-    return `rgb(${r}, ${g}, ${b}) ${percentage.toFixed(2)}%`;
-  });
+    stops[index] = `rgb(${r}, ${g}, ${b}) ${percentage.toFixed(2)}%`;
+  }
   // Draw the gradient from bottom (0%) to top (100%) so that
   // the highest value is at the top of the element.
   return `linear-gradient(to top, ${stops.join(', ')})`;


### PR DESCRIPTION
💡 What: Replaced `Array.prototype.map()` with a pre-allocated array (`new Array(len)`) and a standard `for` loop in `getColormapCssGradient` within `src/utils/colormap.ts`.
🎯 Why: To reduce intermediate array allocations, eliminate callback function overhead, and minimize garbage collection pressure during dynamic colormap updates.
📊 Impact: Measurable reduction in memory overhead and function execution time when rendering the colormap legend during settings changes.
🔬 Measurement: Profile the execution time and GC pauses of `getColormapCssGradient` during rapid colormap or dynamic range slider updates.

---
*PR created automatically by Jules for task [1693163266362114518](https://jules.google.com/task/1693163266362114518) started by @2fst4u*