### PR TITLE
🧪 Add tests for localStorage error paths in useUnitsPersistence

### DIFF
--- a/tests/useUnits.test.ts
+++ b/tests/useUnits.test.ts
@@ -67,6 +67,33 @@ describe('useUnitsPersistence', () => {
     expect(localStorage.getItem(STORAGE_KEY)).toBe('imperial');
   });
 
+
+
+  it('handles localStorage.getItem throwing an error gracefully', () => {
+    const originalGetItem = window.localStorage.getItem;
+    window.localStorage.getItem = () => { throw new Error('Access denied'); };
+
+    // Initializing hook while mock is active should not crash
+    expect(() => {
+      renderHook(() => useUnitsPersistence());
+    }).not.toThrow();
+
+    window.localStorage.getItem = originalGetItem;
+  });
+
+  it('handles localStorage.setItem throwing an error gracefully', () => {
+    useAntennaStore.setState({ units: 'imperial' });
+    const originalSetItem = window.localStorage.setItem;
+    window.localStorage.setItem = () => { throw new Error('Quota exceeded'); };
+
+    // Changing state while mock is active should not crash
+    expect(() => {
+      renderHook(() => useUnitsPersistence());
+    }).not.toThrow();
+
+    window.localStorage.setItem = originalSetItem;
+  });
+
   it('updates localStorage when units change in the store', () => {
     useAntennaStore.setState({ units: 'metric' });
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,10 +9,10 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       thresholds: {
-        statements: 71.56,
-        branches: 63.56,
-        functions: 75.36,
-        lines: 93.84,
+        statements: 72.27,
+        branches: 64.88,
+        functions: 76.69,
+        lines: 94.46,
       }
     }
   },


### PR DESCRIPTION
🎯 **What:** Added tests to cover the `localStorage.getItem` and `localStorage.setItem` error paths in the `useUnitsPersistence` hook.

---
*Closing: the intent of this PR is already covered in main — improved versions of these tests (using `vi.spyOn`) were merged as part of a subsequent PR. No new changes needed.*