### PR TITLE
🧪 Add error path tests for useTheme local storage access

### DIFF
--- a/tests/useTheme.test.ts
+++ b/tests/useTheme.test.ts
@@ -52,4 +52,51 @@ describe('useTheme hook', () => {
     expect(document.documentElement.dataset.theme).toBe('light');
     expect(window.localStorage.getItem('gv.theme')).toBe('light');
   });
+
+  it('ignores errors when localStorage.getItem throws on mount', () => {
+    const getItemSpy = vi.spyOn(window.localStorage, 'getItem').mockImplementation(() => {
+      throw new Error('Access denied');
+    });
+
+    expect(() => {
+      renderHook(() => useTheme());
+    }).not.toThrow();
+
+    expect(useAntennaStore.getState().theme).toBe('dark');
+
+    getItemSpy.mockRestore();
+  });
+
+  it('ignores errors when localStorage.setItem throws', () => {
+    renderHook(() => useTheme());
+
+    const setItemSpy = vi.spyOn(window.localStorage, 'setItem').mockImplementation(() => {
+      throw new Error('Access denied');
+    });
+
+    expect(() => {
+      act(() => {
+        useAntennaStore.getState().setTheme('light');
+      });
+    }).not.toThrow();
+
+    expect(document.documentElement.dataset.theme).toBe('light');
+
+    setItemSpy.mockRestore();
+  });
+
+  it('does not save to localStorage if theme is invalid', () => {
+    renderHook(() => useTheme());
+
+    const setItemSpy = vi.spyOn(window.localStorage, 'setItem');
+
+    act(() => {
+      useAntennaStore.setState({ theme: 'invalid-theme' as any });
+    });
+
+    expect(document.documentElement.dataset.theme).toBe('invalid-theme');
+    expect(setItemSpy).not.toHaveBeenCalledWith('gv.theme', 'invalid-theme');
+
+    setItemSpy.mockRestore();
+  });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,10 +9,10 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       thresholds: {
-        statements: 71.56,
-        branches: 63.56,
-        functions: 75.36,
-        lines: 93.84,
+        statements: 72.27,
+        branches: 64.91,
+        functions: 76.69,
+        lines: 94.46,
       }
     }
   },


### PR DESCRIPTION
🎯 **What:** Added tests for `localStorage` error paths in `useTheme.ts`.

---
*Closing: the intent of this PR is already covered in main — improved versions of these tests (using `vi.spyOn`) were merged as part of a subsequent PR. No new changes needed.*