### PR TITLE
📚 Archivist: Fix minimum tip height constraints for V and Loop antennas

### DIFF
--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -98,3 +98,7 @@
 
 **Learning:** The documentation for the Inverted-L antenna stated that its base starts at `VERTICAL_WHIP_BASE_GAP_M` (0.01 m) above ground, while earlier lines incorrectly implied the vertical whip base started at `height`. Additionally, `buildInvertedLWires` actually hardcodes the base start to exactly `VERTICAL_WHIP_BASE_GAP_M` regardless of `height`. The `docs/antenna-spec.md` needs to reflect this behavior properly across all monopole antennas.
 **Action:** Updated the vertical whip documentation to clarify that its base starts at the maximum of `height` and `VERTICAL_WHIP_BASE_GAP_M`, accurately reflecting how the gap ensures electrical isolation and making the comparison for the Inverted-L accurate.
+
+## 2026-06-28 - Minimum Tip Height Documentation Drift
+**Learning:** The documentation for Inverted-V, Sloping V, Delta Loop, and Terminated Delta antennas claimed the minimum tip/bottom wire height was `0.1` m. However, the codebase (`src/store/antennaGeometry.ts` and `src/physics/constants.ts`) enforces a minimum height of `SLOPING_V_MIN_TIP_Z_M` (`0.5` m) for these topologies to prevent unphysical results or NEC wire-touching-ground warnings.
+**Action:** Updated `docs/antenna-spec.md` to accurately reflect the `0.5` m minimum tip/bottom wire height limit enforced by the geometry builders for these antenna types.

--- a/docs/antenna-spec.md
+++ b/docs/antenna-spec.md
@@ -151,7 +151,7 @@ Every type below uses the coordinate conventions of Part I §1 and the glossary 
 - **Reference Length:** $0.485\lambda$ (Resonance).
 - **Angle/Slope:** Included angle $\alpha$ between legs (Default 120°). Mapping: $\alpha$ is the angle in the vertical plane.
 - **Tips:** Symmetric endpoints at $z = \text{height} - (L/2) \cdot \cos(\alpha/2)$.
-- **Min Height:** Tip height must be $\ge 0.1$ m.
+- **Min Height:** Tip height must be $\ge 0.5$ m.
 
 ### 7.2 Feedpoint Definition
 
@@ -189,7 +189,7 @@ Every type below uses the coordinate conventions of Part I §1 and the glossary 
 - **Reference Length:** $2.0\lambda$ **total** ($\approx 1.0\lambda$ per leg). The `length` parameter is the total radiating wire, split into two legs of $(L - \text{bridge})/2$ each. Traveling-wave structure, so no end-effect correction applies.
 - **Angle/Slope:** Included angle $\alpha$ (between legs) and slope angle $\theta$ (below horizontal).
 - **Tips:** Endpoints at ground-ward end of legs.
-- **Min Height:** Tip height must be $\ge 0.1$ m.
+- **Min Height:** Tip height must be $\ge 0.5$ m.
 
 ### 8.2 Feedpoint Definition
 
@@ -241,7 +241,7 @@ Every type below uses the coordinate conventions of Part I §1 and the glossary 
 - **Reference Length:** $1.02\lambda$ (Resonance).
 - **Angle/Slope:** Equilateral triangle in the vertical plane (flattens to isosceles when the mast height is below the equilateral height; perimeter preserved).
 - **Tips:** Bottom corners.
-- **Min Height:** Bottom wire must be $\ge 0.1$ m above ground.
+- **Min Height:** Bottom wire must be $\ge 0.5$ m above ground.
 
 ### 9.2 Feedpoint Definition
 
@@ -279,7 +279,7 @@ Every type below uses the coordinate conventions of Part I §1 and the glossary 
 - **Reference Length:** $1.02\lambda$ canonical, but resonance is not the design goal: a properly bridged termination flattens impedance across an octave or more, so the antenna is used multi-band rather than at a single design frequency.
 - **Angle/Slope:** Equilateral triangle in the vertical plane (flattens to isosceles when the mast height is below the equilateral height; perimeter preserved).
 - **Tips:** Bottom corners. The bottom wire is split at the centre with a gap (`TERMINATED_DELTA_CENTRE_GAP_M`).
-- **Min Height:** Bottom wire must be $\ge 0.1$ m above ground.
+- **Min Height:** Bottom wire must be $\ge 0.5$ m above ground.
 
 ### 10.2 Feedpoint Definition
 


### PR DESCRIPTION
💡 Problem: The documentation in `docs/antenna-spec.md` incorrectly claimed that the minimum tip or bottom wire height for Inverted-V, Sloping V, Delta Loop, and Terminated Delta antennas was `0.1` m. The codebase actually enforces a strict `0.5` m minimum (`SLOPING_V_MIN_TIP_Z_M`) to prevent NEC `GE 1` (wire touching ground) instability.
🎯 Fix: Updated the "Min Height" constraints for these four antenna topologies in `docs/antenna-spec.md` to accurately reflect the `0.5` m limit. Also logged the critical learning in `.jules/archivist.md`.
🧪 Verification: Checked the engine implementation (`src/physics/constants.ts` and `src/store/antennaGeometry.ts`), successfully ran tests (`npm run test -- --run`) and verified formatting.
🔎 Scope: This PR contains ONLY documentation changes and updating the Archivist's journal.

---
*PR created automatically by Jules for task [17758622557267173810](https://jules.google.com/task/17758622557267173810) started by @2fst4u*