### PR TITLE
🧹 Sweep: Extract useSceneConfiguration from SceneContents

### DIFF
--- a/.jules/sweep.md
+++ b/.jules/sweep.md
@@ -84,6 +84,9 @@
 ## 2025-02-13 - Removed unused exports from usePhysicsEngine
 **Learning:** Functions that are only used internally within their module should not be exported, as it bloats the public API and triggers unused export warnings in static analysis tools (like Knip).
 **Action:** Removed the `export` keyword from `handleWorkerMessage`, `buildWorkerRequest`, `useWorkerLifecycle`, and `usePhysicsScheduler` in `src/hooks/usePhysicsEngine.ts` to keep them local to the module.
+## 2024-06-29 - React Refactoring Pattern
+**Learning:** Functions over 100 lines inside a complex React component (like `SceneContents`) can be heavily refactored and cleaned up without introducing new files. By extracting massive, multi-variable block assignments and store reads into localized custom hooks (like `useSceneConfiguration`) living in the same file, the core view component becomes much more declarative and simpler to manage.
+**Action:** Created `useSceneConfiguration` in `src/components/Scene/AntennaScene.tsx` and moved all store state pulling and computed property logic inside it.
 >> ## 2025-02-28 - Extract Antenna Termination Logic
 >> **What:** The `buildTerminationElements` function in `src/store/antennaStore.ts` exceeded 100 lines and combined three separate logic branches (`sloping-v`, `terminated-delta`, and `folded-dipole`).
 >> **Why:** Splitting this high-complexity function into three smaller, focused helper functions and delegating logic via a `switch` statement makes the codebase significantly easier to read, maintain, and unit test in isolation.

--- a/src/components/Scene/AntennaScene.tsx
+++ b/src/components/Scene/AntennaScene.tsx
@@ -20,36 +20,9 @@ interface AntennaSceneProps {
   readonly snapshot?: ComparisonSnapshot | null;
 }
 
-function SceneContents({ snapshot = null }: AntennaSceneProps) {
-  const {
-    liveType,
-    liveLength,
-    liveHeight,
-    liveOrientation,
-    liveWireRadius,
-    liveSegments,
-    liveGroundId,
-    liveResult,
-    liveFeedlineId,
-    liveFeedlineLength,
-    liveFeedlineOffset,
-    liveWhipCounterpoise,
-    liveVAngle,
-    liveLegSlope,
-    liveFoldedDipoleAperture,
-    liveTransformerEnabled,
-    liveTransformerRatio,
-    liveFrequency,
-    liveAtuEnabled,
-    liveAtuMainFeedlineLength,
-    showGrid,
-    showAxes,
-    patternScale,
-    dbRange,
-    colorMaxDb,
-    colormap,
-    theme,
-  } = useAntennaStore(useShallow((s) => ({
+
+function useSceneConfiguration(snapshot: ComparisonSnapshot | null) {
+  const store = useAntennaStore(useShallow((s) => ({
     liveType: s.antennaType,
     liveLength: s.length,
     liveHeight: s.height,
@@ -79,22 +52,22 @@ function SceneContents({ snapshot = null }: AntennaSceneProps) {
     theme: s.theme,
   })));
 
-  const type = snapshot?.antennaType ?? liveType;
-  const length = snapshot?.length ?? liveLength;
-  const height = snapshot?.height ?? liveHeight;
-  const orientation = snapshot?.orientation ?? liveOrientation;
-  const wireRadius = snapshot?.wireRadius ?? liveWireRadius;
-  const segments = snapshot?.segments ?? liveSegments;
-  const groundId = snapshot?.groundId ?? liveGroundId;
-  const result = snapshot?.result ?? liveResult;
-  const feedlineId = snapshot?.feedlineId ?? liveFeedlineId;
-  const feedlineLength = snapshot?.feedlineLength ?? liveFeedlineLength;
-  const feedlineOffset = snapshot?.feedlineOffset ?? liveFeedlineOffset;
-  const whipCounterpoise = snapshot?.whipCounterpoise ?? liveWhipCounterpoise;
-  const vAngle = snapshot?.vAngle ?? liveVAngle;
-  const legSlope = snapshot?.legSlope ?? liveLegSlope;
-  const foldedDipoleAperture = snapshot?.foldedDipoleAperture ?? liveFoldedDipoleAperture;
-  const frequency = snapshot?.frequency ?? liveFrequency;
+  const type = snapshot?.antennaType ?? store.liveType;
+  const length = snapshot?.length ?? store.liveLength;
+  const height = snapshot?.height ?? store.liveHeight;
+  const orientation = snapshot?.orientation ?? store.liveOrientation;
+  const wireRadius = snapshot?.wireRadius ?? store.liveWireRadius;
+  const segments = snapshot?.segments ?? store.liveSegments;
+  const groundId = snapshot?.groundId ?? store.liveGroundId;
+  const result = snapshot?.result ?? store.liveResult;
+  const feedlineId = snapshot?.feedlineId ?? store.liveFeedlineId;
+  const feedlineLength = snapshot?.feedlineLength ?? store.liveFeedlineLength;
+  const feedlineOffset = snapshot?.feedlineOffset ?? store.liveFeedlineOffset;
+  const whipCounterpoise = snapshot?.whipCounterpoise ?? store.liveWhipCounterpoise;
+  const vAngle = snapshot?.vAngle ?? store.liveVAngle;
+  const legSlope = snapshot?.legSlope ?? store.liveLegSlope;
+  const foldedDipoleAperture = snapshot?.foldedDipoleAperture ?? store.liveFoldedDipoleAperture;
+  const frequency = snapshot?.frequency ?? store.liveFrequency;
 
   // Scale the pattern bubble to realized gain: the gain actually delivered after
   // feedpoint mismatch (and any transformer/ATU) loss. The offset is realizedGain
@@ -104,63 +77,104 @@ function SceneContents({ snapshot = null }: AntennaSceneProps) {
   const realizedGainOffsetDb = useMemo(() => {
     if (!result || result.maxRealizedGainDbi == null) return 0;
     const { displayedRealizedGainDbi } = displayedFeedMetrics(result, {
-      transformerEnabled: snapshot ? false : liveTransformerEnabled,
-      transformerRatio: snapshot ? 1 : liveTransformerRatio,
+      transformerEnabled: snapshot ? false : store.liveTransformerEnabled,
+      transformerRatio: snapshot ? 1 : store.liveTransformerRatio,
       feedlineActive: feedlineId !== 'none',
       atu: snapshot ? undefined : selectAtuConfig({
-        atuEnabled: liveAtuEnabled,
+        atuEnabled: store.liveAtuEnabled,
         frequency,
         feedlineId,
         feedlineLength,
-        atuMainFeedlineLength: liveAtuMainFeedlineLength,
+        atuMainFeedlineLength: store.liveAtuMainFeedlineLength,
       }),
     });
     return displayedRealizedGainDbi != null ? displayedRealizedGainDbi - result.maxGainDbi : 0;
-  }, [result, snapshot, liveTransformerEnabled, liveTransformerRatio, feedlineId, feedlineLength, liveAtuEnabled, frequency, liveAtuMainFeedlineLength]);
+  }, [
+    result,
+    snapshot,
+    store.liveTransformerEnabled,
+    store.liveTransformerRatio,
+    feedlineId,
+    feedlineLength,
+    store.liveAtuEnabled,
+    frequency,
+    store.liveAtuMainFeedlineLength,
+  ]);
+
+  return {
+    type,
+    length,
+    height,
+    orientation,
+    wireRadius,
+    segments,
+    groundId,
+    result,
+    feedlineId,
+    feedlineLength,
+    feedlineOffset,
+    whipCounterpoise,
+    vAngle,
+    legSlope,
+    foldedDipoleAperture,
+    frequency,
+    realizedGainOffsetDb,
+    showGrid: store.showGrid,
+    showAxes: store.showAxes,
+    patternScale: store.patternScale,
+    dbRange: store.dbRange,
+    colorMaxDb: store.colorMaxDb,
+    colormap: store.colormap,
+    theme: store.theme,
+  };
+}
+
+function SceneContents({ snapshot = null }: AntennaSceneProps) {
+  const config = useSceneConfiguration(snapshot);
 
   return (
     <>
-      <color attach="background" args={[THEME_COLORS[theme].background]} />
+      <color attach="background" args={[THEME_COLORS[config.theme].background]} />
       <ambientLight intensity={0.35} />
       <directionalLight position={[15, 25, 10]} intensity={1.15} castShadow />
       <directionalLight position={[-10, 8, -8]} intensity={0.45} />
 
       <Suspense fallback={null}>
-        <GroundPlane groundId={groundId} height={height} showGrid={showGrid} antennaType={type} />
+        <GroundPlane groundId={config.groundId} height={config.height} showGrid={config.showGrid} antennaType={config.type} />
         <AntennaWire
-          type={type}
-          length={length}
-          height={height}
-          orientation={orientation}
-          wireRadius={wireRadius}
-          segments={segments}
-          feedlineId={feedlineId}
-          feedlineLength={feedlineLength}
-          feedlineOffset={feedlineOffset}
-          whipCounterpoise={whipCounterpoise}
-          vAngle={vAngle}
-          legSlope={legSlope}
-          frequency={frequency}
-          foldedDipoleAperture={foldedDipoleAperture}
+          type={config.type}
+          length={config.length}
+          height={config.height}
+          orientation={config.orientation}
+          wireRadius={config.wireRadius}
+          segments={config.segments}
+          feedlineId={config.feedlineId}
+          feedlineLength={config.feedlineLength}
+          feedlineOffset={config.feedlineOffset}
+          whipCounterpoise={config.whipCounterpoise}
+          vAngle={config.vAngle}
+          legSlope={config.legSlope}
+          frequency={config.frequency}
+          foldedDipoleAperture={config.foldedDipoleAperture}
         />
         <RadiationPattern
-          result={result}
-          originY={type === 'inverted-l' ? 0 : height}
-          patternScale={patternScale}
-          dbRange={dbRange}
-          colorMaxDb={colorMaxDb}
-          colormap={colormap}
-          realizedGainOffsetDb={realizedGainOffsetDb}
+          result={config.result}
+          originY={config.type === 'inverted-l' ? 0 : config.height}
+          patternScale={config.patternScale}
+          dbRange={config.dbRange}
+          colorMaxDb={config.colorMaxDb}
+          colormap={config.colormap}
+          realizedGainOffsetDb={config.realizedGainOffsetDb}
         />
       </Suspense>
 
-      {showAxes && <axesHelper args={[6]} />}
+      {config.showAxes && <axesHelper args={[6]} />}
 
       <OrbitControls
         makeDefault
         enableDamping
         dampingFactor={0.08}
-        target={[0, height, 0]}
+        target={[0, config.height, 0]}
       />
       <GizmoHelper alignment="bottom-right" margin={[80, 80]}>
         <GizmoViewport axisColors={['#ff4466', '#44cc66', '#4488ff']} labelColor="white" />


### PR DESCRIPTION
🎯 **What:** Extracted configuration logic and complex state selection out of `SceneContents` into a new `useSceneConfiguration` custom hook within the same file.
💡 **Why:** `SceneContents` was originally over 100 lines and mostly filled with state destructuring and derived configuration. Extracting this out separates logic from rendering, making the codebase considerably easier to maintain, read, and test, resolving the "High Complexity Function" issue.
✅ **Verification:** Verified by reviewing the source changes to ensure no dependencies or side-effects were broken, passing all ESLint rules, and successfully running the entire Vitest test suite (`npm run test -- --run`).
✨ **Result:** Clean, focused, and minimal `SceneContents` component with an explicit configuration hook managing logic.

---
*PR created automatically by Jules for task [10152139031108299836](https://jules.google.com/task/10152139031108299836) started by @2fst4u*