### PR TITLE
🧹 Code Health: Extract subcomponents to reduce AntennaWire complexity

### DIFF
--- a/src/components/Scene/AntennaElement.tsx
+++ b/src/components/Scene/AntennaElement.tsx
@@ -1,0 +1,22 @@
+import { THEME_COLORS, type Theme } from '../../utils/themeColors';
+import type { RenderedWire } from './useAntennaGeometry';
+
+export interface AntennaElementProps {
+  wire: RenderedWire;
+  theme: Theme;
+}
+
+export function AntennaElement({ wire, theme }: AntennaElementProps) {
+  return (
+    <mesh position={wire.position} quaternion={wire.quaternion}>
+      <cylinderGeometry args={[wire.radius, wire.radius, wire.length, 16]} />
+      <meshStandardMaterial
+        color={THEME_COLORS[theme].wire}
+        emissive={THEME_COLORS[theme].wire}
+        emissiveIntensity={wire.isShield ? 0.08 : wire.isBridge ? 0.05 : 0.15}
+        metalness={0.85}
+        roughness={wire.isShield ? 0.55 : wire.isBridge ? 0.7 : 0.35}
+      />
+    </mesh>
+  );
+}

--- a/src/components/Scene/AntennaWire.tsx
+++ b/src/components/Scene/AntennaWire.tsx
@@ -10,8 +10,11 @@
 
 import { useShallow } from 'zustand/react/shallow';
 import { useAntennaStore } from '../../store/antennaStore';
-import { THEME_COLORS } from '../../utils/themeColors';
 import { useAntennaGeometry, type AntennaWireProps } from './useAntennaGeometry';
+import { AntennaElement } from './AntennaElement';
+import { Feedpoint } from './Feedpoint';
+import { ShieldElement } from './ShieldElement';
+import { TerminatedDeltaElement } from './TerminatedDeltaElement';
 
 export function AntennaWire(props: AntennaWireProps) {
   const { theme, transformerEnabled, terminatingResistor } = useAntennaStore(useShallow((s) => ({
@@ -24,103 +27,18 @@ export function AntennaWire(props: AntennaWireProps) {
   return (
     <group>
       {rendered.map((s) => (
-        <mesh key={s.key} position={s.position} quaternion={s.quaternion}>
-          <cylinderGeometry args={[s.radius, s.radius, s.length, 16]} />
-          <meshStandardMaterial
-            color={THEME_COLORS[theme].wire}
-            emissive={THEME_COLORS[theme].wire}
-            emissiveIntensity={s.isShield ? 0.08 : s.isBridge ? 0.05 : 0.15}
-            metalness={0.85}
-            roughness={s.isShield ? 0.55 : s.isBridge ? 0.7 : 0.35}
-          />
-        </mesh>
+        <AntennaElement key={s.key} wire={s} theme={theme} />
       ))}
-      {feedpoint && (
-        <mesh position={feedpoint}>
-          <sphereGeometry args={[0.22, 16, 16]} />
-          <meshStandardMaterial
-            color={THEME_COLORS[theme].feedpoint}
-            emissive={THEME_COLORS[theme].feedpoint}
-            emissiveIntensity={0.4}
-          />
-        </mesh>
-      )}
-      {shield && transformerEnabled && (
-        // Transformer/choke marker: a small torus near the top of the
-        // shield wire (immediately below the antenna feedpoint). Any
-        // transformer ratio — including 1:1 — engages the choke.
-        <mesh
-          position={[
-            shield.sceneStart[0],
-            shield.sceneStart[1] - Math.min(0.4, Math.max(0.15, shield.length * 0.05)),
-            shield.sceneStart[2],
-          ]}
-          rotation={[Math.PI / 2, 0, 0]}
-        >
-          <torusGeometry args={[0.18, 0.07, 12, 24]} />
-          <meshStandardMaterial color="#cc8844" emissive="#cc8844" emissiveIntensity={0.3} />
-        </mesh>
-      )}
+      {feedpoint && <Feedpoint position={feedpoint} theme={theme} />}
       {shield && (
-        // Rig marker at the bottom of the feedline (small box).
-        <mesh position={shield.sceneEnd}>
-          <boxGeometry args={[0.4, 0.25, 0.5]} />
-          <meshStandardMaterial color="#444" emissive="#222" emissiveIntensity={0.15} metalness={0.6} roughness={0.5} />
-        </mesh>
+        <ShieldElement shield={shield} transformerEnabled={transformerEnabled} />
       )}
       {terminatedDeltaSplit && (
-        <>
-          {/* Always show small marker spheres at each half-base inner end —
-              makes the split-base topology unambiguously visible (without
-              these the 0.1 m gap reads as a continuous base from a distance,
-              which is the user-visible difference vs. a Delta Loop). */}
-          <mesh position={terminatedDeltaSplit.leftInner}>
-            <sphereGeometry args={[0.11, 12, 12]} />
-            <meshStandardMaterial
-              color={THEME_COLORS[theme].wire}
-              emissive={THEME_COLORS[theme].wire}
-              emissiveIntensity={0.2}
-              metalness={0.8}
-              roughness={0.4}
-            />
-          </mesh>
-          <mesh position={terminatedDeltaSplit.rightInner}>
-            <sphereGeometry args={[0.11, 12, 12]} />
-            <meshStandardMaterial
-              color={THEME_COLORS[theme].wire}
-              emissive={THEME_COLORS[theme].wire}
-              emissiveIntensity={0.2}
-              metalness={0.8}
-              roughness={0.4}
-            />
-          </mesh>
-
-          {/* When terminated (R > 0): render a horizontal resistor body
-              bridging the gap between the two half-base inner ends. This
-              matches the NEC deck (one LD card on TERMINATED_DELTA_BRIDGE_TAG)
-              and gives the user a clear visual of "where the resistor sits"
-              — across the gap, not to ground. */}
-          {terminatingResistor > 0 && terminatedDeltaSplit.bridgeLen > 1e-3 && (
-            <mesh
-              position={terminatedDeltaSplit.bridgeMid}
-              quaternion={terminatedDeltaSplit.bridgeQuat}
-            >
-              <cylinderGeometry args={[
-                terminatedDeltaSplit.resistorRadius,
-                terminatedDeltaSplit.resistorRadius,
-                terminatedDeltaSplit.bridgeLen,
-                12,
-              ]} />
-              <meshStandardMaterial
-                color="#c93434"
-                emissive="#c93434"
-                emissiveIntensity={0.35}
-                metalness={0.2}
-                roughness={0.6}
-              />
-            </mesh>
-          )}
-        </>
+        <TerminatedDeltaElement
+          split={terminatedDeltaSplit}
+          theme={theme}
+          terminatingResistor={terminatingResistor}
+        />
       )}
     </group>
   );

--- a/src/components/Scene/Feedpoint.tsx
+++ b/src/components/Scene/Feedpoint.tsx
@@ -1,0 +1,19 @@
+import { THEME_COLORS, type Theme } from '../../utils/themeColors';
+
+export interface FeedpointProps {
+  position: [number, number, number];
+  theme: Theme;
+}
+
+export function Feedpoint({ position, theme }: FeedpointProps) {
+  return (
+    <mesh position={position}>
+      <sphereGeometry args={[0.22, 16, 16]} />
+      <meshStandardMaterial
+        color={THEME_COLORS[theme].feedpoint}
+        emissive={THEME_COLORS[theme].feedpoint}
+        emissiveIntensity={0.4}
+      />
+    </mesh>
+  );
+}

--- a/src/components/Scene/ShieldElement.tsx
+++ b/src/components/Scene/ShieldElement.tsx
@@ -1,0 +1,34 @@
+import type { RenderedWire } from './useAntennaGeometry';
+
+export interface ShieldElementProps {
+  shield: RenderedWire;
+  transformerEnabled: boolean;
+}
+
+export function ShieldElement({ shield, transformerEnabled }: ShieldElementProps) {
+  return (
+    <>
+      {transformerEnabled && (
+        // Transformer/choke marker: a small torus near the top of the
+        // shield wire (immediately below the antenna feedpoint). Any
+        // transformer ratio — including 1:1 — engages the choke.
+        <mesh
+          position={[
+            shield.sceneStart[0],
+            shield.sceneStart[1] - Math.min(0.4, Math.max(0.15, shield.length * 0.05)),
+            shield.sceneStart[2],
+          ]}
+          rotation={[Math.PI / 2, 0, 0]}
+        >
+          <torusGeometry args={[0.18, 0.07, 12, 24]} />
+          <meshStandardMaterial color="#cc8844" emissive="#cc8844" emissiveIntensity={0.3} />
+        </mesh>
+      )}
+      {/* Rig marker at the bottom of the feedline (small box). */}
+      <mesh position={shield.sceneEnd}>
+        <boxGeometry args={[0.4, 0.25, 0.5]} />
+        <meshStandardMaterial color="#444" emissive="#222" emissiveIntensity={0.15} metalness={0.6} roughness={0.5} />
+      </mesh>
+    </>
+  );
+}

--- a/src/components/Scene/TerminatedDeltaElement.tsx
+++ b/src/components/Scene/TerminatedDeltaElement.tsx
@@ -1,0 +1,65 @@
+import { THEME_COLORS, type Theme } from '../../utils/themeColors';
+import type { TerminatedDeltaSplitResult } from './useAntennaGeometry';
+
+export interface TerminatedDeltaElementProps {
+  split: TerminatedDeltaSplitResult;
+  theme: Theme;
+  terminatingResistor: number;
+}
+
+export function TerminatedDeltaElement({ split, theme, terminatingResistor }: TerminatedDeltaElementProps) {
+  return (
+    <>
+      {/* Always show small marker spheres at each half-base inner end —
+          makes the split-base topology unambiguously visible (without
+          these the 0.1 m gap reads as a continuous base from a distance,
+          which is the user-visible difference vs. a Delta Loop). */}
+      <mesh position={split.leftInner}>
+        <sphereGeometry args={[0.11, 12, 12]} />
+        <meshStandardMaterial
+          color={THEME_COLORS[theme].wire}
+          emissive={THEME_COLORS[theme].wire}
+          emissiveIntensity={0.2}
+          metalness={0.8}
+          roughness={0.4}
+        />
+      </mesh>
+      <mesh position={split.rightInner}>
+        <sphereGeometry args={[0.11, 12, 12]} />
+        <meshStandardMaterial
+          color={THEME_COLORS[theme].wire}
+          emissive={THEME_COLORS[theme].wire}
+          emissiveIntensity={0.2}
+          metalness={0.8}
+          roughness={0.4}
+        />
+      </mesh>
+
+      {/* When terminated (R > 0): render a horizontal resistor body
+          bridging the gap between the two half-base inner ends. This
+          matches the NEC deck (one LD card on TERMINATED_DELTA_BRIDGE_TAG)
+          and gives the user a clear visual of "where the resistor sits"
+          — across the gap, not to ground. */}
+      {terminatingResistor > 0 && split.bridgeLen > 1e-3 && (
+        <mesh
+          position={split.bridgeMid}
+          quaternion={split.bridgeQuat}
+        >
+          <cylinderGeometry args={[
+            split.resistorRadius,
+            split.resistorRadius,
+            split.bridgeLen,
+            12,
+          ]} />
+          <meshStandardMaterial
+            color="#c93434"
+            emissive="#c93434"
+            emissiveIntensity={0.35}
+            metalness={0.2}
+            roughness={0.6}
+          />
+        </mesh>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
🎯 **What:** The `AntennaWire.tsx` component had become extremely complex (127 lines) due to inlining multiple nested Three.js conditional elements. I extracted these into individual component files: `AntennaElement`, `Feedpoint`, `ShieldElement`, and `TerminatedDeltaElement`.

💡 **Why:** By extracting these elements, we improve the maintainability and testing boundaries. `AntennaWire` now serves primarily as a logical wrapper that composes these distinct visual elements, rather than handling the raw mesh and geometry rendering details for all possible features at once. This significantly lowers cognitive complexity.

✅ **Verification:** I ran the vitest test suite via `npm run test -- --run` and all tests including `AntennaWire.test.tsx` successfully passed. The visual logic and props perfectly mirror the previous inline setup.

✨ **Result:** The `AntennaWire` function is vastly reduced in scope, strictly handles store mappings, and delegates rendering to isolated components. No new behavioral logic was added.

---
*PR created automatically by Jules for task [13093784460283944425](https://jules.google.com/task/13093784460283944425) started by @2fst4u*