### PR TITLE
🎨 Palette: Add loading spinner to StatsReadout

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,9 @@
+1. **Update `StatsReadout.tsx` to include a loading spinner.**
+   - In `src/components/Panel/StatsReadout.tsx`, the loading state currently just says "Computing...". It's missing the `.spinner` class that is used in other similar loading states (like in `Propagation/ConditionsReadout.tsx` and `Charts/SWRChart.tsx`). I'll add the spinner here to make the visual feedback consistent and add a bit more delight to the UI while waiting for the calculation.
+
+2. **Run tests and linting to verify the changes.**
+   - Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.
+
+3. **Submit the PR.**
+   - Title: `🎨 Palette: Add loading spinner to StatsReadout`
+   - Description: Added a spinner to the loading state in StatsReadout to match the loading pattern used elsewhere in the application.

--- a/src/components/Panel/StatsReadout.tsx
+++ b/src/components/Panel/StatsReadout.tsx
@@ -42,7 +42,9 @@ export function StatsReadout() {
       <section className="panel-section">
         {/* SEO: Use sequential heading tags (H2) to follow document outline initiated by H1 */}
         <h2>Results</h2>
-        <div role="status" aria-live="polite" style={{ color: 'var(--text-muted)', fontSize: 12 }}>Computing…</div>
+        <div role="status" aria-live="polite" style={{ display: 'flex', alignItems: 'center', gap: '8px', color: 'var(--text-muted)', fontSize: 12 }}>
+          <div className="spinner" aria-hidden="true" /> Computing…
+        </div>
       </section>
     );
   }


### PR DESCRIPTION
💡 What: Added a `.spinner` element to the "Computing…" loading state inside `StatsReadout.tsx`.
🎯 Why: To maintain consistent visual feedback across the application. Other components (`ConditionsReadout.tsx`, `SWRChart.tsx`) already use the spinner for their loading states. A text-only "Computing…" state can make the app feel momentarily unresponsive, and adding the spinner gives immediate visual confirmation that work is happening.
📸 Before/After: Visual change verified via screenshot/video, replacing text-only "Computing..." with a spinning indicator next to the text.
♿ Accessibility: Placed `aria-hidden="true"` on the spinner div to ensure screen readers don't attempt to read the visual element, relying correctly on the existing `role="status"` and `aria-live="polite"` wrapper.

---
*PR created automatically by Jules for task [7649862559810672532](https://jules.google.com/task/7649862559810672532) started by @2fst4u*