### PR TITLE
🧪 Add tests for Feedpoint R3F component

### DIFF
--- a/tests/Feedpoint.test.tsx
+++ b/tests/Feedpoint.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { Feedpoint } from '../src/components/Scene/Feedpoint';
+import { THEME_COLORS } from '../src/utils/themeColors';
+
+describe('Feedpoint', () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let originalError: typeof console.error;
+
+  beforeEach(() => {
+    cleanup();
+    originalError = console.error;
+    // Suppress React warnings about custom elements
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation((msg, ...args) => {
+      if (typeof msg === 'string' && (msg.includes('is unrecognized in this browser') || msg.includes('React does not recognize') || msg.includes('using incorrect casing') || msg.includes('Received'))) {
+        return;
+      }
+      originalError(msg, ...args);
+    });
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+    vi.clearAllMocks();
+  });
+
+  it('renders correctly with dark theme', () => {
+    const position: [number, number, number] = [1, 2, 3];
+    const { container } = render(<Feedpoint position={position} theme="dark" />);
+
+    const mesh = container.querySelector('mesh');
+    expect(mesh).toBeTruthy();
+
+    // Check position
+    // R3F passes the props directly down in the render string
+    const positionAttr = mesh?.getAttribute('position');
+    expect(positionAttr).toBe('1,2,3');
+
+    // Check geometry
+    const geometry = container.querySelector('spheregeometry');
+    expect(geometry).toBeTruthy();
+    expect(geometry?.getAttribute('args')).toBe('0.22,16,16');
+
+    // Check material colors
+    const material = container.querySelector('meshstandardmaterial');
+    expect(material).toBeTruthy();
+    expect(material?.getAttribute('color')).toBe(THEME_COLORS.dark.feedpoint);
+    expect(material?.getAttribute('emissive')).toBe(THEME_COLORS.dark.feedpoint);
+    expect(material?.getAttribute('emissiveintensity')).toBe('0.4');
+  });
+
+  it('renders correctly with light theme', () => {
+    const position: [number, number, number] = [-5, 0, 10];
+    const { container } = render(<Feedpoint position={position} theme="light" />);
+
+    const material = container.querySelector('meshstandardmaterial');
+    expect(material).toBeTruthy();
+    expect(material?.getAttribute('color')).toBe(THEME_COLORS.light.feedpoint);
+    expect(material?.getAttribute('emissive')).toBe(THEME_COLORS.light.feedpoint);
+
+    const mesh = container.querySelector('mesh');
+    const positionAttr = mesh?.getAttribute('position');
+    expect(positionAttr).toBe('-5,0,10');
+  });
+});


### PR DESCRIPTION
🎯 **What:** The `Feedpoint` component in `src/components/Scene/Feedpoint.tsx` was missing test coverage. This is a basic React-Three-Fiber component that maps props to 3D meshes.
📊 **Coverage:** The new test file covers:
- Rendering the component in "dark" and "light" themes, confirming correct color strings.
- Verifying position stringifies correctly for R3F mapping.
- Verifying geometry arguments stringify correctly for R3F mapping.
✨ **Result:** Increased code coverage by adding a test file for the previously untested `Feedpoint` component, while setting a good standard for unit testing R3F prop-mapping without bringing in heavier renderer mocks.

---
*PR created automatically by Jules for task [2227926838098759779](https://jules.google.com/task/2227926838098759779) started by @2fst4u*