### PR TITLE
🧪 [testing improvement] Add tests for recommendedTerminatingResistor in antennaStore

### DIFF
--- a/tests/antennaStore.test.ts
+++ b/tests/antennaStore.test.ts
@@ -8,6 +8,9 @@ import {
   computeEffectiveSlope,
   legMultipleFromLength,
   computeOptimalVAngleDeg,
+  recommendedTerminatingResistor,
+  SLOPING_V_DEFAULT_TERMINATION_OHMS,
+  TERMINATED_DELTA_DEFAULT_TERMINATION_OHMS,
   SWR_VIEW_F_MIN_MHZ,
   SWR_VIEW_F_MAX_MHZ,
   LEFT_LEG_TAG,
@@ -494,6 +497,26 @@ describe("antennaStore selectors", () => {
       // Top stays at the feedpoint height.
       expect(shield.start[2]).toBe(5);
     });
+  });
+});
+
+
+describe("recommendedTerminatingResistor", () => {
+  it("returns SLOPING_V_DEFAULT_TERMINATION_OHMS for sloping-v", () => {
+    expect(recommendedTerminatingResistor("sloping-v", 0.5, 0.001)).toBe(SLOPING_V_DEFAULT_TERMINATION_OHMS);
+  });
+
+  it("returns TERMINATED_DELTA_DEFAULT_TERMINATION_OHMS for terminated-delta", () => {
+    expect(recommendedTerminatingResistor("terminated-delta", 0.5, 0.001)).toBe(TERMINATED_DELTA_DEFAULT_TERMINATION_OHMS);
+  });
+
+  it("calculates correct rounded impedance for folded-dipole", () => {
+    // 120 * acosh(0.5 / (2 * 0.001)) = 120 * acosh(250) ≈ 120 * 6.2146 ≈ 746
+    expect(recommendedTerminatingResistor("folded-dipole", 0.5, 0.001)).toBe(746);
+  });
+
+  it("returns 0 for unsupported antenna types like dipole", () => {
+    expect(recommendedTerminatingResistor("dipole", 0.5, 0.001)).toBe(0);
   });
 });
 


### PR DESCRIPTION
🎯 **What:** The `recommendedTerminatingResistor` function in `src/store/antennaStore.ts` lacked test coverage despite being a highly testable pure function.
📊 **Coverage:** Added four test cases inside `tests/antennaStore.test.ts`:
- Returns accurate constant resistance for `sloping-v`.
- Returns accurate constant resistance for `terminated-delta`.
- Returns mathematically correct rounded impedance for `folded-dipole`.
- Returns zero for fallback paths (`dipole`, etc).
✨ **Result:** Enhanced the overall codebase reliability by covering branch logic and impedance computations in unit tests. Total passing test cases increased to 801.

---
*PR created automatically by Jules for task [17966269773464146288](https://jules.google.com/task/17966269773464146288) started by @2fst4u*