### PR TITLE
🧪 Testing: Improve findSwrBands coverage and remove dead interpolation branch

### DIFF
--- a/src/physics/bandwidth.ts
+++ b/src/physics/bandwidth.ts
@@ -48,12 +48,12 @@ export function findSwrBands<T>(
 
     if (prevS > threshold && currS <= threshold) {
       // Entering a band.
-      const t = currS === prevS ? 0 : (threshold - prevS) / (currS - prevS);
+      const t = (threshold - prevS) / (currS - prevS);
       curLow = prevF + t * (currF - prevF);
       curLowClipped = false;
     } else if (prevS <= threshold && currS > threshold && curLow !== null) {
       // Leaving a band.
-      const t = currS === prevS ? 0 : (threshold - prevS) / (currS - prevS);
+      const t = (threshold - prevS) / (currS - prevS);
       const highEdge = prevF + t * (currF - prevF);
       bands.push({ fLow: curLow, fHigh: highEdge, lowClipped: curLowClipped, highClipped: false });
       curLow = null;

--- a/tests/swrBands.test.ts
+++ b/tests/swrBands.test.ts
@@ -59,6 +59,43 @@ describe('findSwrBands', () => {
   it('handles an empty sweep', () => {
     expect(findBandsHelper([], [], 2)).toHaveLength(0);
   });
+
+  it('handles division by zero mathematically identical cases in findSwrBands logic (entering band without zero division)', () => {
+    // Prev > threshold, Curr <= threshold. Prev=2.1, Curr=1.9, threshold=2.0
+    // Tests the path without the ternary.
+    const bands = findBandsHelper([7.0, 7.5], [2.1, 1.9], 2.0);
+    expect(bands).toHaveLength(1);
+  });
+
+  it('flags a band clipped at the high edge only', () => {
+    // It enters the band but the sweep ends before it leaves.
+    const bands = findBandsHelper([7.0, 7.1, 7.2], [2.5, 1.2, 1.5], 2);
+    expect(bands).toHaveLength(1);
+    expect(bands[0]!.lowClipped).toBe(false);
+    expect(bands[0]!.highClipped).toBe(true);
+    expect(bands[0]!.fLow).toBeCloseTo(7.0 + 0.1 * (0.5 / 1.3), 6);
+    expect(bands[0]!.fHigh).toBe(7.2);
+  });
+
+  it('leaves a band precisely handling interpolation on exit', () => {
+    const bands = findBandsHelper([7.0, 7.1, 7.2], [1.5, 1.2, 2.5], 2);
+    expect(bands).toHaveLength(1);
+    expect(bands[0]!.lowClipped).toBe(true);
+    expect(bands[0]!.highClipped).toBe(false);
+    expect(bands[0]!.fLow).toBe(7.0);
+    // Crosses threshold on exit between 7.1 and 7.2
+    expect(bands[0]!.fHigh).toBeCloseTo(7.1 + 0.1 * (0.8 / 1.3), 6);
+  });
+
+  it('handles division by zero mathematically identical cases in findSwrBands logic (leaving band without zero division)', () => {
+    // Prev <= threshold, Curr > threshold. Prev=1.9, Curr=2.1, threshold=2.0
+    // Tests the path without the ternary.
+    const bands = findBandsHelper([7.0, 7.5], [1.9, 2.1], 2.0);
+    expect(bands).toHaveLength(1);
+    expect(bands[0]!.lowClipped).toBe(true);
+    expect(bands[0]!.highClipped).toBe(false);
+    expect(bands[0]!.fHigh).toBeCloseTo(7.0 + 0.5 * (0.1 / 0.2), 6);
+  });
 });
 
 describe('formatBandwidth', () => {


### PR DESCRIPTION
🎯 **What:** The `findSwrBands` function had some interpolation edge case logic missing full test coverage, and its internal implementation had a mathematically impossible ternary condition (`currS === prevS ? 0 : ...`) within entering and leaving band checks (which inherently mandated strictly differing relative positions to the threshold).

📊 **Coverage:** Added test coverage for high-side clipped bands and verified edge case transitions (entering and leaving). Additionally, improved code health by eliminating the dead ternary branch.

✨ **Result:** Maintained high project coverage while removing a logical impossibility from the core bandwidth detection physics loop, adding safer validations for future updates.

---
*PR created automatically by Jules for task [15445123383630589281](https://jules.google.com/task/15445123383630589281) started by @2fst4u*