### PR TITLE
🧹 [Code Health] Extract sweep logic from Nec2Engine

### DIFF
--- a/src/physics/constants.ts
+++ b/src/physics/constants.ts
@@ -17,6 +17,12 @@ export const Z0_SYSTEM = 50;
 /** Default wire radius for HF antennas, metres (≈ 14 AWG copper ~ 2 mm). */
 export const DEFAULT_WIRE_RADIUS_M = 0.001;
 
+/** Lower bound for the SWR-sweep display window (MHz). */
+export const SWEEP_F_MIN_MHZ = 1.0;
+
+/** Upper bound for the SWR-sweep display window (MHz). */
+export const SWEEP_F_MAX_MHZ = 30;
+
 /**
  * Convenience: wavelength in metres for a given frequency in MHz.
  */

--- a/src/physics/nec2Engine.ts
+++ b/src/physics/nec2Engine.ts
@@ -22,8 +22,9 @@ import { buildNecCards } from './necCard';
 import { parseNecImpedanceSweep, parseNecOutput } from './necParser';
 import { computeTerminationDiagnostics } from './terminationDiagnostics';
 import { swr, mismatchLossFactor } from './impedance';
-import { findSwrBands, type SwrBand } from './bandwidth';
 import type { Engine, ImpedanceResult, SimulationInput, SimulationResult, SweepPoint } from './types';
+import { SWEEP_F_MIN_MHZ, SWEEP_F_MAX_MHZ } from './constants';
+import { clampSpan, runScan, adaptiveSweep } from './sweep';
 
 interface EmscriptenFS {
   writeFile(path: string, data: string | Uint8Array): void;
@@ -329,256 +330,26 @@ export class Nec2Engine implements Engine {
 
   async sweepImpedance(input: SimulationInput, opts: SweepOptions = {}): Promise<SweepPoint[]> {
     const points = Math.max(3, Math.round(opts.points ?? 15));
+    const solveCb = this.solveImpedanceSweep.bind(this);
     // Explicit window → fixed single-pass sweep over exactly that range. This
     // is the interactive zoom/pan path: the caller owns the framing, so no
     // auto-zoom is applied.
     if (opts.window) {
       const lo = Math.min(opts.window.startMHz, opts.window.endMHz);
       const hi = Math.max(opts.window.startMHz, opts.window.endMHz);
-      const start = Math.max(Nec2Engine.F_MIN_MHZ, lo);
-      const end = Math.min(Nec2Engine.F_MAX_MHZ, hi);
-      return this.runScan(input, start, end, points);
+      const start = Math.max(SWEEP_F_MIN_MHZ, lo);
+      const end = Math.min(SWEEP_F_MAX_MHZ, hi);
+      return runScan(solveCb, input, start, end, points);
     }
     // Explicit spanFraction → fixed single-pass sweep (back-compat for tests
     // and callers that want a specific window).
     if (opts.spanFraction !== undefined) {
-      const { start, end } = this.clampSpan(input.frequencyMHz, opts.spanFraction);
-      return this.runScan(input, start, end, points);
+      const { start, end } = clampSpan(input.frequencyMHz, opts.spanFraction);
+      return runScan(solveCb, input, start, end, points);
     }
     // Otherwise auto-frame the window around the antenna's 2:1 bandwidth.
-    return this.adaptiveSweep(input, points, Math.max(1, opts.displayRatio ?? 1), opts);
+    return adaptiveSweep(solveCb, input, points, Math.max(1, opts.displayRatio ?? 1), opts);
   }
-
-  // Lower bound for the SWR-sweep display window. Deliberately below the 1.8 MHz
-  // amateur 160 m floor (the operating-frequency control is still clamped to
-  // ≥ 1.8 MHz): broadband antennas — terminated folded dipoles especially —
-  // stay ≤ 2:1 down through and below 1.8 MHz, so anchoring the window at 1.8
-  // chopped the low side of the band off at the chart's left edge. Extending to
-  // 1.0 MHz lets the curve reach (or approach) its low 2:1 crossing so the band
-  // is framed in full rather than cut off.
-  private static readonly F_MIN_MHZ = 1.0;
-  private static readonly F_MAX_MHZ = 30;
-
-  private clampSpan(freq: number, spanFraction: number): { start: number; end: number } {
-    return {
-      start: Math.max(Nec2Engine.F_MIN_MHZ, freq * (1 - spanFraction / 2)),
-      end: Math.min(Nec2Engine.F_MAX_MHZ, freq * (1 + spanFraction / 2)),
-    };
-  }
-
-  /** Run one fixed-window scan over [start, end] with `n` evenly-spaced points. */
-  private async runScan(
-    input: SimulationInput,
-    start: number,
-    end: number,
-    n: number,
-  ): Promise<SweepPoint[]> {
-    const step = n > 1 ? (end - start) / (n - 1) : 0;
-    const parsedResults = await this.solveImpedanceSweep(input, n, start, step);
-    const sweep: SweepPoint[] = [];
-    for (let i = 0; i < n; i++) {
-      const frequencyMHz = i === n - 1 ? end : start + step * i;
-      const parsed = parsedResults[i];
-      if (!parsed?.impedance) {
-        throw new Error(`NEC-2 sweep missing impedance result for frequency ${frequencyMHz} MHz`);
-      }
-      sweep.push({
-        frequencyMHz,
-        swr: swr(parsed.impedance),
-        R: parsed.impedance.R,
-        X: parsed.impedance.X,
-      });
-    }
-    return sweep;
-  }
-
-  /**
-   * Adaptive sweep: expands a coarse characterisation window until the
-   * (display-effective) SWR rises above 2:1 on both sides of the minimum or
-   * the HF band limits are reached, locates the 2:1 crossings, then re-sweeps
-   * a window framed around that bandwidth (with margin) at full resolution.
-   * The result fills the chart whether the antenna is sharply resonant or
-   * broadband — no fixed span has to be guessed up-front.
-   *
-   * For multi-band antennas (e.g. terminated folded dipoles and end-feds
-   * resonant on harmonics), a secondary broad characterisation scan across the
-   * full HF range finds any additional ≤2:1 bands that fall outside the primary
-   * scan window, so the final sweep frames all usable bands in one chart.
-   */
-  private async adaptiveSweep(
-    input: SimulationInput,
-    points: number,
-    displayRatio: number,
-    opts: Pick<SweepOptions, 'charPoints' | 'maxIter' | 'skipBroadScan'> = {},
-  ): Promise<SweepPoint[]> {
-    const CHAR_POINTS = Math.max(3, opts.charPoints ?? 11);
-    const MAX_ITER = Math.max(1, opts.maxIter ?? 5);
-    const SKIP_BROAD = opts.skipBroadScan ?? false;
-
-    const { F_MIN_MHZ: F_MIN, F_MAX_MHZ: F_MAX } = Nec2Engine;
-    const f = input.frequencyMHz;
-    // Effective SWR = what the user sees (after any display-only balun).
-    const effSwr = (p: SweepPoint): number =>
-      displayRatio > 1 ? swr({ R: p.R / displayRatio, X: p.X / displayRatio }) : p.swr;
-
-    // Phase 1 — expand until both edges exceed 2:1, or we hit the band limits.
-    let span = 0.1;
-    const first = this.clampSpan(f, span);
-    let scan = await this.runScan(input, first.start, first.end, CHAR_POINTS);
-    let reachedLimits = false;
-    for (let iter = 0; iter < MAX_ITER; iter++) {
-      const lowOK = effSwr(scan[0]!) > 2;
-      const highOK = effSwr(scan[scan.length - 1]!) > 2;
-      const atLimits =
-        scan[0]!.frequencyMHz <= F_MIN + 1e-9 && scan[scan.length - 1]!.frequencyMHz >= F_MAX - 1e-9;
-      if (atLimits) { reachedLimits = true; break; }
-      if (lowOK && highOK) break;
-      span *= 3;
-      const { start, end } = this.clampSpan(f, span);
-      scan = await this.runScan(input, start, end, CHAR_POINTS);
-    }
-
-    const loEdge = scan[0]!.frequencyMHz;
-    const hiEdge = scan[scan.length - 1]!.frequencyMHz;
-
-    // Phase 2 — if the primary scan did not need to span the entire HF range
-    // (the ≤2:1 band near f is fully bounded), sweep the full range once with
-    // enough points to detect additional ≤2:1 bands that lie outside the
-    // primary window. Bands found there (e.g. lower-band resonances of a TFD
-    // or harmonic resonances of an EFHW) are merged with the primary bands so
-    // the final frame includes all of them.
-
-    // ⚡ Bolt: Avoid intermediate arrays by passing the scan array and accessors directly
-    // to findSwrBands, significantly reducing memory allocation overhead and GC pressure.
-    const primaryBands = findSwrBands(
-      scan,
-      (pt) => pt.frequencyMHz,
-      (pt) => effSwr(pt),
-      2,
-    );
-
-    // Frame the final sweep window around a set of ≤2:1 bands, keeping the
-    // operating-frequency marker in view and clamping to the HF band limits.
-    const frameWindow = (bands: readonly SwrBand[]): { start: number; end: number } => {
-      let winStart: number;
-      let winEnd: number;
-      if (bands.length > 0) {
-        const unionLow = bands[0]!.fLow;
-        const unionHigh = bands[bands.length - 1]!.fHigh;
-        const width = Math.max(unionHigh - unionLow, f * 0.02);
-        const margin = Math.max(width * 0.25, f * 0.02);
-        // When a band is clipped the actual crossing lies beyond the scan boundary.
-        // Use the appropriate HF limit as the anchor on that side.
-        const lowAnchor = bands[0]!.lowClipped
-          ? (reachedLimits ? loEdge : F_MIN)
-          : unionLow;
-        const highAnchor = bands[bands.length - 1]!.highClipped
-          ? (reachedLimits ? hiEdge : F_MAX)
-          : unionHigh;
-        winStart = lowAnchor - margin;
-        winEnd = highAnchor + margin;
-      } else {
-        // Never dips below 2:1 within the explored window — show what we scanned.
-        winStart = loEdge;
-        winEnd = hiEdge;
-      }
-      winStart = Math.max(F_MIN, Math.min(winStart, f));
-      winEnd = Math.min(F_MAX, Math.max(winEnd, f));
-      if (!(winEnd > winStart)) {
-        ({ start: winStart, end: winEnd } = this.clampSpan(f, 0.1));
-      }
-      return { start: winStart, end: winEnd };
-    };
-
-    // Width of the operating-frequency band — the primary band containing f, or
-    // failing that the primary band nearest f. Used to protect that band's
-    // resolution when deciding whether to widen the window for distant bands.
-    const operatingBandWidth = ((): number => {
-      if (primaryBands.length === 0) return f * 0.02;
-      let band = primaryBands[0];
-      let bestDistance = Infinity;
-      for (let i = 0; i < primaryBands.length; i++) {
-        const b = primaryBands[i];
-        if (f >= b.fLow && f <= b.fHigh) {
-          band = b;
-          break;
-        }
-        const d = Math.min(Math.abs(b.fLow - f), Math.abs(b.fHigh - f));
-        if (d < bestDistance) {
-          bestDistance = d;
-          band = b;
-        }
-      }
-      return Math.max(band.fHigh - band.fLow, f * 0.001);
-    })();
-
-    let allBands = primaryBands;
-    if (!reachedLimits && !SKIP_BROAD) {
-      // ~1 pt/MHz across 1.0–30 MHz — detects any band ≥ ~2 MHz wide.
-      // Scale down with CHAR_POINTS so low-power devices get proportionally
-      // fewer Wasm points here too (floor at 11 to retain ~1 pt/2.5 MHz).
-      const BROAD_CHAR_POINTS = Math.max(11, Math.round(CHAR_POINTS * 29 / 11));
-      const broadScan = await this.runScan(input, F_MIN, F_MAX, BROAD_CHAR_POINTS);
-      // Use a stricter threshold than the display 2:1 boundary. The broad scan
-      // has only ~1 pt/MHz resolution: a single sample can dip just under 2:1
-      // purely because of where it falls on a shallow, narrow dip. By requiring
-      // SWR < 1.5 at the coarse sample, we ensure only bands where the minimum
-      // SWR is genuinely well below 2:1 — and therefore reliably captured by
-      // the fine sweep — are included. Multi-band antennas (TFDs, EFHWs) have
-      // SWR comfortably below 1.5 in all their matching bands; marginal dips
-      // that only just breach 2:1 in the coarse scan are safely ignored.
-      const BROAD_THRESHOLD = 1.5;
-
-      // ⚡ Bolt: Avoid intermediate arrays by passing the broadScan array and accessors directly
-      const broadBands = findSwrBands(
-        broadScan,
-        (pt) => pt.frequencyMHz,
-        (pt) => effSwr(pt),
-        BROAD_THRESHOLD,
-      );
-      // Accept bands from the broad scan that lie clearly outside the primary
-      // scan window (0.5 MHz guard band avoids duplicating the primary band).
-      let merged: typeof primaryBands | null = null;
-      for (let i = 0; i < broadBands.length; i++) {
-        const b = broadBands[i];
-        if (b.fHigh < loEdge - 0.5 || b.fLow > hiEdge + 0.5) {
-          if (merged === null) {
-            merged = [];
-            for (let j = 0; j < primaryBands.length; j++) {
-              merged.push(primaryBands[j]);
-            }
-          }
-          merged.push(b);
-        }
-      }
-
-      if (merged !== null) {
-        merged.sort((a, b) => a.fLow - b.fLow);
-        if (primaryBands.length === 0) {
-          // No operating-frequency band to protect — show whatever band exists.
-          allBands = merged;
-        } else {
-          // Resolve-aware merge: only widen the window to include a distant band
-          // (e.g. a harmonic resonance of a narrowband dipole) if the operating
-          // band stays adequately sampled at the final point count. Otherwise
-          // the operating band falls between samples — its dip vanishes from the
-          // chart and the marker reads an off-resonance SWR — so we keep the
-          // window focused on the operating band instead.
-          const MIN_OPERATING_BAND_SAMPLES = 4;
-          const { start, end } = frameWindow(merged);
-          const spacing = points > 1 ? (end - start) / (points - 1) : end - start;
-          const samplesInOperatingBand = spacing > 0 ? operatingBandWidth / spacing : Infinity;
-          if (samplesInOperatingBand >= MIN_OPERATING_BAND_SAMPLES) {
-            allBands = merged;
-          }
-        }
-      }
-    }
-
-    const { start: winStart, end: winEnd } = frameWindow(allBands);
-    return this.runScan(input, winStart, winEnd, points);
-  }
-
   /** Simple in-process mutex so overlapping simulate() calls queue up. */
   private async acquire(): Promise<() => void> {
     const prev = this.lock;

--- a/src/physics/sweep.ts
+++ b/src/physics/sweep.ts
@@ -1,0 +1,233 @@
+import { swr } from './impedance';
+import { findSwrBands, type SwrBand } from './bandwidth';
+import type { ImpedanceResult, SimulationInput, SweepPoint } from './types';
+import type { SweepOptions } from './nec2Engine';
+import { SWEEP_F_MIN_MHZ, SWEEP_F_MAX_MHZ } from './constants';
+
+export type SolveImpedanceSweepCallback = (
+  input: SimulationInput,
+  points: number,
+  startFreq: number,
+  step: number
+) => Promise<{ impedance: ImpedanceResult | null; power: number | null }[]>;
+
+export function clampSpan(freq: number, spanFraction: number): { start: number; end: number } {
+  return {
+    start: Math.max(SWEEP_F_MIN_MHZ, freq * (1 - spanFraction / 2)),
+    end: Math.min(SWEEP_F_MAX_MHZ, freq * (1 + spanFraction / 2)),
+  };
+}
+
+/** Run one fixed-window scan over [start, end] with `n` evenly-spaced points. */
+export async function runScan(
+  solveImpedanceSweep: SolveImpedanceSweepCallback,
+  input: SimulationInput,
+  start: number,
+  end: number,
+  n: number,
+): Promise<SweepPoint[]> {
+  const step = n > 1 ? (end - start) / (n - 1) : 0;
+  const parsedResults = await solveImpedanceSweep(input, n, start, step);
+  const sweep: SweepPoint[] = [];
+  for (let i = 0; i < n; i++) {
+    const frequencyMHz = i === n - 1 ? end : start + step * i;
+    const parsed = parsedResults[i];
+    if (!parsed?.impedance) {
+      throw new Error(`NEC-2 sweep missing impedance result for frequency ${frequencyMHz} MHz`);
+    }
+    sweep.push({
+      frequencyMHz,
+      swr: swr(parsed.impedance),
+      R: parsed.impedance.R,
+      X: parsed.impedance.X,
+    });
+  }
+  return sweep;
+}
+
+/**
+ * Adaptive sweep: expands a coarse characterisation window until the
+ * (display-effective) SWR rises above 2:1 on both sides of the minimum or
+ * the HF band limits are reached, locates the 2:1 crossings, then re-sweeps
+ * a window framed around that bandwidth (with margin) at full resolution.
+ * The result fills the chart whether the antenna is sharply resonant or
+ * broadband — no fixed span has to be guessed up-front.
+ *
+ * For multi-band antennas (e.g. terminated folded dipoles and end-feds
+ * resonant on harmonics), a secondary broad characterisation scan across the
+ * full HF range finds any additional ≤2:1 bands that fall outside the primary
+ * scan window, so the final sweep frames all usable bands in one chart.
+ */
+export async function adaptiveSweep(
+  solveImpedanceSweep: SolveImpedanceSweepCallback,
+  input: SimulationInput,
+  points: number,
+  displayRatio: number,
+  opts: Pick<SweepOptions, 'charPoints' | 'maxIter' | 'skipBroadScan'> = {},
+): Promise<SweepPoint[]> {
+  const CHAR_POINTS = Math.max(3, opts.charPoints ?? 11);
+  const MAX_ITER = Math.max(1, opts.maxIter ?? 5);
+  const SKIP_BROAD = opts.skipBroadScan ?? false;
+
+  const f = input.frequencyMHz;
+  // Effective SWR = what the user sees (after any display-only balun).
+  const effSwr = (p: SweepPoint): number =>
+    displayRatio > 1 ? swr({ R: p.R / displayRatio, X: p.X / displayRatio }) : p.swr;
+
+  // Phase 1 — expand until both edges exceed 2:1, or we hit the band limits.
+  let span = 0.1;
+  const first = clampSpan(f, span);
+  let scan = await runScan(solveImpedanceSweep, input, first.start, first.end, CHAR_POINTS);
+  let reachedLimits = false;
+  for (let iter = 0; iter < MAX_ITER; iter++) {
+    const lowOK = effSwr(scan[0]!) > 2;
+    const highOK = effSwr(scan[scan.length - 1]!) > 2;
+    const atLimits =
+      scan[0]!.frequencyMHz <= SWEEP_F_MIN_MHZ + 1e-9 && scan[scan.length - 1]!.frequencyMHz >= SWEEP_F_MAX_MHZ - 1e-9;
+    if (atLimits) { reachedLimits = true; break; }
+    if (lowOK && highOK) break;
+    span *= 3;
+    const { start, end } = clampSpan(f, span);
+    scan = await runScan(solveImpedanceSweep, input, start, end, CHAR_POINTS);
+  }
+
+  const loEdge = scan[0]!.frequencyMHz;
+  const hiEdge = scan[scan.length - 1]!.frequencyMHz;
+
+  // Phase 2 — if the primary scan did not need to span the entire HF range
+  // (the ≤2:1 band near f is fully bounded), sweep the full range once with
+  // enough points to detect additional ≤2:1 bands that lie outside the
+  // primary window. Bands found there (e.g. lower-band resonances of a TFD
+  // or harmonic resonances of an EFHW) are merged with the primary bands so
+  // the final frame includes all of them.
+
+  // ⚡ Bolt: Avoid intermediate arrays by passing the scan array and accessors directly
+  // to findSwrBands, significantly reducing memory allocation overhead and GC pressure.
+  const primaryBands = findSwrBands(
+    scan,
+    (pt) => pt.frequencyMHz,
+    (pt) => effSwr(pt),
+    2,
+  );
+
+  // Frame the final sweep window around a set of ≤2:1 bands, keeping the
+  // operating-frequency marker in view and clamping to the HF band limits.
+  const frameWindow = (bands: readonly SwrBand[]): { start: number; end: number } => {
+    let winStart: number;
+    let winEnd: number;
+    if (bands.length > 0) {
+      const unionLow = bands[0]!.fLow;
+      const unionHigh = bands[bands.length - 1]!.fHigh;
+      const width = Math.max(unionHigh - unionLow, f * 0.02);
+      const margin = Math.max(width * 0.25, f * 0.02);
+      // When a band is clipped the actual crossing lies beyond the scan boundary.
+      // Use the appropriate HF limit as the anchor on that side.
+      const lowAnchor = bands[0]!.lowClipped
+        ? (reachedLimits ? loEdge : SWEEP_F_MIN_MHZ)
+        : unionLow;
+      const highAnchor = bands[bands.length - 1]!.highClipped
+        ? (reachedLimits ? hiEdge : SWEEP_F_MAX_MHZ)
+        : unionHigh;
+      winStart = lowAnchor - margin;
+      winEnd = highAnchor + margin;
+    } else {
+      // Never dips below 2:1 within the explored window — show what we scanned.
+      winStart = loEdge;
+      winEnd = hiEdge;
+    }
+    winStart = Math.max(SWEEP_F_MIN_MHZ, Math.min(winStart, f));
+    winEnd = Math.min(SWEEP_F_MAX_MHZ, Math.max(winEnd, f));
+    if (!(winEnd > winStart)) {
+      ({ start: winStart, end: winEnd } = clampSpan(f, 0.1));
+    }
+    return { start: winStart, end: winEnd };
+  };
+
+  // Width of the operating-frequency band — the primary band containing f, or
+  // failing that the primary band nearest f. Used to protect that band's
+  // resolution when deciding whether to widen the window for distant bands.
+  const operatingBandWidth = ((): number => {
+    if (primaryBands.length === 0) return f * 0.02;
+    let band = primaryBands[0];
+    let bestDistance = Infinity;
+    for (let i = 0; i < primaryBands.length; i++) {
+      const b = primaryBands[i];
+      if (f >= b.fLow && f <= b.fHigh) {
+        band = b;
+        break;
+      }
+      const d = Math.min(Math.abs(b.fLow - f), Math.abs(b.fHigh - f));
+      if (d < bestDistance) {
+        bestDistance = d;
+        band = b;
+      }
+    }
+    return Math.max(band.fHigh - band.fLow, f * 0.001);
+  })();
+
+  let allBands = primaryBands;
+  if (!reachedLimits && !SKIP_BROAD) {
+    // ~1 pt/MHz across 1.0–30 MHz — detects any band ≥ ~2 MHz wide.
+    // Scale down with CHAR_POINTS so low-power devices get proportionally
+    // fewer Wasm points here too (floor at 11 to retain ~1 pt/2.5 MHz).
+    const BROAD_CHAR_POINTS = Math.max(11, Math.round(CHAR_POINTS * 29 / 11));
+    const broadScan = await runScan(solveImpedanceSweep, input, SWEEP_F_MIN_MHZ, SWEEP_F_MAX_MHZ, BROAD_CHAR_POINTS);
+    // Use a stricter threshold than the display 2:1 boundary. The broad scan
+    // has only ~1 pt/MHz resolution: a single sample can dip just under 2:1
+    // purely because of where it falls on a shallow, narrow dip. By requiring
+    // SWR < 1.5 at the coarse sample, we ensure only bands where the minimum
+    // SWR is genuinely well below 2:1 — and therefore reliably captured by
+    // the fine sweep — are included. Multi-band antennas (TFDs, EFHWs) have
+    // SWR comfortably below 1.5 in all their matching bands; marginal dips
+    // that only just breach 2:1 in the coarse scan are safely ignored.
+    const BROAD_THRESHOLD = 1.5;
+
+    // ⚡ Bolt: Avoid intermediate arrays by passing the broadScan array and accessors directly
+    const broadBands = findSwrBands(
+      broadScan,
+      (pt) => pt.frequencyMHz,
+      (pt) => effSwr(pt),
+      BROAD_THRESHOLD,
+    );
+    // Accept bands from the broad scan that lie clearly outside the primary
+    // scan window (0.5 MHz guard band avoids duplicating the primary band).
+    let merged: typeof primaryBands | null = null;
+    for (let i = 0; i < broadBands.length; i++) {
+      const b = broadBands[i];
+      if (b.fHigh < loEdge - 0.5 || b.fLow > hiEdge + 0.5) {
+        if (merged === null) {
+          merged = [];
+          for (let j = 0; j < primaryBands.length; j++) {
+            merged.push(primaryBands[j]);
+          }
+        }
+        merged.push(b);
+      }
+    }
+
+    if (merged !== null) {
+      merged.sort((a, b) => a.fLow - b.fLow);
+      if (primaryBands.length === 0) {
+        // No operating-frequency band to protect — show whatever band exists.
+        allBands = merged;
+      } else {
+        // Resolve-aware merge: only widen the window to include a distant band
+        // (e.g. a harmonic resonance of a narrowband dipole) if the operating
+        // band stays adequately sampled at the final point count. Otherwise
+        // the operating band falls between samples — its dip vanishes from the
+        // chart and the marker reads an off-resonance SWR — so we keep the
+        // window focused on the operating band instead.
+        const MIN_OPERATING_BAND_SAMPLES = 4;
+        const { start, end } = frameWindow(merged);
+        const spacing = points > 1 ? (end - start) / (points - 1) : end - start;
+        const samplesInOperatingBand = spacing > 0 ? operatingBandWidth / spacing : Infinity;
+        if (samplesInOperatingBand >= MIN_OPERATING_BAND_SAMPLES) {
+          allBands = merged;
+        }
+      }
+    }
+  }
+
+  const { start: winStart, end: winEnd } = frameWindow(allBands);
+  return runScan(solveImpedanceSweep, input, winStart, winEnd, points);
+}


### PR DESCRIPTION
🎯 **What:** Extracted the adaptive sweep logic (`clampSpan`, `runScan`, `adaptiveSweep`) out of the `Nec2Engine` class and into a dedicated `sweep.ts` module. Moved two related constants to `constants.ts`.
💡 **Why:** To improve code health and maintainability by splitting up an overly large class, reducing its length by over 200 lines. The sweep logic is mathematically pure, operating independently once provided with a solver callback, so isolating it from engine lifecycle state clarifies responsibilities.
✅ **Verification:** Verified by running the full Vitest suite (`npm run test -- --run --coverage`), checking `tsc` without errors, updating coverage metrics in `vitest.config.ts`, and passing ESLint.
✨ **Result:** A more modular and readable `nec2Engine.ts` and a cleanly isolated set of pure math sweep functions.

---
*PR created automatically by Jules for task [733042385042897980](https://jules.google.com/task/733042385042897980) started by @2fst4u*