### PR TITLE
📚 Archivist: Clarify min height constraint for horizontal antennas

### DIFF
--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -105,3 +105,7 @@
 ## 2026-06-29 - Terminated Delta and T2FD Terminology Drift
 **Learning:** `docs/antenna-spec.md` incorrectly referred to the Terminated Delta as a T2FD (Terminated Tilted Folded Dipole). A Terminated Delta is an aperiodic loop, but the T2FD designation specifically applies to a Terminated Folded Dipole.
 **Action:** Removed references to T2FD in the Terminated Delta documentation and properly attributed T2FD to the Terminated Folded Dipole section, referring to the Terminated Delta as its "triangular cousin".
+
+## 2026-06-30 - Horizontal Antenna Min Height Constraint Drift
+**Learning:** The `docs/antenna-spec.md` falsely claimed that horizontal antennas like the Center-Fed Dipole and Terminated Folded Dipole have a strict minimum height constraint of `z >= 0.1 m` to avoid NEC-2 `GE 1` instability. In reality, the engine (`src/store/antennaStore.ts`) fully supports modeling these antennas at `height = 0` (or `height <= 0`) by seamlessly switching to a free space environment without ground. The documentation drifted from the implemented physics model, unnecessarily restricting perceived capabilities.
+**Action:** The documentation in `docs/antenna-spec.md` was updated for the Dipole and Folded Dipole to remove the false `0.1 m` constraint and explicitly clarify that they support `height <= 0` by switching to free space.

--- a/docs/antenna-spec.md
+++ b/docs/antenna-spec.md
@@ -112,7 +112,7 @@ Every type below uses the coordinate conventions of Part I §1 and the glossary 
 - **Reference Length:** $0.475\lambda$ (Resonance).
 - **Conventions:** Straight wire aligned with orientation vector.
 - **Tips:** Symmetric endpoints at $\pm L/2$ relative to apex.
-- **Min Height:** All points must satisfy $z \ge 0.1$ m to avoid NEC-2 `GE 1` instability.
+- **Min Height:** Fully supports `height = 0` (or `height <= 0`), which seamlessly switches the model to a free space environment without ground, preventing NEC-2 `GE 1` instability.
 
 ### 6.2 Feedpoint Definition
 
@@ -393,7 +393,7 @@ Every type below uses the coordinate conventions of Part I §1 and the glossary 
 - **`foldedDipoleAperture` parameter:** Vertical spacing between the two parallel conductors (metres). Default 0.3 m. Clamped to [0.02 m, `FOLDED_DIPOLE_MAX_APERTURE_M` = 0.5 m]. The upper cap keeps the antenna a genuine folded dipole and, crucially, within the spacing range where NEC's close-parallel-wire solution converges inside `MAX_SEGS_PER_LEG` (see §13.5).
 - **Orientation:** Azimuth the conductor axis runs. The aperture is in the vertical (Z) direction; changing the orientation rotates the axis in the horizontal plane but the top/bottom wire layout is preserved.
 - **Fed conductor:** Split at its centre by a `FEED_BRIDGE_LENGTH_M` feed bridge (the two halves carry `DIPOLE_LEFT_TAG` / `DIPOLE_RIGHT_TAG`, the same split-fed convention as the standard dipole).
-- **Min Height:** Bottom conductor at `z = height`; `height ≥ 0.1` m to avoid NEC `GE 1` instability. The top conductor is automatically at `z = height + aperture`.
+- **Min Height:** Bottom conductor at `z = height`; fully supports `height = 0` (or `height <= 0`), which seamlessly switches the model to a free space environment without ground, preventing NEC-2 `GE 1` instability. The top conductor is automatically at `z = height + aperture`.
 
 ### 13.2 Feedpoint Definition
 


### PR DESCRIPTION
💡 Problem: The documentation in `docs/antenna-spec.md` incorrectly claimed that horizontal antennas (Center-Fed Dipole and Terminated Folded Dipole) had a strict minimum height constraint of `z >= 0.1 m` to avoid NEC-2 `GE 1` instability. The actual physics implementation natively switches to a free space environment when `height <= 0`, allowing accurate modeling at and below a ground level of 0 without errors.

🎯 Fix: Updated sections 6.1 (Dipole) and 13.1 (Folded Dipole) in `docs/antenna-spec.md` to remove the false 0.1m height constraint. Explicitly clarified that they fully support `height <= 0` by seamlessly switching the model to a free space environment. Added a new journal entry to `.jules/archivist.md` detailing this drift.

🧪 Verification: Verified implementation in `src/store/antennaStore.ts` via string parsing logic matching `height <= 0`. Re-ran full test suite (`npm run test -- --run`) and verified linting (`npm run lint`), which passed successfully.

🔎 Scope: This PR contains ONLY documentation changes to markdown files.

---
*PR created automatically by Jules for task [6586050697961876831](https://jules.google.com/task/6586050697961876831) started by @2fst4u*