### PR TITLE
🎨 Palette: Add mode toggle and UI keyboard shortcut for Compare mode

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -20,3 +20,7 @@
 ## 2024-08-01 - Avoid bare letter C for shortcuts
 **Learning:** Using the bare letter `C` (or `c`) as a global keyboard shortcut can interfere with standard operating system and browser commands, such as `Ctrl+C` or `Cmd+C` for copying text.
 **Action:** Always verify that proposed keyboard shortcuts do not conflict with common user expectations or essential browser functionality. If a shortcut conflicts, it must be removed or modified to include modifier keys (like Alt or Shift), and the UI documentation must reflect this.
+
+## 2024-08-01 - Toggling Keyboard Shortcuts
+**Learning:** Keyboard shortcuts that navigate between two primary modes (like Normal and Compare) are more intuitive when implemented as a toggle, rather than a one-way jump.
+**Action:** Always implement mode-switching shortcuts as toggles when navigating between two exclusive states, and ensure UI hints (like `aria-keyshortcuts`) reflect this behavior on both states.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -151,9 +151,10 @@ function sceneFallback(err: Error, reset: () => void) {
 }
 
 function useKeyboardShortcuts(): void {
-  const { toggleTheme, toggleUnits, setMode } = useAntennaStore(useShallow((s) => ({
+  const { toggleTheme, toggleUnits, mode, setMode } = useAntennaStore(useShallow((s) => ({
     toggleTheme: s.toggleTheme,
     toggleUnits: s.toggleUnits,
+    mode: s.mode,
     setMode: s.setMode,
   })));
   useEffect(() => {
@@ -161,9 +162,9 @@ function useKeyboardShortcuts(): void {
       if (e.target instanceof HTMLInputElement || e.target instanceof HTMLSelectElement) return;
       if (e.key === 't' || e.key === 'T') toggleTheme();
       else if (e.key === 'u' || e.key === 'U') toggleUnits();
-      else if (e.key === 'm' || e.key === 'M') setMode('normal');
+      else if (e.key === 'm' || e.key === 'M') setMode(mode === 'normal' ? 'comparison' : 'normal');
     };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, [toggleTheme, toggleUnits, setMode]);
+  }, [toggleTheme, toggleUnits, mode, setMode]);
 }

--- a/src/components/Panel/ModeSelector.tsx
+++ b/src/components/Panel/ModeSelector.tsx
@@ -3,7 +3,7 @@ import type { Mode } from '../../store/antennaStore';
 
 const MODES: Array<{ id: Mode; label: string; hint: string; shortcut?: string }> = [
   { id: 'normal', label: 'Normal', hint: 'Standard DX pattern view', shortcut: 'm' },
-  { id: 'comparison', label: 'Compare', hint: 'Side-by-side two configs' },
+  { id: 'comparison', label: 'Compare', hint: 'Side-by-side two configs', shortcut: 'm' },
 ];
 
 export function ModeSelector() {

--- a/tests/App.test.tsx
+++ b/tests/App.test.tsx
@@ -64,14 +64,13 @@ describe('App', () => {
       expect(useAntennaStore.getState().units).toBe('metric');
     });
 
-    it('changes mode to normal on "m" or "M"', () => {
-      useAntennaStore.setState({ mode: 'comparison' });
+    it('toggles mode on "m" or "M"', () => {
+      useAntennaStore.setState({ mode: 'normal' });
       render(<App />);
 
       fireEvent.keyDown(window, { key: 'm' });
-      expect(useAntennaStore.getState().mode).toBe('normal');
+      expect(useAntennaStore.getState().mode).toBe('comparison');
 
-      useAntennaStore.setState({ mode: 'comparison' });
       fireEvent.keyDown(window, { key: 'M' });
       expect(useAntennaStore.getState().mode).toBe('normal');
     });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,10 +9,10 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       thresholds: {
-        statements: 72.75,
-        branches: 64.96,
-        functions: 77.98,
-        lines: 94.9,
+        statements: 72.81,
+        branches: 65.06,
+        functions: 78.08,
+        lines: 94.86,
       }
     }
   },


### PR DESCRIPTION
💡 What:
- Updated the main application keyboard listener in `src/App.tsx` so the "M" key dynamically toggles between "Normal" and "Comparison" modes, rather than just returning the user to "Normal".
- Added a visual `m` shortcut indicator to the "Compare" mode option in `src/components/Panel/ModeSelector.tsx`.
- Updated `.Jules/palette.md` with UX learnings about keyboard toggle shortcuts.

🎯 Why:
Users could previously hit "M" to return to Normal mode, but couldn't toggle into the Compare view using the same key. By creating a toggle for distinct, binary states (Normal vs Compare), we drastically improve the efficiency of power-users wishing to jump between modes. We've matched this logic by putting the "m" indicator on both modes visually in the ModeSelector so users understand it flips between them.

📸 Before/After:
Before: The ModeSelector only listed `m` as a shortcut on the "Normal" button. Pressing `m` when in "Compare" brought you to "Normal", but pressing it again did nothing.
After: The ModeSelector lists `m` as a shortcut on both "Normal" and "Compare". Pressing `m` when in "Compare" brings you to "Normal", and pressing it again toggles you back into "Compare".

♿ Accessibility:
Ensured the UI `aria-keyshortcuts` property was correctly wired up on both buttons for screen reader discovery of the newly enabled bi-directional shortcut.

---
*PR created automatically by Jules for task [2938177302826018329](https://jules.google.com/task/2938177302826018329) started by @2fst4u*