### PR TITLE
📚 Archivist: Update delta loop reference length documentation to match implementation

### DIFF
--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -109,3 +109,6 @@
 ## 2026-06-30 - Horizontal Antenna Min Height Constraint Drift
 **Learning:** The `docs/antenna-spec.md` falsely claimed that horizontal antennas like the Center-Fed Dipole and Terminated Folded Dipole have a strict minimum height constraint of `z >= 0.1 m` to avoid NEC-2 `GE 1` instability. In reality, the engine (`src/store/antennaStore.ts`) fully supports modeling these antennas at `height = 0` (or `height <= 0`) by seamlessly switching to a free space environment without ground. The documentation drifted from the implemented physics model, unnecessarily restricting perceived capabilities.
 **Action:** The documentation in `docs/antenna-spec.md` was updated for the Dipole and Folded Dipole to remove the false `0.1 m` constraint and explicitly clarify that they support `height <= 0` by switching to free space.
+## 2026-07-01 - Delta Loop Reference Length Documentation Drift
+**Learning:** The documentation listed the delta loop and terminated delta reference lengths as 1.02λ, likely assuming the use of the ARRL formula. However, the `calculateDefaultLength` function in `src/store/antennaStore.ts` explicitly overrides this and returns exactly 1.0λ for these antenna types as the default starting point.
+**Action:** `docs/antenna-spec.md` was updated to accurately reflect 1.0λ to match the implemented default length logic.

--- a/docs/antenna-spec.md
+++ b/docs/antenna-spec.md
@@ -238,7 +238,7 @@ Every type below uses the coordinate conventions of Part I §1 and the glossary 
 - **Structure:** An apex-up, isosceles triangular loop of wire.
 - **Apex Location:** Highest point at $(0, 0, \text{height})$.
 - **Leg Count & Length:** 3 wires forming a triangle, total perimeter $L$.
-- **Reference Length:** $1.02\lambda$ (Resonance).
+- **Reference Length:** $1.0\lambda$ (Resonance).
 - **Angle/Slope:** Equilateral triangle in the vertical plane (flattens to isosceles when the mast height is below the equilateral height; perimeter preserved).
 - **Tips:** Bottom corners.
 - **Min Height:** Bottom wire must be $\ge 0.5$ m above ground.
@@ -276,7 +276,7 @@ Every type below uses the coordinate conventions of Part I §1 and the glossary 
 - **Structure:** A triangular loop of wire, split at the centre of the base, with a single horizontal _bridge wire_ spanning the gap.
 - **Apex Location:** Highest point at $(0, 0, \text{height})$.
 - **Leg Count & Length:** 3 wires forming a triangle, total perimeter $L$. The bottom wire is split at the centre, so the structure is emitted as two top legs + two half-base wires + one bridge wire across the gap (when terminated).
-- **Reference Length:** $1.02\lambda$ canonical, but resonance is not the design goal: a properly bridged termination flattens impedance across an octave or more, so the antenna is used multi-band rather than at a single design frequency.
+- **Reference Length:** $1.0\lambda$ canonical, but resonance is not the design goal: a properly bridged termination flattens impedance across an octave or more, so the antenna is used multi-band rather than at a single design frequency.
 - **Angle/Slope:** Equilateral triangle in the vertical plane (flattens to isosceles when the mast height is below the equilateral height; perimeter preserved).
 - **Tips:** Bottom corners. The bottom wire is split at the centre with a gap (`TERMINATED_DELTA_CENTRE_GAP_M`).
 - **Min Height:** Bottom wire must be $\ge 0.5$ m above ground.


### PR DESCRIPTION
📚 Archivist: Update delta loop reference length documentation to match implementation

💡 Problem: The documentation in `docs/antenna-spec.md` incorrectly claimed that the default reference length for Delta Loop and Terminated Delta antennas was 1.02λ (the ARRL formula).
🎯 Fix: Updated the specification to state 1.0λ, accurately reflecting the explicit `return lambda;` logic implemented in `calculateDefaultLength` (`src/store/antennaStore.ts`).
🧪 Verification: Read the source code in `src/store/antennaStore.ts` to confirm the default length calculation, then ran the full test suite to ensure no code was altered.
🔎 Scope: This PR contains ONLY documentation changes in `docs/antenna-spec.md`.

---
*PR created automatically by Jules for task [15934830794235065812](https://jules.google.com/task/15934830794235065812) started by @2fst4u*