### PR TITLE
⚡ Bolt: Optimize getColormapCssGradient with pre-allocated for loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -207,3 +207,6 @@
 ## 2026-07-05 - Optimize Bilinear Interpolation Math
 **Learning:** In hot rendering loops (like computing 3D radiation pattern geometries), optimizing the standard linear interpolation formula from `v0 * (1 - t) + v1 * t` to `v0 + (v1 - v0) * t` saves one multiplication per interpolation per vertex, providing a small but compounding performance improvement.
 **Action:** Refactored `RadiationPattern.tsx` to use the optimized LERP equation without sacrificing the necessary boundary constraints (modulo/clamping) for the array lookups.
+## 2026-07-07 - Avoid Array.prototype.map() in CSS Gradient Generation
+**Learning:** In utility functions like `getColormapCssGradient` that are frequently invoked during UI updates, using `Array.prototype.map()` creates intermediate array allocations and incurs callback execution overhead.
+**Action:** Replace `.map()` with a pre-allocated array (e.g., `new Array(len)`) and a standard `for` loop to reduce garbage collection pressure and improve execution speed, ensuring to add comments explaining the optimization.

--- a/src/utils/colormap.ts
+++ b/src/utils/colormap.ts
@@ -112,13 +112,18 @@ export function sampleColormapFast(table: readonly RGB[], t: number, out: Float3
 export function getColormapCssGradient(name: ColormapName): string {
   const table = pickTable(name);
   const len = table.length;
-  const stops = table.map((rgb, index) => {
+  // ⚡ Bolt: Replaced .map() with a pre-allocated array and a standard for loop
+  // to avoid intermediate functional callback allocation and reduce GC overhead
+  // when regenerating colormaps.
+  const stops = new Array(len);
+  for (let index = 0; index < len; index++) {
+    const rgb = table[index]!;
     const percentage = (index / (len - 1)) * 100;
     const r = Math.round(rgb[0] * 255);
     const g = Math.round(rgb[1] * 255);
     const b = Math.round(rgb[2] * 255);
-    return `rgb(${r}, ${g}, ${b}) ${percentage.toFixed(2)}%`;
-  });
+    stops[index] = `rgb(${r}, ${g}, ${b}) ${percentage.toFixed(2)}%`;
+  }
   // Draw the gradient from bottom (0%) to top (100%) so that
   // the highest value is at the top of the element.
   return `linear-gradient(to top, ${stops.join(', ')})`;


### PR DESCRIPTION
💡 What: Replaced `Array.prototype.map()` with a pre-allocated array and a standard `for` loop in `getColormapCssGradient` within `src/utils/colormap.ts`. Added inline comments explaining the performance optimization.

🎯 Why: In high-frequency UI updates where colormaps are regenerated, using `.map()` on the colormap table creates unnecessary intermediate array allocations and incurs functional callback overhead, increasing GC pressure. Using a pre-allocated array with a `for` loop resolves this bottleneck.

📊 Impact: Eliminates callback execution overhead and prevents intermediate array allocations, reducing garbage collection pressure and improving execution speed for gradient string generation.

🔬 Measurement: Verified by running the full Vitest suite (`npm run test -- --run`) and ensuring all `tests/colormap.test.ts` pass, proving identical gradient string output. Run `npm run lint` to ensure code style compliance.

---
*PR created automatically by Jules for task [3776597937062436667](https://jules.google.com/task/3776597937062436667) started by @2fst4u*