### PR TITLE
🎨 Palette: Bind section headings to their primary dropdown inputs

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-07-05 - Keyboard Toggles and Form Labels
 **Learning:** Keyboard shortcuts for toggling app modes (like 'm' for Mode) should genuinely toggle between available states rather than just resetting to the default state, as users expect a toggle behavior. Additionally, primary control headings (like "Frequency" and "Ground") should act as `<label>`s linked to their respective inputs via `htmlFor` to provide a larger click target and improve screen reader context.
 **Action:** Always implement shortcuts as true toggles when alternating between two distinct states, and explicitly bind section headings to primary inputs when the heading acts as the de facto visual label.
+## 2026-07-08 - Bind Headings to Inputs
+**Learning:** Headings that conceptually label a section's primary input (like "Antenna" or "Feedline") should act as explicit `<label>` elements bound to the input via `htmlFor`. This prevents screen readers from encountering redundant, unhelpful labels (like "Type" under "Antenna") and increases the click target size.
+**Action:** Always wrap the section heading text in a `<label htmlFor="...">` when it naturally acts as the visual label for a primary control, and remove the visually redundant inner label.

--- a/src/components/Panel/FeedlineControl.tsx
+++ b/src/components/Panel/FeedlineControl.tsx
@@ -260,8 +260,7 @@ export function FeedlineControl() {
   return (
     <section className="panel-section">
       {/* SEO: Use sequential heading tags (H2) to follow document outline initiated by H1 */}
-      <h2>Feedline</h2>
-      <label htmlFor="feedline-preset">Cable</label>
+      <h2><label htmlFor="feedline-preset">Feedline</label></h2>
       <select
         id="feedline-preset"
         value={feedlineId}

--- a/src/components/Panel/GeometryControl.tsx
+++ b/src/components/Panel/GeometryControl.tsx
@@ -348,7 +348,6 @@ function TypeControl() {
 
   return (
     <>
-      <label htmlFor="antenna-type">Type</label>
       <select
         id="antenna-type"
         value={antennaType}
@@ -542,7 +541,7 @@ export function GeometryControl() {
   return (
     <section className="panel-section">
       {/* SEO: Use sequential heading tags (H2) to follow document outline initiated by H1 */}
-      <h2>Antenna</h2>
+      <h2><label htmlFor="antenna-type">Antenna</label></h2>
 
       <TypeControl />
       <LengthControl />

--- a/tests/FeedlineControl.test.tsx
+++ b/tests/FeedlineControl.test.tsx
@@ -80,7 +80,9 @@ describe('FeedlineControl', () => {
 
   it('changes the cable preset when the select changes', () => {
     render(<FeedlineControl />);
-    const select = screen.getByLabelText(/Cable/) as HTMLSelectElement;
+    // Select the label specifically for the Cable select menu,
+    // which we just updated to "Feedline" in FeedlineControl.tsx
+    const select = screen.getByRole('combobox', { name: 'Feedline' });
 
     fireEvent.change(select, { target: { value: 'none' } });
 

--- a/tests/GeometryControl.test.tsx
+++ b/tests/GeometryControl.test.tsx
@@ -188,7 +188,7 @@ describe('GeometryControl', () => {
 
     render(<GeometryControl />);
 
-    const typeSelect = screen.getByRole('combobox', { name: /Type/i });
+    const typeSelect = screen.getByRole('combobox', { name: /Antenna/i });
     fireEvent.change(typeSelect, { target: { value: 'inverted-v' } });
 
     expect(setAntennaType).toHaveBeenCalledWith('inverted-v');


### PR DESCRIPTION
💡 What: Wrapped the `Antenna` and `Feedline` section headings in `<label>` elements and bound them to their respective primary `<select>` inputs via `htmlFor`. Removed the redundant "Type" and "Cable" internal labels.
🎯 Why: Having "Antenna" and then immediately "Type" (or "Feedline" and then "Cable") is visually redundant. This cleans up the UI while actually improving screen reader context by using the section heading as the explicit label, and increases the clickable area for the dropdowns.
📸 Before/After: Visual clutter reduced. Headings now focus the dropdown when clicked.
♿ Accessibility: Preserves a11y compliance by ensuring the `<select>` still has a semantic label (the heading), improving the experience for screen reader users and those with motor impairments. Tests were also updated to use the new labels to prevent regressions.

---
*PR created automatically by Jules for task [3043840925746538648](https://jules.google.com/task/3043840925746538648) started by @2fst4u*