### PR TITLE
📚 Archivist: Clarify Vertical Whip default length

### DIFF
--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -112,3 +112,7 @@
 ## 2026-07-01 - Delta Loop Reference Length Documentation Drift
 **Learning:** The documentation listed the delta loop and terminated delta reference lengths as 1.02λ, likely assuming the use of the ARRL formula. However, the `calculateDefaultLength` function in `src/store/antennaStore.ts` explicitly overrides this and returns exactly 1.0λ for these antenna types as the default starting point.
 **Action:** `docs/antenna-spec.md` was updated to accurately reflect 1.0λ to match the implemented default length logic.
+
+## 2026-07-09 - Vertical Whip Default Length Drift
+**Learning:** The documentation for the Vertical Whip antenna failed to mention its default length. In the codebase (`src/store/antennaStore.ts`), it defaults to `DEFAULT_WHIP_LENGTH_M` (32 ft / 9.75 m) rather than calculating a resonant length by default, unlike other antennas. This omitted detail obscures the initial application state from the user.
+**Action:** Appended the 32 ft (9.75 m) default behavior to the `length` parameter description in `docs/antenna-spec.md`.

--- a/docs/antenna-spec.md
+++ b/docs/antenna-spec.md
@@ -315,7 +315,7 @@ Every type below uses the coordinate conventions of Part I §1 and the glossary 
 
 - **Shape:** A single vertical wire extending upwards from the base.
 - **`height` parameter:** The height of the base above ground (metres). Usually 0 or very small.
-- **`length` parameter:** The length of the vertical wire (metres).
+- **`length` parameter:** The length of the vertical wire (metres). Defaults to 32 ft (9.75 m).
 - **Orientation:** Not applicable (omnidirectional).
 - **Base:** The vertical wire starts at the maximum of `VERTICAL_WHIP_BASE_GAP_M` (0.01 m) and `height` to ensure electrical isolation from the ground.
 - **Reference length:** ¼λ (quarter-wave monopole).


### PR DESCRIPTION
💡 Problem: The documentation omitted that the Vertical Whip defaults to a fixed length of 32 ft (`DEFAULT_WHIP_LENGTH_M` = 9.75m), unlike other antennas which start with resonant default calculations, creating ambiguity.
🎯 Fix: Appended 'Defaults to 32 ft (9.75 m).' to the `length` parameter description in `docs/antenna-spec.md` and added a learning log in `.jules/archivist.md`.
🧪 Verification: Checked `src/store/antennaStore.ts` to confirm it explicitly uses `DEFAULT_WHIP_LENGTH_M` as the default for Vertical Whip. Ran `pnpm run lint` and `pnpm run test -- --run` successfully.
🔎 Scope: Only documentation updates, no functional code changes.

---
*PR created automatically by Jules for task [1451467067207717240](https://jules.google.com/task/1451467067207717240) started by @2fst4u*