### PR TITLE
⚡ Bolt: Memoize colormap CSS gradient generation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -210,3 +210,6 @@
 ## 2026-07-07 - Avoid Array.prototype.map() in CSS Gradient Generation
 **Learning:** In utility functions like `getColormapCssGradient` that are frequently invoked during UI updates, using `Array.prototype.map()` creates intermediate array allocations and incurs callback execution overhead.
 **Action:** Replace `.map()` with a pre-allocated array (e.g., `new Array(len)`) and a standard `for` loop to reduce garbage collection pressure and improve execution speed, ensuring to add comments explaining the optimization.
+## 2025-03-09 - React Hooks Optimization Pattern
+**Learning:** When adding memoization (e.g., `useMemo`) to an existing component to optimize performance, you must ensure the new hook is placed at the top level of the component and *before* any early return statements (e.g., `if (!data) return null;`) to comply with React's Rules of Hooks. Placing a hook after an early return will cause a linter error (`react-hooks/rules-of-hooks`) because React requires hooks to be called in the exact same order on every render.
+**Action:** Always scan the component body for early returns before inserting a new hook. Insert the hook above the earliest conditional return.

--- a/src/components/Scene/ColormapLegend.tsx
+++ b/src/components/Scene/ColormapLegend.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useAntennaStore } from '../../store/antennaStore';
 import { useShallow } from 'zustand/react/shallow';
 import { getColormapCssGradient } from '../../utils/colormap';
@@ -16,11 +17,15 @@ export function ColormapLegend({ result }: Props) {
     })),
   );
 
+  // ⚡ Bolt: Performance Optimization
+  // Memoize the CSS gradient string generation. This prevents unnecessary string allocations
+  // and array processing when the component re-renders due to unrelated state changes
+  // (like `colorMaxDb` or `dbRange`), reducing GC overhead and CPU usage.
+  const gradient = useMemo(() => getColormapCssGradient(colormap), [colormap]);
+
   if (!result) return null;
 
   const minDb = colorMaxDb - dbRange;
-
-  const gradient = getColormapCssGradient(colormap);
 
   return (
     /* SEO: Upgrade generic div wrapper to a semantic figure tag, with figcaption for clear labeling */


### PR DESCRIPTION
💡 What:
Wrapped the CSS gradient string generation (`getColormapCssGradient`) in a `useMemo` hook inside the `ColormapLegend` component.

🎯 Why:
The `ColormapLegend` component accesses several Zustand store states (`colormap`, `dbRange`, `colorMaxDb`). Whenever `dbRange` or `colorMaxDb` changed, the component would re-render, triggering `getColormapCssGradient`. This utility function loops through a color table array to construct a CSS linear gradient string. Recomputing this string on every render unnecessarily allocates memory and consumes CPU, leading to GC pressure.

📊 Impact:
Eliminates redundant string array processing and string concatenations on every render triggered by non-colormap state updates, improving render efficiency.

🔬 Measurement:
Start the application and change the dB Range or Color Max dB sliders. The `ColormapLegend` component will re-render, but the CSS gradient string generation logic inside `getColormapCssGradient` will no longer execute.

---
*PR created automatically by Jules for task [8389961241166732830](https://jules.google.com/task/8389961241166732830) started by @2fst4u*