### PR TITLE
📚 Archivist: Clarify mode toggle shortcut documentation

### DIFF
--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -116,3 +116,6 @@
 ## 2026-07-09 - Vertical Whip Default Length Drift
 **Learning:** The documentation for the Vertical Whip antenna failed to mention its default length. In the codebase (`src/store/antennaStore.ts`), it defaults to `DEFAULT_WHIP_LENGTH_M` (32 ft / 9.75 m) rather than calculating a resonant length by default, unlike other antennas. This omitted detail obscures the initial application state from the user.
 **Action:** Appended the 32 ft (9.75 m) default behavior to the `length` parameter description in `docs/antenna-spec.md`.
+## 2026-07-11 - Toggle Mode Shortcut Documentation Drift
+**Learning:** The documentation for the 'm' keyboard shortcut in README.md incorrectly stated that it "Return to normal mode", while the application logic (in src/App.tsx and src/store/antennaStore.ts) implements it as a toggle between 'normal' and 'comparison' modes. The documentation drifted and failed to reflect the toggle functionality.
+**Action:** Edited README.md to clarify that the 'm' shortcut toggles between normal and comparison modes.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ While this repository is fully open source and developers are welcome to fork or
 
 - **`t`**: Toggle dark/light theme
 - **`u`**: Toggle metric/imperial units
-- **`m`**: Return to normal mode
+- **`m`**: Toggle between normal and comparison mode
 
 ## Stack
 


### PR DESCRIPTION
💡 Problem: The README.md incorrectly stated that the `m` shortcut "Return to normal mode". In reality, the codebase (`src/App.tsx` via `toggleMode` in `src/store/antennaStore.ts`) implements this as a bidirectional toggle between "normal" and "comparison" modes. This inconsistency could confuse users trying to enter comparison mode using the keyboard.
🎯 Fix: Updated the `README.md` to accurately describe the `m` shortcut as a toggle between normal and comparison modes.
🧪 Verification: Checked `src/App.tsx` and `src/store/antennaStore.ts` to confirm the toggle behavior. Ran markdown linters and the full test suite (`npm run test -- --run`).
🔎 Scope: This PR contains ONLY documentation changes to `README.md` and a journal entry in `.jules/archivist.md`.

---
*PR created automatically by Jules for task [12852411073924213418](https://jules.google.com/task/12852411073924213418) started by @2fst4u*