### PR TITLE
🧪 Test GeometryStatus clamping logic boundary edge cases

### DIFF
--- a/tests/GeometryStatus.test.tsx
+++ b/tests/GeometryStatus.test.tsx
@@ -76,4 +76,41 @@ describe('GeometryStatus', () => {
     render(<GeometryStatus />);
     expect(screen.getByText(/Geometry Clamped/i)).toBeTruthy();
   });
+
+  it('does not clamp when requested slope is just below threshold (+0.1 deg limit)', () => {
+    // For height=10.5, min tip=0.5 -> delta=10
+    // length=40 -> half=20. maxSin = 10/20 = 0.5 -> maxSlopeDeg = 30
+    // Threshold is 30.1
+    useAntennaStore.setState({
+      antennaType: 'inverted-v',
+      length: 40,
+      height: 10.5,
+      // requestedSlope = (180 - 119.9) / 2 = 30.05
+      // 30.05 < 30.1 so it should NOT clamp
+      vAngle: 119.9,
+      units: 'metric',
+    });
+
+    render(<GeometryStatus />);
+    expect(screen.getByText(/Geometry Status/i)).toBeTruthy();
+    expect(screen.queryByText(/Geometry Clamped/i)).toBeNull();
+  });
+
+  it('clamps when requested slope is just above threshold (+0.1 deg limit)', () => {
+    // For height=10.5, min tip=0.5 -> delta=10
+    // length=40 -> half=20. maxSin = 10/20 = 0.5 -> maxSlopeDeg = 30
+    // Threshold is 30.1
+    useAntennaStore.setState({
+      antennaType: 'inverted-v',
+      length: 40,
+      height: 10.5,
+      // requestedSlope = (180 - 119.7) / 2 = 30.15
+      // 30.15 > 30.1 so it SHOULD clamp
+      vAngle: 119.7,
+      units: 'metric',
+    });
+
+    render(<GeometryStatus />);
+    expect(screen.getByText(/Geometry Clamped/i)).toBeTruthy();
+  });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,10 +9,10 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       thresholds: {
-        statements: 72.81,
+        statements: 72.83,
         branches: 64.97,
         functions: 78.13,
-        lines: 94.83,
+        lines: 94.84,
       }
     }
   },


### PR DESCRIPTION
🎯 **What:** Tested the precise boundary threshold (`maxSlopeDeg + 0.1`) where the `GeometryStatus` component switches from 'Geometry Status' to 'Geometry Clamped'. Previously, we only tested safe inputs vs massively clamped inputs.
📊 **Coverage:** Specifically tests inputs designed to sit just below (+0.05deg variance) and just above (+0.15deg variance) the exact +0.1 degree clamp logic threshold (`isClamped = requestedSlopeDeg > maxSlopeDeg + 0.1`) to definitively prove the conditional renders correctly.
✨ **Result:** Statement coverage for `tests/GeometryStatus.test.tsx` stays at 100%, but Vitest global lines hit 94.84% and statement thresholds are up to 72.83%. Codebase robustness slightly improved.

---
*PR created automatically by Jules for task [1809563554442887378](https://jules.google.com/task/1809563554442887378) started by @2fst4u*