### PR TITLE
🧹 false positive: no 'any' type in computeTerminationDiagnostics

### DIFF
--- a/commit_message.txt
+++ b/commit_message.txt
@@ -1,0 +1,10 @@
+🧹 false positive: no 'any' type in computeTerminationDiagnostics
+
+🎯 What:
+Closed a false positive code health issue regarding a "Simplifiable 'any' Type Declaration" in `computeTerminationDiagnostics`.
+💡 Why:
+The reported code `export function computeTerminationDiagnostics(input: any)` does not exist in the codebase. The only instance of the word "any" in `src/physics/terminationDiagnostics.ts:6` was in a comment: `// feedpoint-match metrics in any UI copy.` The function itself takes 5 strongly-typed arguments. Therefore, there is no code health issue to fix.
+✅ Verification:
+Confirmed the function's strict typings in `src/physics/terminationDiagnostics.ts` and `src/physics/types.ts`. Grep search confirmed no `any` types in the file. Ran the full test suite with 100% passing tests.
+✨ Result:
+No code changes required; codebase is already strictly typed and healthy.


### PR DESCRIPTION
🎯 What:
Closed a false positive code health issue regarding a "Simplifiable 'any' Type Declaration" in `computeTerminationDiagnostics`.

💡 Why:
The reported code `export function computeTerminationDiagnostics(input: any)` does not exist in the codebase. The only instance of the word "any" in `src/physics/terminationDiagnostics.ts:6` was in a comment: `// feedpoint-match metrics in any UI copy.` The function itself takes 5 strongly-typed arguments. Therefore, there is no code health issue to fix.

✅ Verification:
Confirmed the function's strict typings in `src/physics/terminationDiagnostics.ts` and `src/physics/types.ts`. Grep search confirmed no `any` types in the file. Ran the full test suite with 100% passing tests.

✨ Result:
No code changes required; codebase is already strictly typed and healthy.

---
*PR created automatically by Jules for task [17467379017111886062](https://jules.google.com/task/17467379017111886062) started by @2fst4u*