### PR TITLE
🧪 Test buildNecCards invalid inputs

### DIFF
--- a/tests/necCard.test.ts
+++ b/tests/necCard.test.ts
@@ -328,5 +328,45 @@ describe('buildNecCards', () => {
       };
       expect(() => buildNecCards(input)).toThrow('Non-finite numeric value in NEC card: -Infinity');
     });
+
+    it('throws error for NaN in ground properties', () => {
+      const input: SimulationInput = {
+        ...defaultInput,
+        ground: { type: 'real', epsilon: NaN },
+      };
+      expect(() => buildNecCards(input)).toThrow('Non-finite numeric value in NEC card: NaN');
+    });
+
+    it('throws error for NaN in excitation properties', () => {
+      const input: SimulationInput = {
+        ...defaultInput,
+        excitation: { ...defaultInput.excitation, real: NaN },
+      };
+      expect(() => buildNecCards(input)).toThrow('Non-finite numeric value in NEC card: NaN');
+    });
+
+    it('throws error for NaN in load properties', () => {
+      const input: SimulationInput = {
+        ...defaultInput,
+        loads: [{ type: 4, wireTag: 1, segmentStart: 1, segmentEnd: 1, param1: NaN, param2: 0 }],
+      };
+      expect(() => buildNecCards(input)).toThrow('Non-finite numeric value in NEC card: NaN');
+    });
+
+    it('throws error for NaN in network properties', () => {
+      const input: SimulationInput = {
+        ...defaultInput,
+        networks: [{ fromTag: 1, fromSegment: 1, toTag: 1, toSegment: 2, y11Real: NaN, y12Real: 0, y22Real: 0 }],
+      };
+      expect(() => buildNecCards(input)).toThrow('Non-finite numeric value in NEC card: NaN');
+    });
+
+    it('throws error for NaN in transmission line properties', () => {
+      const input: SimulationInput = {
+        ...defaultInput,
+        transmissionLines: [{ fromTag: 1, fromSegment: 1, toTag: 2, toSegment: 1, z0: NaN, lengthM: 10 }],
+      };
+      expect(() => buildNecCards(input)).toThrow('Non-finite numeric value in NEC card: NaN');
+    });
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,10 +9,10 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       thresholds: {
-        statements: 72.81,
+        statements: 72.83,
         branches: 64.97,
         functions: 78.13,
-        lines: 94.83,
+        lines: 94.84,
       }
     }
   },


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was that `buildNecCards` contained logic that could construct inputs with `NaN` in nested properties (like `ground`, `loads`, `networks`, `transmissionLines`), which would throw a `Non-finite numeric value` error via the `n()` helper. However, these error conditions for the specific nested configurations were previously untested, leaving a coverage gap for error handling.
  
  📊 **Coverage:** The test suite now explicitly covers `NaN` values for `ground.epsilon`, `excitation.real`, `loads[0].param1`, `networks[0].y11Real`, and `transmissionLines[0].z0`.
  
  ✨ **Result:** Test coverage for `src/physics/necCard.ts` remains 100% and overall statements coverage in `vitest.config.ts` increased from 72.81% to 72.83%. Codebase reliability is improved by explicitly locking in these edge-case error behaviors.

---
*PR created automatically by Jules for task [2801168782587143096](https://jules.google.com/task/2801168782587143096) started by @2fst4u*