### PR TITLE
🧹 Refactor `buildWiresInternal` by extracting dipole logic into `buildDipoleWires`

### DIFF
--- a/src/store/antennaGeometry.ts
+++ b/src/store/antennaGeometry.ts
@@ -2,6 +2,7 @@ import { cleanZero } from "../utils/math";
 import {
   SLOPING_V_MIN_TIP_Z_M,
   wavelengthMeters,
+  MAIN_WIRE_TAG,
   LEFT_LEG_TAG,
   RIGHT_LEG_TAG,
   FEED_BRIDGE_TAG,
@@ -1101,4 +1102,83 @@ export function buildFoldedAntennaWires(params: FoldedAntennaWiresParams): Wire[
     // Right end connector across the aperture.
     createWire(pts.rightFed, pts.rightOpp, segs.connSegs, FOLDED_DIPOLE_CONNECTOR_TAG),
   ];
+}
+
+export interface DipoleWiresParams {
+  length: number;
+  height: number;
+  orientation: Orientation;
+  wireRadius: number;
+  segments: number;
+  layout: { offset: number; shield: { bottomZ: number; radius: number } | null } | null;
+}
+
+export function buildDipoleWires(params: DipoleWiresParams): Wire[] {
+  const { length, height: h, orientation, wireRadius, segments, layout } = params;
+  const half = length / 2;
+  const [dx, dy] = orientationVector(orientation);
+
+  if (!layout) {
+    return [{
+      start: [cleanZero(-half * dx), cleanZero(-half * dy), h],
+      end: [cleanZero(half * dx), cleanZero(half * dy), h],
+      radius: wireRadius,
+      segments: segments,
+      tag: MAIN_WIRE_TAG,
+    }];
+  }
+
+  const offset = layout.offset;
+  const bridgeHalf = FEED_BRIDGE_LENGTH_M / 2;
+
+  const bridgeStart: [number, number, number] = [
+    cleanZero((offset - bridgeHalf) * dx),
+    cleanZero((offset - bridgeHalf) * dy),
+    h,
+  ];
+  const bridgeEnd: [number, number, number] = [
+    cleanZero((offset + bridgeHalf) * dx),
+    cleanZero((offset + bridgeHalf) * dy),
+    h,
+  ];
+
+  const leftTip: [number, number, number] = [cleanZero(-half * dx), cleanZero(-half * dy), h];
+  const rightTip: [number, number, number] = [cleanZero(half * dx), cleanZero(half * dy), h];
+
+  const dist = (p1: [number, number, number], p2: [number, number, number]) =>
+    Math.sqrt((p1[0] - p2[0]) ** 2 + (p1[1] - p2[1]) ** 2 + (p1[2] - p2[2]) ** 2);
+
+  const leftLen = dist(leftTip, bridgeStart);
+  const rightLen = dist(rightTip, bridgeEnd);
+
+  const totalSeg = segments;
+  const segDensity = totalSeg / length;
+  const leftSeg = Math.max(3, oddRound(leftLen * segDensity));
+  const rightSeg = Math.max(3, oddRound(rightLen * segDensity));
+
+  return [
+    {
+      start: leftTip, end: bridgeStart,
+      radius: wireRadius,
+      segments: leftSeg,
+      tag: LEFT_LEG_TAG,
+    },
+    {
+      start: bridgeEnd, end: rightTip,
+      radius: wireRadius,
+      segments: rightSeg,
+      tag: RIGHT_LEG_TAG,
+    },
+    {
+      start: bridgeStart, end: bridgeEnd,
+      radius: wireRadius,
+      segments: 1,
+      tag: FEED_BRIDGE_TAG,
+    },
+  ];
+}
+
+export function oddRound(v: number): number {
+  const n = Math.max(1, Math.round(v));
+  return n % 2 === 0 ? n + 1 : n;
 }

--- a/src/store/antennaStore.ts
+++ b/src/store/antennaStore.ts
@@ -5,7 +5,6 @@
 //     the component edge via useUnits() / toDisplayLength().
 //   - `result` is read-only for UI code; it is written only by the physics
 //     worker bridge via the underscored _setResult action.
-import { cleanZero } from "../utils/math";
 
 import { create } from 'zustand';
 import { subscribeWithSelector } from 'zustand/middleware';
@@ -86,7 +85,7 @@ import {
   buildVerticalWhipWires,
   buildInvertedLWires,
   buildFoldedAntennaWires,
-  orientationVector,
+  buildDipoleWires,
   type Orientation,
 } from './antennaGeometry';
 
@@ -960,7 +959,6 @@ function buildWiresInternal(
     Partial<Pick<AntennaState, 'feedlineId' | 'feedlineLength' | 'feedlineOffset' | 'whipCounterpoise' | 'foldedDipoleAperture' | 'terminatingResistor'>>,
 ): Wire[] {
   const antennaType = state.antennaType;
-  const half = state.length / 2;
   const h = state.height;
 
   if (antennaType === 'inverted-v') {
@@ -1047,69 +1045,16 @@ function buildWiresInternal(
     });
   }
 
-  const [dx, dy] = orientationVector(state.orientation);
-
-
   const layout = computeFeedlineLayout(state);
 
-  if (!layout) {
-    return [{
-      start: [cleanZero(-half * dx), cleanZero(-half * dy), h],
-      end: [cleanZero(half * dx), cleanZero(half * dy), h],
-      radius: state.wireRadius,
-      segments: state.segments,
-      tag: MAIN_WIRE_TAG,
-    }];
-  }
-
-  const offset = layout.offset;
-  const bridgeHalf = FEED_BRIDGE_LENGTH_M / 2;
-
-  const bridgeStart: [number, number, number] = [
-    cleanZero((offset - bridgeHalf) * dx),
-    cleanZero((offset - bridgeHalf) * dy),
-    h,
-  ];
-  const bridgeEnd: [number, number, number] = [
-    cleanZero((offset + bridgeHalf) * dx),
-    cleanZero((offset + bridgeHalf) * dy),
-    h,
-  ];
-
-  const leftTip: [number, number, number] = [cleanZero(-half * dx), cleanZero(-half * dy), h];
-  const rightTip: [number, number, number] = [cleanZero(half * dx), cleanZero(half * dy), h];
-
-  const dist = (p1: [number, number, number], p2: [number, number, number]) =>
-    Math.sqrt((p1[0] - p2[0]) ** 2 + (p1[1] - p2[1]) ** 2 + (p1[2] - p2[2]) ** 2);
-
-  const leftLen = dist(leftTip, bridgeStart);
-  const rightLen = dist(rightTip, bridgeEnd);
-
-  const totalSeg = state.segments;
-  const segDensity = totalSeg / state.length;
-  const leftSeg = Math.max(3, oddRound(leftLen * segDensity));
-  const rightSeg = Math.max(3, oddRound(rightLen * segDensity));
-
-  return [
-    {
-      start: leftTip, end: bridgeStart,
-      radius: state.wireRadius,
-      segments: leftSeg,
-      tag: LEFT_LEG_TAG,
-    },
-    {
-      start: bridgeEnd, end: rightTip,
-      radius: state.wireRadius,
-      segments: rightSeg,
-      tag: RIGHT_LEG_TAG,
-    },
-    {
-      start: bridgeStart, end: bridgeEnd,
-      radius: state.wireRadius,
-      segments: 1,
-      tag: FEED_BRIDGE_TAG,
-    },
-  ];
+  return buildDipoleWires({
+    length: state.length,
+    height: h,
+    orientation: state.orientation,
+    wireRadius: state.wireRadius,
+    segments: state.segments,
+    layout,
+  });
 }
 
 interface FeedlineLayout {
@@ -1156,10 +1101,6 @@ function computeFeedlineLayout(
   };
 }
 
-function oddRound(v: number): number {
-  const n = Math.max(1, Math.round(v));
-  return n % 2 === 0 ? n + 1 : n;
-}
 
 function buildGroundParams(state: AntennaState): GroundParams {
   // The height<=0 short-circuit makes the model "free space" when the user


### PR DESCRIPTION
🎯 **What:** Extracted the inline dipole wire building logic from `buildWiresInternal` in `src/store/antennaStore.ts` into a new `buildDipoleWires` function in `src/store/antennaGeometry.ts`. The `oddRound` utility was also relocated to `antennaGeometry.ts`.

💡 **Why:** `buildWiresInternal` was growing excessively long due to the inline implementation of the fallback dipole topology calculation. Moving this logic to a dedicated builder function matching the patterns of the other antenna types (like `buildInvertedVWires` and `buildFoldedAntennaWires`) greatly improves the maintainability and readability of `antennaStore.ts`, keeping the root store focused on state management rather than complex geometry math.

✅ **Verification:** Verified by ensuring the code perfectly replicated the original behavior, preserving array mapping, node tagging, segment scaling calculations (`oddRound`), and fallback handling. Ran both the linter (`npm run lint`) and the full Vitest suite (`npm run test -- --run`) which passed successfully, proving no regressions.

✨ **Result:** A cleaner `buildWiresInternal` core function that acts purely as a router, offloading physical mesh calculations back to the `antennaGeometry.ts` domain where they belong.

---
*PR created automatically by Jules for task [16867986067491606313](https://jules.google.com/task/16867986067491606313) started by @2fst4u*