### PR TITLE
🔒 fix: remove unsafe-inline from CSP style-src

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en" data-theme="dark">
   <head>
     <meta charset="UTF-8" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; worker-src 'self' blob:; object-src 'none';" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self'; img-src 'self' data:; connect-src 'self'; worker-src 'self' blob:; object-src 'none';" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="apple-touch-icon" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />


### PR DESCRIPTION
🎯 **What:** Removed the `'unsafe-inline'` directive from the `style-src` in the Content-Security-Policy header defined within `index.html`.

⚠️ **Risk:** Including `'unsafe-inline'` in the CSP allows the execution of inline CSS. This can potentially be exploited by attackers to perform cross-site scripting (XSS) or inject malicious styles that alter the application's appearance or behavior (e.g., clickjacking or hiding important security indicators).

🛡️ **Solution:** Removed `'unsafe-inline'` from `style-src`. Production builds using Vite automatically extract CSS into separate files or apply inline styles via the CSSOM, which natively complies with `style-src 'self'`. This hardens the security posture of the production application while maintaining correct rendering behavior.

---
*PR created automatically by Jules for task [12244566683805618866](https://jules.google.com/task/12244566683805618866) started by @2fst4u*