### PR TITLE
🔒 Security: Fix URL parsing vulnerability in nec2Engine

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,7 @@
 **Vulnerability:** The `HHmmToHour` function previously used an unsafe regular expression (`/[^0-9]/g`) to strip non-numeric characters from a time string. While currently constrained by UI length limits, a maliciously long input could cause catastrophic backtracking or excessive CPU consumption, leading to a Denial of Service (ReDoS).
 **Learning:** Avoid using global regex replacements on unbounded or large input strings, especially when simple character code checks can achieve the same result more safely and deterministically.
 **Prevention:** Replace global regex replacements with explicit `for` loop iterations that validate character codes (e.g., `charCode >= 48 && charCode <= 57`), and always enforce a maximum input string length at the start of the function.
+## 2026-07-11 - Fix URL parser differential vulnerability
+**Vulnerability:** The code validated a URL's protocol using `new URL()`, but subsequently passed the original, unvalidated string into a dynamic `import()`. A parser differential (e.g., how leading spaces or malformed file/data prefixes are handled between `new URL` and `import`) could allow a malicious URL (like a `data:` URI with payload) to bypass the protocol allowlist.
+**Learning:** Always use the `href` property of the *validated* URL object (`parsedUrl.href`) instead of the original raw string when passing it to the final execution sink. This eliminates Time-of-Check to Time-of-Use (TOCTOU) issues caused by parser discrepancies.
+**Action:** Changed `import(url)` to `import(parsedUrl.href)` in `nec2Engine.ts`.

--- a/src/physics/nec2Engine.ts
+++ b/src/physics/nec2Engine.ts
@@ -78,7 +78,7 @@ async function loadNec2Factory(baseUrl: string): Promise<EmscriptenFactory> {
   if (!['http:', 'https:', 'file:'].includes(parsedUrl.protocol)) {
     throw new Error(`Untrusted protocol: ${parsedUrl.protocol}`);
   }
-  const mod = (await import(/* @vite-ignore */ url)) as { default: EmscriptenFactory };
+  const mod = (await import(/* @vite-ignore */ parsedUrl.href)) as { default: EmscriptenFactory };
   return mod.default;
 }
 


### PR DESCRIPTION
🎯 **What:** Fixed an untrusted protocol vulnerability in `src/physics/nec2Engine.ts` where a URL's protocol was validated against an allowlist, but the original, unvalidated `url` string was passed to a dynamic `import()` statement.

⚠️ **Risk:** If an attacker can control the `baseUrl` parameter, they could craft a malicious payload (e.g., a `data:` URI with leading spaces or a malformed `http:data:` string) that passes the `new URL()` protocol allowlist check (because `new URL()` strips leading spaces or resolves differently) but is interpreted as a `data:` protocol by the module loader `import()`. This parser differential would allow unauthorized code execution by loading a malicious Wasm/JS factory instead of the intended `nec2.js` module.

🛡️ **Solution:** Changed the dynamic import statement from `import(url)` to `import(parsedUrl.href)`. This ensures that the exact, normalized URL string that was just validated by the security check is the one passed to the execution sink, neutralizing any parser differential TOCTOU (Time-of-Check to Time-of-Use) attacks.

---
*PR created automatically by Jules for task [2353082605831187999](https://jules.google.com/task/2353082605831187999) started by @2fst4u*