### PR TITLE
📚 Archivist: Clarify monopole reference length end-effects

### DIFF
--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -119,3 +119,7 @@
 ## 2026-07-11 - Toggle Mode Shortcut Documentation Drift
 **Learning:** The documentation for the 'm' keyboard shortcut in README.md incorrectly stated that it "Return to normal mode", while the application logic (in src/App.tsx and src/store/antennaStore.ts) implements it as a toggle between 'normal' and 'comparison' modes. The documentation drifted and failed to reflect the toggle functionality.
 **Action:** Edited README.md to clarify that the 'm' shortcut toggles between normal and comparison modes.
+
+## 2026-07-12 - Monopole Reference Length End-Effect Drift
+**Learning:** The documentation listed the reference length for the Vertical Whip and Inverted-L simply as "¼λ", omitting the 0.95 end-effect multiplier that is explicitly applied in `calculateDefaultLength` (`lambda * 0.25 * 0.95`). This was inconsistent with the Dipole documentation, which correctly noted its end-effect (0.475λ).
+**Action:** Updated `docs/antenna-spec.md` to explicitly state the reference length as 0.2375λ (¼λ with 0.95 end-effect) for both monopole antennas to match the implemented physics logic.

--- a/docs/antenna-spec.md
+++ b/docs/antenna-spec.md
@@ -318,7 +318,7 @@ Every type below uses the coordinate conventions of Part I §1 and the glossary 
 - **`length` parameter:** The length of the vertical wire (metres). Defaults to 32 ft (9.75 m).
 - **Orientation:** Not applicable (omnidirectional).
 - **Base:** The vertical wire starts at the maximum of `VERTICAL_WHIP_BASE_GAP_M` (0.01 m) and `height` to ensure electrical isolation from the ground.
-- **Reference length:** ¼λ (quarter-wave monopole).
+- **Reference length:** $0.2375\lambda$ (¼λ with 0.95 end-effect).
 
 ### 11.2 Feedpoint Definition
 
@@ -356,7 +356,7 @@ Every type below uses the coordinate conventions of Part I §1 and the glossary 
 - **Orientation:** Azimuth direction the horizontal section runs.
 - **Base:** The vertical wire starts at `VERTICAL_WHIP_BASE_GAP_M` (0.01 m) above ground — same electrical isolation as the vertical whip.
 - **Bend junction:** The end of the vertical wire and the start of the horizontal wire share an exact coordinate so NEC creates a proper wire junction.
-- **Reference length:** ¼λ total (same as a quarter-wave vertical); the horizontal section provides the electrical length the mast height falls short of.
+- **Reference length:** $0.2375\lambda$ total (¼λ with 0.95 end-effect); the horizontal section provides the electrical length the mast height falls short of.
 
 ### 12.2 Feedpoint Definition
 


### PR DESCRIPTION
💡 Problem: The documentation listed the reference length for the Vertical Whip and Inverted-L simply as "¼λ", omitting the 0.95 end-effect multiplier that is explicitly applied in `calculateDefaultLength` (`lambda * 0.25 * 0.95`). This was inconsistent with the Dipole documentation, which correctly noted its end-effect (0.475λ).
🎯 Fix: Updated `docs/antenna-spec.md` to explicitly state the reference length as 0.2375λ (¼λ with 0.95 end-effect) for both monopole antennas to perfectly match the implemented physics logic.
🧪 Verification: Read the logic inside `src/store/antennaStore.ts` and confirmed the `calculateDefaultLength` function applies a 0.95 end-effect multiplier to these types. Ran tests and linters to verify correctness.
🔎 Scope: Confirmation that this PR contains ONLY documentation changes and corresponding journal updates.

---
*PR created automatically by Jules for task [17743239946876685507](https://jules.google.com/task/17743239946876685507) started by @2fst4u*