### PR TITLE
🧹 Sweep: Remove unused export `oddRound` from `antennaGeometry.ts`

### DIFF
--- a/.jules/sweep.md
+++ b/.jules/sweep.md
@@ -99,3 +99,6 @@
 ## 2024-07-07 - [Unused Exports Cleanup]
 **Learning:** Tools like `knip` often flag internal utility functions (like `safeSegs` or `buildPlugins`) as unused exports when they are only consumed locally within the same module.
 **Action:** Always check if a flagged unused export is being used internally before completely deleting the function. If it is used locally, merely strip the `export` keyword to restrict its scope rather than removing the code entirely, then recalculate and enforce Vitest coverage thresholds to prevent CI regressions.
+## 2025-03-02 - Removed unused oddRound export
+**Learning:** `knip` will correctly flag functions that are exported but only used within the file they are defined in. In `src/store/antennaGeometry.ts`, `oddRound` was exported despite only being consumed locally.
+**Action:** Un-export functions that are strictly internal helpers. This reduces the public API surface area and eliminates false-positive static analysis warnings without deleting necessary code.

--- a/src/store/antennaGeometry.ts
+++ b/src/store/antennaGeometry.ts
@@ -1178,7 +1178,7 @@ export function buildDipoleWires(params: DipoleWiresParams): Wire[] {
   ];
 }
 
-export function oddRound(v: number): number {
+function oddRound(v: number): number {
   const n = Math.max(1, Math.round(v));
   return n % 2 === 0 ? n + 1 : n;
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,9 +9,9 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       thresholds: {
-        statements: 72.83,
+        statements: 72.85,
         branches: 64.97,
-        functions: 78.13,
+        functions: 78.15,
         lines: 94.84,
       }
     }


### PR DESCRIPTION
💡 What: Removed the `export` keyword from `oddRound` in `src/store/antennaGeometry.ts`.
🎯 Why: `knip` flagged this as an unused export. It is an internal helper only used within its defining file. Un-exporting it reduces the public API surface area and fixes static analysis warnings without deleting active code.
🔬 Verification: Ran `knip` and a global grep search across the project to verify `oddRound` was not imported or used anywhere else outside of `src/store/antennaGeometry.ts`. Full test suite pass + vitest thresholds re-calibrated.

---
*PR created automatically by Jules for task [16678484227282436971](https://jules.google.com/task/16678484227282436971) started by @2fst4u*