### PR TITLE
🧹 Code Health: Decouple AntennaElement from Theme

### DIFF
--- a/src/components/Scene/AntennaElement.tsx
+++ b/src/components/Scene/AntennaElement.tsx
@@ -1,18 +1,17 @@
-import { THEME_COLORS, type Theme } from '../../utils/themeColors';
 import type { RenderedWire } from './useAntennaGeometry';
 
 export interface AntennaElementProps {
   wire: RenderedWire;
-  theme: Theme;
+  color: string;
 }
 
-export function AntennaElement({ wire, theme }: AntennaElementProps) {
+export function AntennaElement({ wire, color }: AntennaElementProps) {
   return (
     <mesh position={wire.position} quaternion={wire.quaternion}>
       <cylinderGeometry args={[wire.radius, wire.radius, wire.length, 16]} />
       <meshStandardMaterial
-        color={THEME_COLORS[theme].wire}
-        emissive={THEME_COLORS[theme].wire}
+        color={color}
+        emissive={color}
         emissiveIntensity={wire.isShield ? 0.08 : wire.isBridge ? 0.05 : 0.15}
         metalness={0.85}
         roughness={wire.isShield ? 0.55 : wire.isBridge ? 0.7 : 0.35}

--- a/src/components/Scene/AntennaWire.tsx
+++ b/src/components/Scene/AntennaWire.tsx
@@ -10,6 +10,7 @@
 
 import { useShallow } from 'zustand/react/shallow';
 import { useAntennaStore } from '../../store/antennaStore';
+import { THEME_COLORS } from '../../utils/themeColors';
 import { useAntennaGeometry, type AntennaWireProps } from './useAntennaGeometry';
 import { AntennaElement } from './AntennaElement';
 import { Feedpoint } from './Feedpoint';
@@ -24,10 +25,12 @@ export function AntennaWire(props: AntennaWireProps) {
   })));
 
   const { rendered, shield, feedpoint, terminatedDeltaSplit } = useAntennaGeometry(props);
+  const wireColor = THEME_COLORS[theme].wire;
+
   return (
     <group>
       {rendered.map((s) => (
-        <AntennaElement key={s.key} wire={s} theme={theme} />
+        <AntennaElement key={s.key} wire={s} color={wireColor} />
       ))}
       {feedpoint && <Feedpoint position={feedpoint} theme={theme} />}
       {shield && (

--- a/tests/AntennaElement.test.tsx
+++ b/tests/AntennaElement.test.tsx
@@ -44,7 +44,7 @@ describe('AntennaElement', () => {
 
   it('renders a basic antenna element wire', () => {
     const { container } = render(
-      <AntennaElement wire={defaultWire} theme="dark" />
+      <AntennaElement wire={defaultWire} color={THEME_COLORS['dark'].wire} />
     );
 
     // Verify correct structure is rendered
@@ -59,7 +59,7 @@ describe('AntennaElement', () => {
   it('adjusts properties for shield wires', () => {
     const shieldWire = { ...defaultWire, isShield: true };
     const { container } = render(
-      <AntennaElement wire={shieldWire} theme="dark" />
+      <AntennaElement wire={shieldWire} color={THEME_COLORS['dark'].wire} />
     );
 
     const material = container.querySelector('meshstandardmaterial');
@@ -71,7 +71,7 @@ describe('AntennaElement', () => {
   it('adjusts properties for bridge wires', () => {
     const bridgeWire = { ...defaultWire, isBridge: true };
     const { container } = render(
-      <AntennaElement wire={bridgeWire} theme="dark" />
+      <AntennaElement wire={bridgeWire} color={THEME_COLORS['dark'].wire} />
     );
 
     const material = container.querySelector('meshstandardmaterial');
@@ -83,7 +83,7 @@ describe('AntennaElement', () => {
   it('adjusts properties for standard wires', () => {
     const standardWire = { ...defaultWire, isShield: false, isBridge: false };
     const { container } = render(
-      <AntennaElement wire={standardWire} theme="dark" />
+      <AntennaElement wire={standardWire} color={THEME_COLORS['dark'].wire} />
     );
 
     const material = container.querySelector('meshstandardmaterial');
@@ -94,7 +94,7 @@ describe('AntennaElement', () => {
 
   it('applies theme colors correctly for light theme', () => {
     const { container } = render(
-      <AntennaElement wire={defaultWire} theme="light" />
+      <AntennaElement wire={defaultWire} color={THEME_COLORS['light'].wire} />
     );
 
     const material = container.querySelector('meshstandardmaterial');
@@ -105,7 +105,7 @@ describe('AntennaElement', () => {
 
   it('applies theme colors correctly for dark theme', () => {
     const { container } = render(
-      <AntennaElement wire={defaultWire} theme="dark" />
+      <AntennaElement wire={defaultWire} color={THEME_COLORS['dark'].wire} />
     );
 
     const material = container.querySelector('meshstandardmaterial');

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       thresholds: {
-        statements: 72.83,
+        statements: 72.84,
         branches: 64.93,
         functions: 77.93,
         lines: 94.82,


### PR DESCRIPTION
🎯 **What:** Removed the `Theme` and `THEME_COLORS` dependencies from `AntennaElement.tsx` by refactoring it to accept a generic `color: string` prop.
💡 **Why:** This decoupling improves the separation of concerns. `AntennaElement` is now a pure presentation component that doesn't need to know about the application's global theme structures, making it cleaner and more reusable, and satisfying the code health constraint.
✅ **Verification:** Verified by checking file modifications, running `npm run lint` (which passes clean), updating corresponding unit tests (`AntennaElement.test.tsx`), and running the full Vitest suite (`npm run test -- --run --coverage`), updating `vitest.config.ts` to match the exact coverage metrics safely.
✨ **Result:** A more modular and decoupled component structure with zero regressions and no unused imports.

---
*PR created automatically by Jules for task [11227500326646633365](https://jules.google.com/task/11227500326646633365) started by @2fst4u*