### PR TITLE
🧹 [decouple Feedpoint from theme dependency]

### DIFF
--- a/src/components/Scene/AntennaWire.tsx
+++ b/src/components/Scene/AntennaWire.tsx
@@ -32,7 +32,7 @@ export function AntennaWire(props: AntennaWireProps) {
       {rendered.map((s) => (
         <AntennaElement key={s.key} wire={s} color={wireColor} />
       ))}
-      {feedpoint && <Feedpoint position={feedpoint} theme={theme} />}
+      {feedpoint && <Feedpoint position={feedpoint} color={THEME_COLORS[theme].feedpoint} />}
       {shield && (
         <ShieldElement shield={shield} transformerEnabled={transformerEnabled} />
       )}

--- a/src/components/Scene/Feedpoint.tsx
+++ b/src/components/Scene/Feedpoint.tsx
@@ -1,17 +1,15 @@
-import { THEME_COLORS, type Theme } from '../../utils/themeColors';
-
 export interface FeedpointProps {
   position: [number, number, number];
-  theme: Theme;
+  color: string;
 }
 
-export function Feedpoint({ position, theme }: FeedpointProps) {
+export function Feedpoint({ position, color }: FeedpointProps) {
   return (
     <mesh position={position}>
       <sphereGeometry args={[0.22, 16, 16]} />
       <meshStandardMaterial
-        color={THEME_COLORS[theme].feedpoint}
-        emissive={THEME_COLORS[theme].feedpoint}
+        color={color}
+        emissive={color}
         emissiveIntensity={0.4}
       />
     </mesh>

--- a/tests/Feedpoint.test.tsx
+++ b/tests/Feedpoint.test.tsx
@@ -26,7 +26,7 @@ describe('Feedpoint', () => {
 
   it('renders correctly with dark theme', () => {
     const position: [number, number, number] = [1, 2, 3];
-    const { container } = render(<Feedpoint position={position} theme="dark" />);
+    const { container } = render(<Feedpoint position={position} color={THEME_COLORS.dark.feedpoint} />);
 
     const mesh = container.querySelector('mesh');
     expect(mesh).toBeTruthy();
@@ -51,7 +51,7 @@ describe('Feedpoint', () => {
 
   it('renders correctly with light theme', () => {
     const position: [number, number, number] = [-5, 0, 10];
-    const { container } = render(<Feedpoint position={position} theme="light" />);
+    const { container } = render(<Feedpoint position={position} color={THEME_COLORS.light.feedpoint} />);
 
     const material = container.querySelector('meshstandardmaterial');
     expect(material).toBeTruthy();


### PR DESCRIPTION
🎯 **What:** Decoupled `Feedpoint` component from the `Theme` type and `THEME_COLORS` global state.
💡 **Why:** `Feedpoint` only needed a single color value but depended on the whole Theme type and specific theme constants, causing an unused import violation and tight coupling. Pushing the dependency evaluation up to the parent `AntennaWire` and accepting a generic primitive `color: string` prop improves the component's reusability and maintainability.
✅ **Verification:** Verified changes via tests (`npm run test -- --run --coverage`) to ensure standard rendering works correctly. No UI changes require visual tests. Evaluated coverage thresholds and ensured tests pass.
✨ **Result:** Improved component purity and decoupling, removing unused imports.

---
*PR created automatically by Jules for task [4397226296452009694](https://jules.google.com/task/4397226296452009694) started by @2fst4u*