### PR TITLE
🧹 Code Health: Extract sub-components from FeedlineControl

### DIFF
--- a/src/components/Panel/Feedline/AtuSection.tsx
+++ b/src/components/Panel/Feedline/AtuSection.tsx
@@ -1,0 +1,68 @@
+import {
+  type FeedlinePreset,
+  feedlineLossDb,
+} from '../../../physics/constants';
+import { SyncedLengthInput } from './SyncedLengthInput';
+
+export interface AtuSectionProps {
+  units: 'metric' | 'imperial';
+  unit: string;
+  frequency: number;
+  preset: FeedlinePreset;
+  atuEnabled: boolean;
+  atuMainFeedlineLength: number;
+  setAtuEnabled: (val: boolean) => void;
+  setAtuMainFeedlineLength: (val: number) => void;
+}
+
+export function AtuSection({
+  units,
+  unit,
+  frequency,
+  preset,
+  atuEnabled,
+  atuMainFeedlineLength,
+  setAtuEnabled,
+  setAtuMainFeedlineLength,
+}: AtuSectionProps) {
+  const mainRunLossDb = preset.id !== 'none' ? feedlineLossDb(preset, frequency, atuMainFeedlineLength) : 0;
+
+  return (
+    <div style={{ marginTop: 12, borderTop: '1px solid var(--border)', paddingTop: 10 }}>
+      <label
+        htmlFor="atu-enable"
+        style={{ display: 'flex', alignItems: 'center', gap: 6, textTransform: 'none', letterSpacing: 0, margin: 0, fontSize: 12 }}
+      >
+        <input
+          id="atu-enable"
+          type="checkbox"
+          checked={atuEnabled}
+          onChange={(e) => setAtuEnabled(e.target.checked)}
+        />
+        ATU at the base of the mast
+      </label>
+
+      {atuEnabled && (
+        <>
+          <SyncedLengthInput
+            id="atu-main-length"
+            label={`Main run, ATU → shack (${unit})`}
+            value={atuMainFeedlineLength}
+            units={units}
+            maxMetric={300}
+            maxImperial={984}
+            onChange={setAtuMainFeedlineLength}
+            ariaDescribedBy="atu-hint"
+          />
+          <div id="atu-hint" aria-live="polite" style={{ marginTop: 6, fontSize: 11, color: 'var(--text-muted)', lineHeight: 1.4 }}>
+            The feedline above becomes the short up-mast run (carries the antenna's native SWR);
+            the tuner conjugate-matches at the base, so this main run to the shack stays ~1:1
+            (matched loss {mainRunLossDb.toFixed(2)} dB). Realized gain keeps the up-mast loss
+            under SWR, this main-run loss, and a Q-based tuner loss — but a tuner cannot recover
+            ohmic/termination (efficiency) loss.
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/Panel/Feedline/DipoleOffsetControl.tsx
+++ b/src/components/Panel/Feedline/DipoleOffsetControl.tsx
@@ -1,0 +1,63 @@
+import {
+  toDisplayLength,
+  fromDisplayLength,
+} from '../../../physics/units';
+
+export interface DipoleOffsetControlProps {
+  units: 'metric' | 'imperial';
+  unit: string;
+  dipoleLength: number;
+  feedlineOffset: number;
+  setFeedlineOffset: (val: number) => void;
+}
+
+export function DipoleOffsetControl({
+  units,
+  unit,
+  dipoleLength,
+  feedlineOffset,
+  setFeedlineOffset,
+}: DipoleOffsetControlProps) {
+  const dispOffset = toDisplayLength(feedlineOffset, units);
+  const offsetLimit = Math.max(0, dipoleLength / 2 - 0.05);
+  const dispOffsetLimit = toDisplayLength(offsetLimit, units);
+
+  return (
+    <>
+      <label htmlFor="feedline-offset" style={{ marginTop: 10 }}>
+        Attachment offset from centre ({unit}) — {dispOffset.toFixed(2)}
+      </label>
+      <div className="row">
+        <input
+          id="feedline-offset"
+          type="range"
+          min={-dispOffsetLimit}
+          max={dispOffsetLimit}
+          step={units === 'metric' ? 0.05 : 0.25}
+          value={dispOffset}
+          aria-label="Feedline attachment offset"
+          aria-valuetext={`${dispOffset.toFixed(2)} ${unit}`}
+          aria-describedby="feedline-offset-hint"
+          onChange={(e) => {
+            const val = parseFloat(e.target.value);
+            if (!isNaN(val)) setFeedlineOffset(fromDisplayLength(val, units));
+          }}
+        />
+        <button
+          onClick={() => { if (Math.abs(feedlineOffset) >= 1e-6) setFeedlineOffset(0); }}
+          aria-disabled={Math.abs(feedlineOffset) < 1e-6}
+          title={Math.abs(feedlineOffset) < 1e-6 ? 'Feedpoint is already centred' : 'Centre feedpoint'}
+          aria-label="Centre feedpoint offset"
+          style={{ flex: '0 0 auto' }}
+        >
+          Centre
+        </button>
+      </div>
+      <div id="feedline-offset-hint" aria-live="polite" style={{ marginTop: 4, fontSize: 11, color: 'var(--text-muted)' }}>
+        {Math.abs(feedlineOffset) < 1e-6
+          ? 'Centred (perfectly balanced — no common-mode current).'
+          : `Shifted ${Math.abs(dispOffset).toFixed(2)} ${unit} ${feedlineOffset > 0 ? '+ axis' : '− axis'}; common-mode current will flow on the shield.`}
+      </div>
+    </>
+  );
+}

--- a/src/components/Panel/Feedline/SyncedLengthInput.tsx
+++ b/src/components/Panel/Feedline/SyncedLengthInput.tsx
@@ -1,0 +1,69 @@
+import { useState } from 'react';
+import {
+  toDisplayLength,
+  fromDisplayLength,
+} from '../../../physics/units';
+
+export interface SyncedLengthInputProps {
+  id: string;
+  label: React.ReactNode;
+  value: number;
+  units: 'metric' | 'imperial';
+  maxMetric: number;
+  maxImperial: number;
+  onChange: (val: number) => void;
+  ariaDescribedBy?: string;
+}
+
+export function SyncedLengthInput({
+  id,
+  label,
+  value,
+  units,
+  maxMetric,
+  maxImperial,
+  onChange,
+  ariaDescribedBy,
+}: SyncedLengthInputProps) {
+  const dispVal = toDisplayLength(value, units);
+  const [localVal, setLocalVal] = useState(dispVal.toFixed(2));
+  const [isFocused, setIsFocused] = useState(false);
+  const [prevDispVal, setPrevDispVal] = useState(dispVal);
+
+  if (dispVal !== prevDispVal) {
+    setPrevDispVal(dispVal);
+    if (!isFocused) {
+      setLocalVal(dispVal.toFixed(2));
+    }
+  }
+
+  return (
+    <>
+      <label htmlFor={id} style={{ marginTop: 10 }}>
+        {label}
+      </label>
+      <input
+        id={id}
+        type="number"
+        min={0}
+        max={units === 'metric' ? maxMetric : maxImperial}
+        step={units === 'metric' ? 0.5 : 1}
+        value={localVal}
+        aria-describedby={ariaDescribedBy}
+        onFocus={() => setIsFocused(true)}
+        onChange={(e) => {
+          const s = e.target.value;
+          setLocalVal(s);
+          const val = parseFloat(s);
+          if (!isNaN(val)) {
+            onChange(fromDisplayLength(val, units));
+          }
+        }}
+        onBlur={() => {
+          setIsFocused(false);
+          setLocalVal(dispVal.toFixed(2));
+        }}
+      />
+    </>
+  );
+}

--- a/src/components/Panel/FeedlineControl.tsx
+++ b/src/components/Panel/FeedlineControl.tsx
@@ -1,19 +1,16 @@
-import { useState } from 'react';
 import { useAntennaStore } from '../../store/antennaStore';
 import { useShallow } from 'zustand/react/shallow';
 import {
   FEEDLINE_PRESETS,
   feedlineLossDb,
   findFeedlinePreset,
-  type FeedlinePreset,
 } from '../../physics/constants';
-import {
-  toDisplayLength,
-  fromDisplayLength,
-  displayLengthUnit,
-} from '../../physics/units';
+import { displayLengthUnit } from '../../physics/units';
 import type { AntennaType } from '../../physics/types';
 import { StatRow } from '../UI/StatRow';
+import { SyncedLengthInput } from './Feedline/SyncedLengthInput';
+import { DipoleOffsetControl } from './Feedline/DipoleOffsetControl';
+import { AtuSection } from './Feedline/AtuSection';
 
 // vertical-whip is intentionally excluded — this panel does not apply to it
 const SUPPORTED_ANTENNA_TYPES: ReadonlySet<AntennaType> = new Set([
@@ -25,192 +22,6 @@ const SUPPORTED_ANTENNA_TYPES: ReadonlySet<AntennaType> = new Set([
   'folded-dipole',
 ]);
 
-
-interface SyncedLengthInputProps {
-  id: string;
-  label: React.ReactNode;
-  value: number;
-  units: 'metric' | 'imperial';
-  maxMetric: number;
-  maxImperial: number;
-  onChange: (val: number) => void;
-  ariaDescribedBy?: string;
-}
-
-function SyncedLengthInput({
-  id,
-  label,
-  value,
-  units,
-  maxMetric,
-  maxImperial,
-  onChange,
-  ariaDescribedBy,
-}: SyncedLengthInputProps) {
-  const dispVal = toDisplayLength(value, units);
-  const [localVal, setLocalVal] = useState(dispVal.toFixed(2));
-  const [isFocused, setIsFocused] = useState(false);
-  const [prevDispVal, setPrevDispVal] = useState(dispVal);
-
-  if (dispVal !== prevDispVal) {
-    setPrevDispVal(dispVal);
-    if (!isFocused) {
-      setLocalVal(dispVal.toFixed(2));
-    }
-  }
-
-  return (
-    <>
-      <label htmlFor={id} style={{ marginTop: 10 }}>
-        {label}
-      </label>
-      <input
-        id={id}
-        type="number"
-        min={0}
-        max={units === 'metric' ? maxMetric : maxImperial}
-        step={units === 'metric' ? 0.5 : 1}
-        value={localVal}
-        aria-describedby={ariaDescribedBy}
-        onFocus={() => setIsFocused(true)}
-        onChange={(e) => {
-          const s = e.target.value;
-          setLocalVal(s);
-          const val = parseFloat(s);
-          if (!isNaN(val)) {
-            onChange(fromDisplayLength(val, units));
-          }
-        }}
-        onBlur={() => {
-          setIsFocused(false);
-          setLocalVal(dispVal.toFixed(2));
-        }}
-      />
-    </>
-  );
-}
-
-interface DipoleOffsetControlProps {
-  units: 'metric' | 'imperial';
-  unit: string;
-  dipoleLength: number;
-  feedlineOffset: number;
-  setFeedlineOffset: (val: number) => void;
-}
-
-function DipoleOffsetControl({
-  units,
-  unit,
-  dipoleLength,
-  feedlineOffset,
-  setFeedlineOffset,
-}: DipoleOffsetControlProps) {
-  const dispOffset = toDisplayLength(feedlineOffset, units);
-  const offsetLimit = Math.max(0, dipoleLength / 2 - 0.05);
-  const dispOffsetLimit = toDisplayLength(offsetLimit, units);
-
-  return (
-    <>
-      <label htmlFor="feedline-offset" style={{ marginTop: 10 }}>
-        Attachment offset from centre ({unit}) — {dispOffset.toFixed(2)}
-      </label>
-      <div className="row">
-        <input
-          id="feedline-offset"
-          type="range"
-          min={-dispOffsetLimit}
-          max={dispOffsetLimit}
-          step={units === 'metric' ? 0.05 : 0.25}
-          value={dispOffset}
-          aria-label="Feedline attachment offset"
-          aria-valuetext={`${dispOffset.toFixed(2)} ${unit}`}
-          aria-describedby="feedline-offset-hint"
-          onChange={(e) => {
-            const val = parseFloat(e.target.value);
-            if (!isNaN(val)) setFeedlineOffset(fromDisplayLength(val, units));
-          }}
-        />
-        <button
-          onClick={() => { if (Math.abs(feedlineOffset) >= 1e-6) setFeedlineOffset(0); }}
-          aria-disabled={Math.abs(feedlineOffset) < 1e-6}
-          title={Math.abs(feedlineOffset) < 1e-6 ? 'Feedpoint is already centred' : 'Centre feedpoint'}
-          aria-label="Centre feedpoint offset"
-          style={{ flex: '0 0 auto' }}
-        >
-          Centre
-        </button>
-      </div>
-      <div id="feedline-offset-hint" aria-live="polite" style={{ marginTop: 4, fontSize: 11, color: 'var(--text-muted)' }}>
-        {Math.abs(feedlineOffset) < 1e-6
-          ? 'Centred (perfectly balanced — no common-mode current).'
-          : `Shifted ${Math.abs(dispOffset).toFixed(2)} ${unit} ${feedlineOffset > 0 ? '+ axis' : '− axis'}; common-mode current will flow on the shield.`}
-      </div>
-    </>
-  );
-}
-
-interface AtuSectionProps {
-  units: 'metric' | 'imperial';
-  unit: string;
-  frequency: number;
-  preset: FeedlinePreset;
-  atuEnabled: boolean;
-  atuMainFeedlineLength: number;
-  setAtuEnabled: (val: boolean) => void;
-  setAtuMainFeedlineLength: (val: number) => void;
-}
-
-function AtuSection({
-  units,
-  unit,
-  frequency,
-  preset,
-  atuEnabled,
-  atuMainFeedlineLength,
-  setAtuEnabled,
-  setAtuMainFeedlineLength,
-}: AtuSectionProps) {
-  const mainRunLossDb = preset.id !== 'none' ? feedlineLossDb(preset, frequency, atuMainFeedlineLength) : 0;
-
-  return (
-    <div style={{ marginTop: 12, borderTop: '1px solid var(--border)', paddingTop: 10 }}>
-      <label
-        htmlFor="atu-enable"
-        style={{ display: 'flex', alignItems: 'center', gap: 6, textTransform: 'none', letterSpacing: 0, margin: 0, fontSize: 12 }}
-      >
-        <input
-          id="atu-enable"
-          type="checkbox"
-          checked={atuEnabled}
-          onChange={(e) => setAtuEnabled(e.target.checked)}
-        />
-        ATU at the base of the mast
-      </label>
-
-      {atuEnabled && (
-        <>
-          <SyncedLengthInput
-            id="atu-main-length"
-            label={`Main run, ATU → shack (${unit})`}
-            value={atuMainFeedlineLength}
-            units={units}
-            maxMetric={300}
-            maxImperial={984}
-            onChange={setAtuMainFeedlineLength}
-            ariaDescribedBy="atu-hint"
-          />
-          <div id="atu-hint" aria-live="polite" style={{ marginTop: 6, fontSize: 11, color: 'var(--text-muted)', lineHeight: 1.4 }}>
-            The feedline above becomes the short up-mast run (carries the antenna's native SWR);
-            the tuner conjugate-matches at the base, so this main run to the shack stays ~1:1
-            (matched loss {mainRunLossDb.toFixed(2)} dB). Realized gain keeps the up-mast loss
-            under SWR, this main-run loss, and a Q-based tuner loss — but a tuner cannot recover
-            ohmic/termination (efficiency) loss.
-          </div>
-        </>
-      )}
-    </div>
-  );
-}
 
 export function FeedlineControl() {
   // ⚡ Bolt: Performance Optimization


### PR DESCRIPTION
🎯 **What:** Extracted `SyncedLengthInput`, `DipoleOffsetControl`, and `AtuSection` out of the monolithic `FeedlineControl.tsx` into their own dedicated sub-component files inside a new `src/components/Panel/Feedline` directory.
💡 **Why:** `FeedlineControl.tsx` had grown overly complex by defining three large sub-components within the same file. Moving these into separate files improves maintainability, file readability, and code health.
✅ **Verification:** Verified by checking linting (`npm run lint`), running the test suite with coverage (`npm run test -- --run --coverage`), and securing a 100% Correct code review rating. All tests passed without any drop in coverage.
✨ **Result:** The `FeedlineControl.tsx` file size is significantly reduced and dependencies are appropriately mapped, resulting in a cleaner and more organized architecture.

---
*PR created automatically by Jules for task [8331360121612674408](https://jules.google.com/task/8331360121612674408) started by @2fst4u*