### PR TITLE
🧹 Sweep: Remove unused export keywords for internal types

### DIFF
--- a/.jules/sweep.md
+++ b/.jules/sweep.md
@@ -102,3 +102,4 @@
 ## 2025-03-02 - Removed unused oddRound export
 **Learning:** `knip` will correctly flag functions that are exported but only used within the file they are defined in. In `src/store/antennaGeometry.ts`, `oddRound` was exported despite only being consumed locally.
 **Action:** Un-export functions that are strictly internal helpers. This reduces the public API surface area and eliminates false-positive static analysis warnings without deleting necessary code.
+## 2026-07-22 - Un-export internal types to fix Knip warnings\n**Learning:** When Knip flags types as unused exports, merely un-exporting them can break the TypeScript build if those types are still used inside other exported interfaces (TS4023). However, if carefully done for types that don't leak into the public API, it clears technical debt.\n**Action:** Un-exported HopStatus, LinkQuality, Vec3, GroundType, Excitation, and FeedlineShield since they were only used internally.

--- a/src/physics/propagation.ts
+++ b/src/physics/propagation.ts
@@ -76,8 +76,8 @@ export interface PropagationInputs {
   readonly swr?: number;
 }
 
-export type HopStatus = 'open' | 'marginal' | 'closed';
-export type LinkQuality = 'useful' | 'weak' | 'unusable';
+type HopStatus = 'open' | 'marginal' | 'closed';
+type LinkQuality = 'useful' | 'weak' | 'unusable';
 
 export interface HopPrediction {
   /** Hop number, 1-based. */

--- a/src/physics/types.ts
+++ b/src/physics/types.ts
@@ -1,6 +1,6 @@
 // Shared physics-layer types. Everything here is metric, SI units.
 
-export type Vec3 = readonly [number, number, number];
+type Vec3 = readonly [number, number, number];
 
 /**
  * Antenna topology type.
@@ -40,7 +40,7 @@ export interface Wire {
   readonly tag?: number;
 }
 
-export type GroundType = 'free' | 'perfect' | 'real';
+type GroundType = 'free' | 'perfect' | 'real';
 
 export interface GroundParams {
   readonly type: GroundType;
@@ -50,7 +50,7 @@ export interface GroundParams {
   readonly epsilon?: number;
 }
 
-export interface Excitation {
+interface Excitation {
   readonly wireTag: number;
   /** 1-based segment index within the tagged wire to feed. */
   readonly segment: number;

--- a/src/store/antennaGeometry.ts
+++ b/src/store/antennaGeometry.ts
@@ -400,7 +400,7 @@ export function buildSlopingVWires(params: SlopingVWiresParams): Wire[] {
   return wires;
 }
 
-export interface FeedlineShield {
+interface FeedlineShield {
   readonly bottomZ: number;
   readonly radius: number;
   readonly segments: number;


### PR DESCRIPTION
💡 What: Removed `export` keyword from `HopStatus`, `LinkQuality`, `Vec3`, `GroundType`, `Excitation`, and `FeedlineShield` types across `src/physics/propagation.ts`, `src/physics/types.ts`, and `src/store/antennaGeometry.ts`.
🎯 Why: These types were flagged by `knip` as unused exports. Restricting their scope to the local file cleans up the module's public API without deleting necessary code or functionality.
🔬 Verification: Ran `npx knip` to verify the types are no longer flagged. Ran `npm run test -- --run --coverage` and `npm run build` to guarantee compilation and tests still succeed with no issues.

---
*PR created automatically by Jules for task [865687544900595299](https://jules.google.com/task/865687544900595299) started by @2fst4u*