### PR TITLE
📚 Archivist: Clarify Sloping V leg slope calculation

### DIFF
--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -131,3 +131,6 @@
 ## 2026-07-28 - Inverted-L Base Height Documentation Drift
 **Learning:** The documentation claimed the Inverted-L vertical wire started at `VERTICAL_WHIP_BASE_GAP_M` above ground, comparing it to the vertical whip for "same electrical isolation". However, `buildVerticalWhipWires` uses `Math.max(VERTICAL_WHIP_BASE_GAP_M, height)` while `buildInvertedLWires` hardcodes it to exactly `VERTICAL_WHIP_BASE_GAP_M` regardless of height. The comparison was inaccurate.
 **Action:** Updated `docs/antenna-spec.md` to state the Inverted-L base starts exactly at `VERTICAL_WHIP_BASE_GAP_M` regardless of height, removing the false comparison to the vertical whip.
+## 2026-07-29 - Sloping V leg slope calculation
+**Learning:** The documentation for the Sloping V antenna listed a user-configurable slope angle $\theta$ (below horizontal) under "Angle/Slope". However, the application engine ignores any input `legSlope` parameter and calculates the downward slope to force the tips to precisely rest at the ground floor (`SLOPING_V_MIN_TIP_Z_M` or $0.5$ m) to ensure termination to the ground.
+**Action:** Updated `docs/antenna-spec.md` to clarify that the downward slope of the legs is automatically calculated, eliminating confusion about a user-configurable slope setting.

--- a/docs/antenna-spec.md
+++ b/docs/antenna-spec.md
@@ -187,7 +187,7 @@ Every type below uses the coordinate conventions of Part I §1 and the glossary 
 - **Apex Location:** Highest point at $(0, 0, \text{height})$. The `height` parameter refers to the feedpoint (apex).
 - **Leg Count & Length:** 2 legs, length $L$ **per leg** (Total radiating wire $2L$).
 - **Reference Length:** $2.0\lambda$ **total** ($\approx 1.0\lambda$ per leg). The `length` parameter is the total radiating wire, split into two legs of $(L - \text{bridge})/2$ each. Traveling-wave structure, so no end-effect correction applies.
-- **Angle/Slope:** Included angle $\alpha$ (between legs) and slope angle $\theta$ (below horizontal).
+- **Angle/Slope:** Included angle $\alpha$ (between legs). The downward slope of the legs is automatically calculated so that the tips rest at the ground floor (`SLOPING_V_MIN_TIP_Z_M` or $0.5$ m) to ensure consistent termination to ground.
 - **Tips:** Endpoints at ground-ward end of legs.
 - **Min Height:** Tip height must be $\ge 0.5$ m.
 


### PR DESCRIPTION
💡 Problem: The documentation incorrectly stated that the Sloping V had a configurable slope angle $\theta$ (below horizontal) while the engine actually ignored it and calculated the slope to reach the ground automatically.
🎯 Fix: Updated `docs/antenna-spec.md` to state that the downward slope of the legs is automatically calculated so that the tips rest at the ground floor (`SLOPING_V_MIN_TIP_Z_M` or $0.5$ m) to ensure consistent termination to ground. Added a new journal entry to `.jules/archivist.md`.
🧪 Verification: Confirmed via reviewing `buildSlopingVWires` in `src/store/antennaGeometry.ts`. Ran `npm run lint` and `npm run test -- --run` to ensure no breakages.
🔎 Scope: Only modified documentation (`docs/antenna-spec.md` and `.jules/archivist.md`).

---
*PR created automatically by Jules for task [652199710421392916](https://jules.google.com/task/652199710421392916) started by @2fst4u*