### PR TITLE
🎨 Palette: Prevent layout shift by persisting optimal transformer match button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -14,3 +14,6 @@
 ## 2025-07-15 - Accessible Tooltips for Disabled Buttons
 **Learning:** Native `disabled` attributes on buttons completely remove them from the keyboard focus order and swallow mouse hover events in most browsers, making `title` tooltips explaining the disabled state invisible to both mouse and keyboard users.
 **Action:** Use `aria-disabled="true"` with conditional `onClick` handlers and matching CSS styles (`button[aria-disabled="true"]`) instead of native `disabled` when a button requires an explanatory tooltip.
+## 2024-07-23 - Prevent layout shift with persistent disabled action buttons
+**Learning:** Disappearing action buttons (like "Match ratio") after being clicked cause jarring layout shifts and remove the indication that the feature exists. They also disrupt screen reader focus.
+**Action:** Use `aria-disabled="true"` with an updated `title` explaining the disabled state instead of conditionally rendering the button out of the DOM. This provides consistent UI and reassures users their setting is optimal.

--- a/src/components/Panel/TransformerControl.tsx
+++ b/src/components/Panel/TransformerControl.tsx
@@ -59,10 +59,13 @@ function TransformerRatioInput({
             setLocalRatio(transformerRatio.toString());
           }}
         />
-        {optimalRatio !== null && optimalRatio !== transformerRatio && (
+        {optimalRatio !== null && (
           <button
-            onClick={() => setTransformerRatio(optimalRatio)}
-            title={`Set ratio to ${optimalRatio}:1 — the estimated best match for this antenna${feedlineActive ? ' and feedline' : ''}, from the simulated impedance. The ratio is never changed automatically; click to apply.`}
+            onClick={() => { if (optimalRatio !== transformerRatio) setTransformerRatio(optimalRatio); }}
+            aria-disabled={optimalRatio === transformerRatio}
+            title={optimalRatio === transformerRatio
+              ? `Already optimally matched to ${optimalRatio}:1`
+              : `Set ratio to ${optimalRatio}:1 — the estimated best match for this antenna${feedlineActive ? ' and feedline' : ''}, from the simulated impedance. The ratio is never changed automatically; click to apply.`}
             aria-label={`Match transformer ratio to ${optimalRatio}:1`}
             style={{ flex: '0 0 auto' }}
           >

--- a/tests/TransformerControl.test.tsx
+++ b/tests/TransformerControl.test.tsx
@@ -84,15 +84,17 @@ describe('TransformerControl', () => {
     expect(button).not.toBeNull();
   });
 
-  it('does not suggest optimal ratio if it matches current ratio', () => {
+  it('suggests optimal ratio is matched if it matches current ratio', () => {
     useAntennaStore.setState({
       transformerEnabled: true,
       transformerRatio: 4,
       feedlineId: 'none',
       result: { impedance: { R: 200, X: 0 } } as unknown as SimulationResult
     });
-    const { queryByRole } = render(<TransformerControl />);
-    expect(queryByRole('button', { name: /Match/i })).toBeNull();
+    const { getByRole } = render(<TransformerControl />);
+    const button = getByRole('button', { name: /Match/i });
+    expect(button.getAttribute('aria-disabled')).toBe('true');
+    expect(button.getAttribute('title')).toContain('Already optimally matched to 4:1');
   });
 
   it('applies optimal ratio when match button is clicked', () => {


### PR DESCRIPTION
💡 What: Change the optimal transformer match button to use an `aria-disabled` state instead of disappearing from the DOM when the current ratio matches the optimal ratio.
🎯 Why: Conditionally hiding the button causes a jarring layout shift upon click. Persisting it in a disabled state provides a more stable, consistent UI and reassuring feedback via a tooltip that the current setting is already optimal.
📸 Before/After: Before, clicking the button made it vanish. Now, clicking it transitions it to a disabled state with a tooltip saying "Already optimally matched to X:1".
♿ Accessibility: Replaces structural DOM changes (which can disrupt screen reader focus) with a stable, discoverable `aria-disabled` element with an explanatory title attribute.

---
*PR created automatically by Jules for task [2179979494372801560](https://jules.google.com/task/2179979494372801560) started by @2fst4u*