### PR TITLE
🎨 Palette: Add aria-controls to Ground settings toggle

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -17,3 +17,6 @@
 ## 2024-07-23 - Prevent layout shift with persistent disabled action buttons
 **Learning:** Disappearing action buttons (like "Match ratio") after being clicked cause jarring layout shifts and remove the indication that the feature exists. They also disrupt screen reader focus.
 **Action:** Use `aria-disabled="true"` with an updated `title` explaining the disabled state instead of conditionally rendering the button out of the DOM. This provides consistent UI and reassures users their setting is optimal.
+## 2026-07-24 - Added aria-controls to Ground Settings toggle
+**Learning:** When using `aria-expanded` on a toggle button to reveal conditionally rendered React content, ensure the target content is wrapped in a container element with an explicit ID, and link the button via `aria-controls` to maintain strict accessibility semantics.
+**Action:** Always check that toggle buttons with `aria-expanded` also have a matching `aria-controls` attribute, and refactor React fragments to `div`s if an ID anchor is missing.

--- a/src/components/Panel/GroundControl.tsx
+++ b/src/components/Panel/GroundControl.tsx
@@ -53,6 +53,7 @@ export function GroundControl() {
           style={{ padding: '2px 8px', fontSize: 11, marginLeft: 8 }}
           onClick={() => setExpanded((v) => !v)}
           aria-expanded={expanded}
+          aria-controls="custom-ground-settings"
           aria-label={expanded ? 'Simple: Hide custom ground settings' : 'Custom: Show custom ground settings'}
           title={expanded ? 'Hide custom settings' : 'Show custom settings'}
         >
@@ -69,7 +70,7 @@ export function GroundControl() {
         {GROUND_PRESET_MAP.get(groundId)?.hint ?? 'Custom ground parameters.'}
       </div>
       {(expanded || groundId === 'custom') && (
-        <>
+        <div id="custom-ground-settings">
           <label htmlFor="custom-ground-sigma" style={{ marginTop: 10 }}>Conductivity σ (S/m)</label>
           <input
             id="custom-ground-sigma"
@@ -112,7 +113,7 @@ export function GroundControl() {
               setLocalEpsilon(epsilon.toString());
             }}
           />
-        </>
+        </div>
       )}
     </section>
   );


### PR DESCRIPTION
💡 What: Added the `aria-controls` attribute to the "Custom" ground settings toggle button and wrapped its conditionally rendered target content in a `<div id="custom-ground-settings">`.
🎯 Why: Completes the ARIA toggle button pattern. While `aria-expanded` was present, screen readers require `aria-controls` to programmatically associate the button with the specific content area it manages.
📸 Before/After: Visual presentation remains exactly identical.
♿ Accessibility: Improves screen reader navigation and predictability by explicitly linking the control to the controlled region.

---
*PR created automatically by Jules for task [1739894088089443597](https://jules.google.com/task/1739894088089443597) started by @2fst4u*