### PR TITLE
🧹 Sweep: Remove duplicate export TERMINATED_DELTA_CENTRE_GAP_M

### DIFF
--- a/src/physics/constants.ts
+++ b/src/physics/constants.ts
@@ -313,7 +313,6 @@ export const VERTICAL_WHIP_RADIAL_COUNT = 4;
  * NEC-valid (no coincident wires) without materially altering the
  * radiating perimeter.
  */
-export const TERMINATED_DELTA_CENTRE_GAP_M = FEED_BRIDGE_LENGTH_M;
 
 /**
  * Z-coordinate of the bottom endpoint of the sloping-V termination stubs,

--- a/src/store/antennaGeometry.ts
+++ b/src/store/antennaGeometry.ts
@@ -11,7 +11,6 @@ import {
   FEEDLINE_SHIELD_TAG,
   TERMINATED_DELTA_LEFT_BASE_TAG,
   TERMINATED_DELTA_RIGHT_BASE_TAG,
-  TERMINATED_DELTA_CENTRE_GAP_M,
   VERTICAL_WHIP_TAG,
   VERTICAL_WHIP_BASE_GAP_M,
   VERTICAL_WHIP_RADIAL_TAG,
@@ -577,10 +576,10 @@ function calcTerminatedDeltaPoints(halfBase: number, dx: number, dy: number, bot
   const rightCorner: [number, number, number] = [halfBase * dx, halfBase * dy, bottomZ];
 
   // Inner ends of the two half-base wires. They sit slightly to the left
-  // and right of the geometric centre with a gap of TERMINATED_DELTA_CENTRE_GAP_M
+  // and right of the geometric centre with a gap of FEED_BRIDGE_LENGTH_M
   // between them — the gap is electrically open in the unterminated case
   // and is bridged by the stub+resistor pair to ground when terminated.
-  const innerOffset = Math.max(0, TERMINATED_DELTA_CENTRE_GAP_M / 2);
+  const innerOffset = Math.max(0, FEED_BRIDGE_LENGTH_M / 2);
   const innerHalfBase = Math.max(0.01, halfBase - innerOffset);
   const centreLeft: [number, number, number] = [-innerOffset * dx, -innerOffset * dy, bottomZ];
   const centreRight: [number, number, number] = [innerOffset * dx, innerOffset * dy, bottomZ];
@@ -595,7 +594,7 @@ function calcTerminatedDeltaPoints(halfBase: number, dx: number, dy: number, bot
  * perimeter-preserving leg/base math, same equilateral-when-possible
  * shape, same apex feed convention. The only structural difference is
  * that the base is **split in the middle** into two independent
- * half-base wires separated by `TERMINATED_DELTA_CENTRE_GAP_M`. Each
+ * half-base wires separated by `FEED_BRIDGE_LENGTH_M`. Each
  * half-base ends near the centre and the termination network (vertical
  * stub + LD-4 resistor) is added in selectSimulationInput when the user
  * specifies a non-zero terminating resistance — mirroring the
@@ -1013,7 +1012,7 @@ export interface FoldedAntennaWiresParams {
   frequency: number;
   /**
    * When > 0, the top (un-fed) conductor is split at its centre with a gap
-   * of TERMINATED_DELTA_CENTRE_GAP_M so that buildTerminationElements can
+   * of FEED_BRIDGE_LENGTH_M so that buildTerminationElements can
    * add a resistive bridge across the gap (TFD topology). When 0 (unterminated),
    * both halves share a common junction at the top centre — electrically
    * equivalent to a single continuous wire.
@@ -1038,7 +1037,7 @@ export interface FoldedAntennaWiresParams {
  * The top (un-fed) conductor is always split into two halves at the centre:
  *   • Unterminated: both halves share the same junction point at topCenter
  *     (0, 0, height + aperture), forming a continuous wire. No gap, no bridge.
- *   • Terminated (terminatingResistor > 0): a gap of TERMINATED_DELTA_CENTRE_GAP_M
+ *   • Terminated (terminatingResistor > 0): a gap of FEED_BRIDGE_LENGTH_M
  *     separates the two inner ends. buildTerminationElements adds a horizontal
  *     bridge wire (FOLDED_DIPOLE_TERM_BRIDGE_TAG) with an LD-4 load across the
  *     gap. Current must flow through R to pass between the halves — exactly the
@@ -1058,7 +1057,7 @@ export function buildFoldedAntennaWires(params: FoldedAntennaWiresParams): Wire[
   const aperture = Math.max(0.02, params.aperture);
   const bridgeHalf = FEED_BRIDGE_LENGTH_M / 2;
   const hasTermination = (params.terminatingResistor ?? 0) > 0;
-  const gapHalf = hasTermination ? TERMINATED_DELTA_CENTRE_GAP_M / 2 : 0;
+  const gapHalf = hasTermination ? FEED_BRIDGE_LENGTH_M / 2 : 0;
 
   const pts = calcFoldedAntennaPoints(params.orientation, h, half, aperture, bridgeHalf, gapHalf);
   const segs = calcFoldedAntennaSegments(

--- a/src/store/antennaStore.ts
+++ b/src/store/antennaStore.ts
@@ -1327,7 +1327,7 @@ function buildFoldedDipoleTermination(R: number, radius: number, wires: Wire[]) 
   // Terminated Folded Dipole (TFD) — correct travelling-wave gap-bridge topology.
   //
   // buildFoldedAntennaWires splits the top (un-fed) conductor into two halves
-  // with a gap of TERMINATED_DELTA_CENTRE_GAP_M at the centre when a
+  // with a gap of FEED_BRIDGE_LENGTH_M at the centre when a
   // terminating resistor is non-zero. The gap inner ends are:
   //   left-half  .end = topCenterLeft
   //   right-half .start = topCenterRight

--- a/tests/antennaGeometry.test.ts
+++ b/tests/antennaGeometry.test.ts
@@ -14,7 +14,7 @@ import {
   TERMINATED_DELTA_RIGHT_BASE_TAG,
   FEED_BRIDGE_TAG,
   FEEDLINE_SHIELD_TAG,
-  TERMINATED_DELTA_CENTRE_GAP_M,
+  FEED_BRIDGE_LENGTH_M,
   FOLDED_DIPOLE_OPPOSITE_TAG,
   FOLDED_DIPOLE_CONNECTOR_TAG,
   SLOPING_V_MIN_TIP_Z_M
@@ -108,7 +108,7 @@ describe('buildTerminatedDeltaWires', () => {
       rightBase!.start[2] - leftBase!.end[2]
     );
 
-    expect(gap).toBeCloseTo(TERMINATED_DELTA_CENTRE_GAP_M, 6);
+    expect(gap).toBeCloseTo(FEED_BRIDGE_LENGTH_M, 6);
   });
 
   it('creates 6 wires including feed bridge and shield wires when feedlineShield is provided', () => {
@@ -427,8 +427,8 @@ describe('buildFoldedAntennaWires', () => {
     const dz = leftOpp.end[2] - rightOpp.start[2];
     const distance = Math.sqrt(dx * dx + dy * dy + dz * dz);
 
-    // The gap should equal TERMINATED_DELTA_CENTRE_GAP_M
-    expect(distance).toBeCloseTo(TERMINATED_DELTA_CENTRE_GAP_M);
+    // The gap should equal FEED_BRIDGE_LENGTH_M
+    expect(distance).toBeCloseTo(FEED_BRIDGE_LENGTH_M);
   });
 
   it('respects orientation by rotating the antenna along the correct axis', () => {

--- a/tests/foldedDipole.test.ts
+++ b/tests/foldedDipole.test.ts
@@ -11,7 +11,7 @@ import {
   FOLDED_DIPOLE_TERM_BRIDGE_TAG,
   type AntennaState,
 } from '../src/store/antennaStore';
-import { TERMINATED_DELTA_CENTRE_GAP_M, FEEDLINE_SHIELD_TAG } from '../src/physics/constants';
+import { FEED_BRIDGE_LENGTH_M, FEEDLINE_SHIELD_TAG } from '../src/physics/constants';
 
 const FREQ = 7.1;
 const APERTURE = 0.5;
@@ -99,7 +99,7 @@ describe('folded dipole geometry', () => {
     expect(leftEnd[2]).toBeCloseTo(12 + APERTURE, 9);
   });
 
-  it('terminated: top conductor halves have a gap of TERMINATED_DELTA_CENTRE_GAP_M at the centre', () => {
+  it('terminated: top conductor halves have a gap of FEED_BRIDGE_LENGTH_M at the centre', () => {
     const wires = foldedAntennaWires({ height: 12, terminatingResistor: 600 });
     const oppWires = wires.filter((w) => w.tag === FOLDED_DIPOLE_OPPOSITE_TAG);
     expect(oppWires).toHaveLength(2);
@@ -108,13 +108,13 @@ describe('folded dipole geometry', () => {
     // Both halves are at z = height + aperture.
     expect(leftEnd[2]).toBeCloseTo(12 + APERTURE, 9);
     expect(rightStart[2]).toBeCloseTo(12 + APERTURE, 9);
-    // The gap between them equals TERMINATED_DELTA_CENTRE_GAP_M.
+    // The gap between them equals FEED_BRIDGE_LENGTH_M.
     const gapDist = Math.hypot(
       rightStart[0] - leftEnd[0],
       rightStart[1] - leftEnd[1],
       rightStart[2] - leftEnd[2],
     );
-    expect(gapDist).toBeCloseTo(TERMINATED_DELTA_CENTRE_GAP_M, 6);
+    expect(gapDist).toBeCloseTo(FEED_BRIDGE_LENGTH_M, 6);
   });
 
   it('forms a closed loop — connector endpoints coincide with both conductors', () => {
@@ -188,7 +188,7 @@ describe('folded dipole excitation and termination', () => {
       bridge.end[1] - bridge.start[1],
       bridge.end[2] - bridge.start[2],
     );
-    expect(bridgeLen).toBeCloseTo(TERMINATED_DELTA_CENTRE_GAP_M, 6);
+    expect(bridgeLen).toBeCloseTo(FEED_BRIDGE_LENGTH_M, 6);
 
     // LD-4 on segment 1 of the bridge wire, with the correct resistance.
     const bridgeLoads = (input.loads ?? []).filter((l) => l.wireTag === FOLDED_DIPOLE_TERM_BRIDGE_TAG);

--- a/tests/terminatedDeltaGeometry.test.ts
+++ b/tests/terminatedDeltaGeometry.test.ts
@@ -20,7 +20,7 @@ import {
   FEED_BRIDGE_TAG,
   FEEDLINE_SHIELD_TAG,
   SLOPING_V_MIN_TIP_Z_M,
-  TERMINATED_DELTA_CENTRE_GAP_M,
+  FEED_BRIDGE_LENGTH_M,
   wavelengthMeters,
 } from '../src/physics/constants';
 
@@ -215,7 +215,7 @@ describe('Terminated Delta — base geometry', () => {
     expect(leftHalfBase.start[2]).toBeCloseTo(rightHalfBase.start[2], 6);
   });
 
-  it('the two half-base inner ends are separated by TERMINATED_DELTA_CENTRE_GAP_M', () => {
+  it('the two half-base inner ends are separated by FEED_BRIDGE_LENGTH_M', () => {
     setupTerminatedDelta(0);
     const input = selectSimulationInput(useAntennaStore.getState());
     const leftHalfBase = input.wires.find((w) => w.tag === TERMINATED_DELTA_LEFT_BASE_TAG)!;
@@ -229,7 +229,7 @@ describe('Terminated Delta — base geometry', () => {
       rightInner[1] - leftInner[1],
       rightInner[2] - leftInner[2],
     );
-    expect(gap).toBeCloseTo(TERMINATED_DELTA_CENTRE_GAP_M, 6);
+    expect(gap).toBeCloseTo(FEED_BRIDGE_LENGTH_M, 6);
   });
 
   it('the half-base inner ends straddle the geometric centre symmetrically', () => {
@@ -305,7 +305,7 @@ describe('Terminated Delta — base geometry', () => {
       rightHalfBase.end[1] - rightHalfBase.start[1],
       rightHalfBase.end[2] - rightHalfBase.start[2],
     );
-    const baseLen = leftHalfBaseLen + rightHalfBaseLen + TERMINATED_DELTA_CENTRE_GAP_M;
+    const baseLen = leftHalfBaseLen + rightHalfBaseLen + FEED_BRIDGE_LENGTH_M;
     // Bottom corners clamped to SLOPING_V_MIN_TIP_Z_M.
     expect(leftLeg.start[2]).toBeCloseTo(SLOPING_V_MIN_TIP_Z_M, 4);
     // In a flattened isosceles triangle (t < equilateral height), legs are
@@ -377,7 +377,7 @@ describe('Terminated Delta — terminated (T2FD-style bridge resistor)', () => {
       bridge.end[1] - bridge.start[1],
       bridge.end[2] - bridge.start[2],
     );
-    expect(len).toBeCloseTo(TERMINATED_DELTA_CENTRE_GAP_M, 6);
+    expect(len).toBeCloseTo(FEED_BRIDGE_LENGTH_M, 6);
   });
 
   it('LD card is type 4 on segment 1 of the bridge, resistance equals terminatingResistor', () => {


### PR DESCRIPTION
💡 What:
Removed the duplicate exported constant `TERMINATED_DELTA_CENTRE_GAP_M` from `src/physics/constants.ts` and replaced all its usages across the codebase with the constant it was aliasing: `FEED_BRIDGE_LENGTH_M`.

🎯 Why:
To reduce redundant constants in the constants file and avoid exporting aliases unnecessarily, fulfilling Sweep's mission to remove clutter and deduplicate variables where no behavioral change is intended. Both variables mathematically represent the same gap length (0.1m).

🔬 Verification:
Ran `git grep TERMINATED_DELTA_CENTRE_GAP_M` to ensure no usages exist in the codebase. Ran `npx knip` to verify unused exports were cleared out. Finally, ran `npm run test -- --run`, `npm run lint` and `npm run build` to guarantee identical functionality and a clean build.

---
*PR created automatically by Jules for task [12971847070628019978](https://jules.google.com/task/12971847070628019978) started by @2fst4u*