### PR TITLE
🧹 [Code Health] Reduce deep conditional nesting in sweep.ts

### DIFF
--- a/src/physics/sweep.ts
+++ b/src/physics/sweep.ts
@@ -194,15 +194,20 @@ export async function adaptiveSweep(
     let merged: typeof primaryBands | null = null;
     for (let i = 0; i < broadBands.length; i++) {
       const b = broadBands[i];
-      if (b.fHigh < loEdge - 0.5 || b.fLow > hiEdge + 0.5) {
-        if (merged === null) {
-          merged = [];
-          for (let j = 0; j < primaryBands.length; j++) {
-            merged.push(primaryBands[j]);
-          }
-        }
-        merged.push(b);
+
+      // Skip bands that overlap or are too close to the primary scan window
+      if (b.fHigh >= loEdge - 0.5 && b.fLow <= hiEdge + 0.5) {
+        continue;
       }
+
+      // Initialize merged array on first valid distant band
+      if (merged === null) {
+        merged = [];
+        for (let j = 0; j < primaryBands.length; j++) {
+          merged.push(primaryBands[j]);
+        }
+      }
+      merged.push(b);
     }
 
     if (merged !== null) {


### PR DESCRIPTION
🎯 **What:** Reduced a deeply nested conditional (4 levels deep) in the broad band merging loop in `src/physics/sweep.ts` to 2 levels.
💡 **Why:** Deep nesting makes code harder to read and reason about. By checking the inverse condition and returning early using `continue`, the main body of the loop is de-nested, improving maintainability while preserving exact behavioral equivalence.
✅ **Verification:** Verified via `npm run lint` and `npm test -- --run --coverage`. All existing functionality and tests pass, indicating that the behavior is identical.
✨ **Result:** Improved readability and reduced cognitive complexity of the `adaptiveSweep` loop.

---
*PR created automatically by Jules for task [10887396910963677372](https://jules.google.com/task/10887396910963677372) started by @2fst4u*