### PR TITLE
🧹 Refactor duplicated Wasm instantiation in Nec2Engine

### DIFF
--- a/src/physics/nec2Engine.ts
+++ b/src/physics/nec2Engine.ts
@@ -203,15 +203,30 @@ export class Nec2Engine implements Engine {
     this.logger?.info('[nec2] engine ready');
   }
 
-    private async runJob(factory: EmscriptenFactory, cards: string, logPrefix: string, errPrefix: string, errorName: string): Promise<string> {
+  /**
+   * Run one nec2c job to completion: instantiate the Wasm module, feed it
+   * `cards` on the virtual filesystem, and return the decoded output deck.
+   *
+   * Callers own the concurrency lock and the module lifetime around this —
+   * `kind` only selects the log and error labels so the two call sites stay
+   * distinguishable in the console and in thrown messages.
+   */
+  private async runJob(
+    factory: EmscriptenFactory,
+    cards: string,
+    kind: 'simulate' | 'sweep',
+  ): Promise<string> {
+    const logLabel = kind === 'sweep' ? 'nec2 sweep' : 'nec2';
+    const errorLabel = kind === 'sweep' ? 'nec2c sweep' : 'nec2c';
+
     const stderrLines: string[] = [];
     const instance = await factory({
       noInitialRun: true,
       locateFile: (path: string) => this.resolveAsset(path),
-      print: this.quiet ? () => {} : (s) => this.logger?.info(logPrefix, s),
+      print: this.quiet ? () => {} : (s) => this.logger?.info(`[${logLabel}]`, s),
       printErr: (s) => {
         stderrLines.push(s);
-        if (!this.quiet) this.logger?.warn(errPrefix, s);
+        if (!this.quiet) this.logger?.warn(`[${logLabel} stderr]`, s);
       },
     });
 
@@ -223,7 +238,7 @@ export class Nec2Engine implements Engine {
     const rc = instance.callMain(['-i', inPath, '-o', outPath]);
     if (rc !== 0) {
       const tail = stderrLines.slice(-5).join(' | ') || '(no stderr)';
-      throw new Error(`${errorName} exited with status ${rc}. ${tail}`);
+      throw new Error(`${errorLabel} exited with status ${rc}. ${tail}`);
     }
 
     const outputBytes = instance.FS.readFile(outPath);
@@ -240,7 +255,7 @@ export class Nec2Engine implements Engine {
     const t0 = performance.now();
     try {
       const cards = buildNecCards(input);
-      const output = await this.runJob(factory, cards, '[nec2]', '[nec2 stderr]', 'nec2c');
+      const output = await this.runJob(factory, cards, 'simulate');
 
       const parsed = parseNecOutput(
         output,
@@ -383,7 +398,7 @@ export class Nec2Engine implements Engine {
         sweepStartFreq: startFreq,
         sweepStep: step,
       });
-      const output = await this.runJob(factory, cards, '[nec2 sweep]', '[nec2 sweep stderr]', 'nec2c sweep');
+      const output = await this.runJob(factory, cards, 'sweep');
       return parseNecImpedanceSweep(output);
     } finally {
       release();

--- a/src/physics/nec2Engine.ts
+++ b/src/physics/nec2Engine.ts
@@ -203,6 +203,33 @@ export class Nec2Engine implements Engine {
     this.logger?.info('[nec2] engine ready');
   }
 
+    private async runJob(factory: EmscriptenFactory, cards: string, logPrefix: string, errPrefix: string, errorName: string): Promise<string> {
+    const stderrLines: string[] = [];
+    const instance = await factory({
+      noInitialRun: true,
+      locateFile: (path: string) => this.resolveAsset(path),
+      print: this.quiet ? () => {} : (s) => this.logger?.info(logPrefix, s),
+      printErr: (s) => {
+        stderrLines.push(s);
+        if (!this.quiet) this.logger?.warn(errPrefix, s);
+      },
+    });
+
+    const inPath = '/input.nec';
+    const outPath = '/output.nout';
+
+    instance.FS.writeFile(inPath, cards);
+
+    const rc = instance.callMain(['-i', inPath, '-o', outPath]);
+    if (rc !== 0) {
+      const tail = stderrLines.slice(-5).join(' | ') || '(no stderr)';
+      throw new Error(`${errorName} exited with status ${rc}. ${tail}`);
+    }
+
+    const outputBytes = instance.FS.readFile(outPath);
+    return new TextDecoder().decode(outputBytes);
+  }
+
   async simulate(input: SimulationInput): Promise<SimulationResult> {
     if (!this.factory) await this.init();
     const factory = this.factory;
@@ -212,31 +239,8 @@ export class Nec2Engine implements Engine {
     const release = await this.acquire();
     const t0 = performance.now();
     try {
-      const stderrLines: string[] = [];
-      const instance = await factory({
-        noInitialRun: true,
-        locateFile: (path: string) => this.resolveAsset(path),
-        print: this.quiet ? () => {} : (s) => this.logger?.info('[nec2]', s),
-        printErr: (s) => {
-          stderrLines.push(s);
-          if (!this.quiet) this.logger?.warn('[nec2 stderr]', s);
-        },
-      });
-
-      const inPath = '/input.nec';
-      const outPath = '/output.nout';
-
       const cards = buildNecCards(input);
-      instance.FS.writeFile(inPath, cards);
-
-      const rc = instance.callMain(['-i', inPath, '-o', outPath]);
-      if (rc !== 0) {
-        const tail = stderrLines.slice(-5).join(' | ') || '(no stderr)';
-        throw new Error(`nec2c exited with status ${rc}. ${tail}`);
-      }
-
-      const outputBytes = instance.FS.readFile(outPath);
-      const output = new TextDecoder().decode(outputBytes);
+      const output = await this.runJob(factory, cards, '[nec2]', '[nec2 stderr]', 'nec2c');
 
       const parsed = parseNecOutput(
         output,
@@ -373,37 +377,13 @@ export class Nec2Engine implements Engine {
 
     const release = await this.acquire();
     try {
-      const stderrLines: string[] = [];
-      const instance = await factory({
-        noInitialRun: true,
-        locateFile: (path: string) => this.resolveAsset(path),
-        print: this.quiet ? () => {} : (s) => this.logger?.info('[nec2 sweep]', s),
-        printErr: (s) => {
-          stderrLines.push(s);
-          if (!this.quiet) this.logger?.warn('[nec2 sweep stderr]', s);
-        },
+      const cards = buildNecCards(input, {
+        includePattern: false,
+        sweepPoints: points,
+        sweepStartFreq: startFreq,
+        sweepStep: step,
       });
-
-      const inPath = '/input.nec';
-      const outPath = '/output.nout';
-      instance.FS.writeFile(
-        inPath,
-        buildNecCards(input, {
-          includePattern: false,
-          sweepPoints: points,
-          sweepStartFreq: startFreq,
-          sweepStep: step,
-        }),
-      );
-
-      const rc = instance.callMain(['-i', inPath, '-o', outPath]);
-      if (rc !== 0) {
-        const tail = stderrLines.slice(-5).join(' | ') || '(no stderr)';
-        throw new Error(`nec2c sweep exited with status ${rc}. ${tail}`);
-      }
-
-      const outputBytes = instance.FS.readFile(outPath);
-      const output = new TextDecoder().decode(outputBytes);
+      const output = await this.runJob(factory, cards, '[nec2 sweep]', '[nec2 sweep stderr]', 'nec2c sweep');
       return parseNecImpedanceSweep(output);
     } finally {
       release();


### PR DESCRIPTION
🎯 **What:** Extracted duplicated Wasm execution, filesystem I/O, and status checking logic from `simulate` and `solveImpedanceSweep` into a single reusable private method `runJob`.
💡 **Why:** Reduces duplicate boilerplate in the `Nec2Engine` class, making both `simulate` and `solveImpedanceSweep` much shorter, easier to read, and less prone to divergence when modifying Wasm instantiation or filesystem logic.
✅ **Verification:** Verified by checking `tests/nec2Engine.integration.test.ts`, `tests/nec2Engine.sweep.test.ts`, and full `npm run test` suite. The refactoring preserves all arguments, standard/error log streams, filesystem paths (`/input.nec`, `/output.nout`), and exit status checks correctly.
✨ **Result:** Cleaned up ~40 lines of duplicated execution setup logic, improving maintainability of the `Nec2Engine`.

---
*PR created automatically by Jules for task [15404857694164053152](https://jules.google.com/task/15404857694164053152) started by @2fst4u*