### PR TITLE
🧹 Refactor deeply nested conditionals in adaptiveSweep

### DIFF
--- a/src/physics/sweep.ts
+++ b/src/physics/sweep.ts
@@ -45,6 +45,42 @@ export async function runScan(
   return sweep;
 }
 
+function resolveMergedBands(
+  merged: ReturnType<typeof findSwrBands> | null,
+  primaryBands: ReturnType<typeof findSwrBands>,
+  frameWindow: (bands: ReturnType<typeof findSwrBands>) => { start: number; end: number },
+  points: number,
+  operatingBandWidth: number,
+): ReturnType<typeof findSwrBands> {
+  if (merged === null) {
+    return primaryBands;
+  }
+
+  merged.sort((a, b) => a.fLow - b.fLow);
+
+  if (primaryBands.length === 0) {
+    // No operating-frequency band to protect — show whatever band exists.
+    return merged;
+  }
+
+  // Resolve-aware merge: only widen the window to include a distant band
+  // (e.g. a harmonic resonance of a narrowband dipole) if the operating
+  // band stays adequately sampled at the final point count. Otherwise
+  // the operating band falls between samples — its dip vanishes from the
+  // chart and the marker reads an off-resonance SWR — so we keep the
+  // window focused on the operating band instead.
+  const MIN_OPERATING_BAND_SAMPLES = 4;
+  const { start, end } = frameWindow(merged);
+  const spacing = points > 1 ? (end - start) / (points - 1) : end - start;
+  const samplesInOperatingBand = spacing > 0 ? operatingBandWidth / spacing : Infinity;
+
+  if (samplesInOperatingBand >= MIN_OPERATING_BAND_SAMPLES) {
+    return merged;
+  }
+
+  return primaryBands;
+}
+
 /**
  * Adaptive sweep: expands a coarse characterisation window until the
  * (display-effective) SWR rises above 2:1 on both sides of the minimum or
@@ -210,27 +246,7 @@ export async function adaptiveSweep(
       merged.push(b);
     }
 
-    if (merged !== null) {
-      merged.sort((a, b) => a.fLow - b.fLow);
-      if (primaryBands.length === 0) {
-        // No operating-frequency band to protect — show whatever band exists.
-        allBands = merged;
-      } else {
-        // Resolve-aware merge: only widen the window to include a distant band
-        // (e.g. a harmonic resonance of a narrowband dipole) if the operating
-        // band stays adequately sampled at the final point count. Otherwise
-        // the operating band falls between samples — its dip vanishes from the
-        // chart and the marker reads an off-resonance SWR — so we keep the
-        // window focused on the operating band instead.
-        const MIN_OPERATING_BAND_SAMPLES = 4;
-        const { start, end } = frameWindow(merged);
-        const spacing = points > 1 ? (end - start) / (points - 1) : end - start;
-        const samplesInOperatingBand = spacing > 0 ? operatingBandWidth / spacing : Infinity;
-        if (samplesInOperatingBand >= MIN_OPERATING_BAND_SAMPLES) {
-          allBands = merged;
-        }
-      }
-    }
+    allBands = resolveMergedBands(merged, primaryBands, frameWindow, points, operatingBandWidth);
   }
 
   const { start: winStart, end: winEnd } = frameWindow(allBands);


### PR DESCRIPTION
🎯 **What:** The code health issue addressed is a deeply nested set of conditionals within `adaptiveSweep` (in `src/physics/sweep.ts:224`) that handled the resolution of merging primary and broad scan bands.

💡 **Why:** This improves readability and maintainability by moving the logic into a dedicated helper function (`resolveMergedBands`) which can use early returns, flattening out the logic flow and avoiding deep `if-else` blocks in the main method.

✅ **Verification:** I confirmed this change is safe by verifying no new type dependencies were required, strict typescript inference was preserved via `ReturnType<typeof findSwrBands>`, linting passes successfully, and the full test suite remains green and exceeds coverage thresholds (`npm run test -- --run --coverage` passed with 848 tests).

✨ **Result:** The complex band merging logic has been isolated and flattened into an easy-to-read, decoupled helper function, improving the maintainability of the core `adaptiveSweep` algorithm.

---
*PR created automatically by Jules for task [3292672172458446352](https://jules.google.com/task/3292672172458446352) started by @2fst4u*