### PR TITLE
🧹 Refactor deeply nested loop using early continue

### DIFF
--- a/src/physics/sweep.ts
+++ b/src/physics/sweep.ts
@@ -194,15 +194,16 @@ export async function adaptiveSweep(
     let merged: typeof primaryBands | null = null;
     for (let i = 0; i < broadBands.length; i++) {
       const b = broadBands[i];
-      if (b.fHigh < loEdge - 0.5 || b.fLow > hiEdge + 0.5) {
-        if (merged === null) {
-          merged = [];
-          for (let j = 0; j < primaryBands.length; j++) {
-            merged.push(primaryBands[j]);
-          }
-        }
-        merged.push(b);
+      if (b.fHigh >= loEdge - 0.5 && b.fLow <= hiEdge + 0.5) {
+        continue;
       }
+      if (merged === null) {
+        merged = [];
+        for (let j = 0; j < primaryBands.length; j++) {
+          merged.push(primaryBands[j]);
+        }
+      }
+      merged.push(b);
     }
 
     if (merged !== null) {


### PR DESCRIPTION
🎯 **What:** Refactored a deeply nested conditional in the `broadBands` loop within `src/physics/sweep.ts` by replacing the `if` block with an early `continue` statement and negating the original condition using De Morgan's laws.

💡 **Why:** Reduces nesting, significantly improving readability and reducing cognitive load while preserving existing functionality and performance optimizations like lazy array initialization. 

✅ **Verification:** Ran `npm run test -- --run --coverage`. All 848 tests passed and code coverage thresholds were strictly maintained without any drops.

✨ **Result:** Cleaner, more maintainable code structure inside a dense mathematical loop.

---
*PR created automatically by Jules for task [5601851641964837305](https://jules.google.com/task/5601851641964837305) started by @2fst4u*