### PR TITLE
🧹 refactor: extract onChange handler in FrequencyControl

### DIFF
--- a/src/components/Panel/FrequencyControl.tsx
+++ b/src/components/Panel/FrequencyControl.tsx
@@ -33,6 +33,14 @@ export function FrequencyControl() {
     }
   }
 
+  const handleFrequencyChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const s = e.target.value;
+    setLocalVal(s);
+    const val = parseFloat(s);
+    if (isNaN(val)) return;
+    setFrequency(val);
+  };
+
   return (
     <section className="panel-section">
       {/* SEO: Use sequential heading tags (H2) to follow document outline initiated by H1 */}
@@ -51,14 +59,7 @@ export function FrequencyControl() {
           value={localVal}
           aria-label="Frequency in MHz"
           onFocus={() => setIsFocused(true)}
-          onChange={(e) => {
-            const s = e.target.value;
-            setLocalVal(s);
-            const val = parseFloat(s);
-            if (!isNaN(val)) {
-              setFrequency(val);
-            }
-          }}
+          onChange={handleFrequencyChange}
           onBlur={() => {
             setIsFocused(false);
             // On blur, ensure the local value matches the (possibly clamped) store value.


### PR DESCRIPTION
🎯 **What:** Extracted the inline `onChange` handler inside `FrequencyControl.tsx` into a named function `handleFrequencyChange` and replaced the nested conditional check with an early return (`if (isNaN(val)) return;`).

💡 **Why:** This improves maintainability and readability by avoiding a deeply nested conditional inside the component's JSX layout, extracting the event handling logic into a clear, focused function block.

✅ **Verification:** Verified that lint checks pass, all tests in the suite pass (`npm run test -- --run --coverage`), and `FrequencyControl.test.tsx` accurately executes. The code review confirmed the behavior is perfectly preserved.

✨ **Result:** The `FrequencyControl` component is cleaner and less deeply nested, directly addressing the targeted code health issue.

---
*PR created automatically by Jules for task [12637480270348359683](https://jules.google.com/task/12637480270348359683) started by @2fst4u*