### PR TITLE
🧹 Simplify nested conditional inside predictPropagation loop

### DIFF
--- a/src/physics/propagation.ts
+++ b/src/physics/propagation.ts
@@ -425,23 +425,16 @@ export function predictPropagation(input: PropagationInputs): PropagationPredict
         const linkQuality = classifyLinkQuality(effectiveGainDbi);
         const qRank = qualityRank(linkQuality);
 
-        if (bestTi === -1) {
-          bestTi = ti;
-          bestEffectiveGainDbi = effectiveGainDbi;
-          bestQualityRank = qRank;
-          bestLinkQuality = linkQuality;
-          continue;
-        }
-
-        const bestBase = baseRays[bestTi]!;
+        const bestBase = bestTi !== -1 ? baseRays[bestTi]! : null;
         if (
+          bestTi === -1 ||
           isBetterRay(
             baseRay.statusRankValue,
-            bestBase.statusRankValue,
+            bestBase!.statusRankValue,
             qRank,
             bestQualityRank,
             baseRay.rangeKm,
-            bestBase.rangeKm
+            bestBase!.rangeKm
           )
         ) {
           bestTi = ti;


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was a deeply nested conditional block in `predictPropagation` within `src/physics/propagation.ts` where duplicated logic existed for assigning the "best" tracking variables in a loop.
💡 **Why:** Refactoring the initialization state (`bestTi === -1`) into the main `isBetterRay` conditional using short-circuiting removes the need to duplicate the assignment block (`bestTi = ti; bestEffectiveGainDbi = effectiveGainDbi; ...`), thus improving maintainability and reducing nesting depth.
✅ **Verification:** I successfully ran the complete test suite via `npm run test -- --run` and ensured all tests, including those specifically targeting the physics engine and propagation logic, continue to pass. The refactor guarantees identical runtime state because of short-circuiting.
✨ **Result:** The duplicated assignment block is completely removed and nesting depth is improved without altering behavior or introducing the risk of null reference exceptions.

---
*PR created automatically by Jules for task [1127161485914696351](https://jules.google.com/task/1127161485914696351) started by @2fst4u*