### PR TITLE
🧹 Refactor: Flatten nested conditionals in GeometryControl

### DIFF
--- a/src/components/Panel/GeometryControl.tsx
+++ b/src/components/Panel/GeometryControl.tsx
@@ -104,9 +104,8 @@ function LengthControl() {
             const s = e.target.value;
             setLocalLen(s);
             const val = parseFloat(s);
-            if (!isNaN(val)) {
-              setLength(fromDisplayLength(val, units));
-            }
+            if (isNaN(val)) return;
+            setLength(fromDisplayLength(val, units));
           }}
           onBlur={() => {
             setIsFocused(false);
@@ -212,7 +211,8 @@ function TerminationControl() {
             const s = e.target.value;
             setLocalResistor(s);
             const val = parseFloat(s);
-            if (!isNaN(val)) setTerminatingResistor(val);
+            if (isNaN(val)) return;
+            setTerminatingResistor(val);
           }}
           onBlur={() => {
             setIsResistorFocused(false);
@@ -313,9 +313,8 @@ function OrientationControl() {
             const s = e.target.value;
             setLocalOrient(s);
             const val = parseFloat(s);
-            if (!isNaN(val)) {
-              setOrientation(val);
-            }
+            if (isNaN(val)) return;
+            setOrientation(val);
           }}
           onBlur={() => {
             setIsOrientFocused(false);
@@ -409,7 +408,8 @@ function HeightControl() {
         aria-valuetext={`${dispHeight.toFixed(1)} ${unit}`}
         onChange={(e) => {
           const val = parseFloat(e.target.value);
-          if (!isNaN(val)) setHeight(fromDisplayLength(val, units));
+          if (isNaN(val)) return;
+          setHeight(fromDisplayLength(val, units));
         }}
       />
     </>
@@ -441,7 +441,8 @@ function VAngleControl() {
         aria-valuetext={`${vAngle}°`}
         onChange={(e) => {
           const val = parseFloat(e.target.value);
-          if (!isNaN(val)) setVAngle(val);
+          if (isNaN(val)) return;
+          setVAngle(val);
         }}
       />
     </>
@@ -484,7 +485,8 @@ function ApertureControl() {
         aria-describedby="folded-dipole-aperture-hint"
         onChange={(e) => {
           const val = parseFloat(e.target.value);
-          if (!isNaN(val)) setFoldedDipoleAperture(fromDisplayLength(val, units));
+          if (isNaN(val)) return;
+          setFoldedDipoleAperture(fromDisplayLength(val, units));
         }}
       />
       <div id="folded-dipole-aperture-hint" aria-live="polite" style={{ marginTop: 6, fontSize: 11, color: 'var(--text-muted)', lineHeight: 1.4 }}>


### PR DESCRIPTION
🎯 **What:** Refactored six occurrences of nested conditionals (`if (!isNaN(val)) { ... }`) in `src/components/Panel/GeometryControl.tsx` to use an early return pattern (`if (isNaN(val)) return;`).

💡 **Why:** By extracting the state update logic out of nested conditional blocks, it flattens the file's block structure. This significantly improves readability and code maintainability by keeping the happy path flat and reducing indentation.

✅ **Verification:** Verified the code using `cat` and `grep` commands to confirm the `if (isNaN(val)) return;` logic is correctly applied without altering any actual application functionality. Re-ran the test suite with `npm run test -- --run` successfully.

✨ **Result:** Improved code cleanliness and standardisation across the numeric input handlers for Antenna dimensions within `GeometryControl`.

---
*PR created automatically by Jules for task [9844508948884990411](https://jules.google.com/task/9844508948884990411) started by @2fst4u*