### PR TITLE
🧹 Refactor nested conditionals to early returns in GroundControl

### DIFF
--- a/src/components/Panel/GroundControl.tsx
+++ b/src/components/Panel/GroundControl.tsx
@@ -83,9 +83,8 @@ export function GroundControl() {
               const s = e.target.value;
               setLocalSigma(s);
               const val = parseFloat(s);
-              if (!isNaN(val)) {
-                setCustomGround(val, epsilon);
-              }
+              if (isNaN(val)) return;
+              setCustomGround(val, epsilon);
             }}
             onBlur={() => {
               setIsSigmaFocused(false);
@@ -104,9 +103,8 @@ export function GroundControl() {
               const s = e.target.value;
               setLocalEpsilon(s);
               const val = parseFloat(s);
-              if (!isNaN(val)) {
-                setCustomGround(sigma, val);
-              }
+              if (isNaN(val)) return;
+              setCustomGround(sigma, val);
             }}
             onBlur={() => {
               setIsEpsilonFocused(false);


### PR DESCRIPTION
🎯 **What:** The `onChange` handler for custom ground parameters (both `custom-ground-sigma` and `custom-ground-epsilon`) in `GroundControl.tsx` had deeply nested conditionals (`if (!isNaN(val)) { setCustomGround(...) }`). This was refactored to use an early return (`if (isNaN(val)) return; setCustomGround(...)`).

💡 **Why:** Flattening deeply nested logic inside callbacks improves readability and makes the execution path much clearer, contributing directly to better codebase maintainability.

✅ **Verification:** Ran `npm run test -- --run --coverage` which executed the full test suite successfully, proving no functionality was broken. Also viewed the file to ensure changes were correctly applied.

✨ **Result:** A cleaner component file with reduced visual noise and simplified event handlers.

---
*PR created automatically by Jules for task [7319365698620364531](https://jules.google.com/task/7319365698620364531) started by @2fst4u*