### PR TITLE
🧹 [code health improvement] Refactor GeometryStatus to separate components

### DIFF
--- a/src/components/Panel/GeometryStatus.tsx
+++ b/src/components/Panel/GeometryStatus.tsx
@@ -1,59 +1,41 @@
 import { useShallow } from 'zustand/react/shallow';
 import { useAntennaStore } from '../../store/antennaStore';
-import { displayLengthUnit, toDisplayLength } from '../../physics/units';
+import { type UnitSystem, displayLengthUnit, toDisplayLength } from '../../physics/units';
 import { FEED_BRIDGE_LENGTH_M, SLOPING_V_MIN_TIP_Z_M } from '../../physics/constants';
 
-export function GeometryStatus() {
-  const {
-    antennaType,
-    length,
-    height,
-    vAngle,
-    units,
-  } = useAntennaStore(useShallow((s) => ({
-    antennaType: s.antennaType,
-    length: s.length,
-    height: s.height,
-    vAngle: s.vAngle,
-    units: s.units,
-  })));
+function SlopingVStatus({ length, height, units, unit }: { length: number; height: number; units: UnitSystem; unit: string }) {
+  // Sloping V: tips always at the ground floor; slope is fully determined
+  // by mast height and leg length.
+  const legLen = Math.max(0.01, (length - FEED_BRIDGE_LENGTH_M) / 2);
+  const sinSlope = Math.max(0, height - SLOPING_V_MIN_TIP_Z_M) / legLen;
+  const slopeRad = Math.asin(Math.max(0, Math.min(1, sinSlope)));
+  const slopeDeg = (slopeRad * 180) / Math.PI;
+  const tipZ = height - legLen * Math.sin(slopeRad);
 
-  if (antennaType !== 'sloping-v' && antennaType !== 'inverted-v') return null;
+  return (
+    <section aria-labelledby="geometry-heading" style={{
+      marginTop: 12,
+      padding: '8px 10px',
+      fontSize: 12,
+      borderRadius: 4,
+      background: 'var(--bg-accent)',
+      border: '1px solid var(--border)',
+    }}>
+      <h3 id="geometry-heading" style={{ fontSize: 'inherit', margin: 0, fontWeight: 600, marginBottom: 4 }}>Geometry</h3>
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '4px 12px' }}>
+        <span style={{ color: 'var(--text-muted)' }}>Slope angle:</span>
+        <span>{slopeDeg.toFixed(1)}°</span>
+        <span style={{ color: 'var(--text-muted)' }}>Tip height:</span>
+        <span>{toDisplayLength(tipZ, units).toFixed(2)} {unit}</span>
+      </div>
+      <div style={{ marginTop: 6, fontSize: 11, fontStyle: 'italic', lineHeight: 1.3, color: 'var(--text-muted)' }}>
+        Slope auto-snaps so tips sit at the ground floor for the current mast height and leg length.
+      </div>
+    </section>
+  );
+}
 
-  const unit = displayLengthUnit(units);
-
-  if (antennaType === 'sloping-v') {
-    // Sloping V: tips always at the ground floor; slope is fully determined
-    // by mast height and leg length.
-    const legLen = Math.max(0.01, (length - FEED_BRIDGE_LENGTH_M) / 2);
-    const sinSlope = Math.max(0, height - SLOPING_V_MIN_TIP_Z_M) / legLen;
-    const slopeRad = Math.asin(Math.max(0, Math.min(1, sinSlope)));
-    const slopeDeg = (slopeRad * 180) / Math.PI;
-    const tipZ = height - legLen * Math.sin(slopeRad);
-
-    return (
-      <section aria-labelledby="geometry-heading" style={{
-        marginTop: 12,
-        padding: '8px 10px',
-        fontSize: 12,
-        borderRadius: 4,
-        background: 'var(--bg-accent)',
-        border: '1px solid var(--border)',
-      }}>
-        <h3 id="geometry-heading" style={{ fontSize: 'inherit', margin: 0, fontWeight: 600, marginBottom: 4 }}>Geometry</h3>
-        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '4px 12px' }}>
-          <span style={{ color: 'var(--text-muted)' }}>Slope angle:</span>
-          <span>{slopeDeg.toFixed(1)}°</span>
-          <span style={{ color: 'var(--text-muted)' }}>Tip height:</span>
-          <span>{toDisplayLength(tipZ, units).toFixed(2)} {unit}</span>
-        </div>
-        <div style={{ marginTop: 6, fontSize: 11, fontStyle: 'italic', lineHeight: 1.3, color: 'var(--text-muted)' }}>
-          Slope auto-snaps so tips sit at the ground floor for the current mast height and leg length.
-        </div>
-      </section>
-    );
-  }
-
+function InvertedVStatus({ length, height, vAngle, units, unit }: { length: number; height: number; vAngle: number; units: UnitSystem; unit: string }) {
   // Inverted V: the per-leg slope is derived from the V opening angle and may
   // be clamped by mast height. Surface everything in terms of the opening angle
   // so it lines up with the "V opening angle" control the user adjusts.
@@ -111,4 +93,30 @@ export function GeometryStatus() {
       )}
     </section>
   );
+}
+
+export function GeometryStatus() {
+  const {
+    antennaType,
+    length,
+    height,
+    vAngle,
+    units,
+  } = useAntennaStore(useShallow((s) => ({
+    antennaType: s.antennaType,
+    length: s.length,
+    height: s.height,
+    vAngle: s.vAngle,
+    units: s.units,
+  })));
+
+  if (antennaType !== 'sloping-v' && antennaType !== 'inverted-v') return null;
+
+  const unit = displayLengthUnit(units);
+
+  if (antennaType === 'sloping-v') {
+    return <SlopingVStatus length={length} height={height} units={units} unit={unit} />;
+  }
+
+  return <InvertedVStatus length={length} height={height} vAngle={vAngle} units={units} unit={unit} />;
 }


### PR DESCRIPTION
🎯 What: Refactored the `GeometryStatus` component in `src/components/Panel/GeometryStatus.tsx` by extracting the rendering logic for 'Sloping V' and 'Inverted V' antenna types into separate sub-components.

💡 Why: The main `GeometryStatus` function was becoming overly long and mixing the logic for fetching state with the specific rendering logic of different antenna types. Extracting these into `SlopingVStatus` and `InvertedVStatus` improves maintainability, readability, and separation of concerns.

✅ Verification: 
- Ran `npm run lint` with no errors.
- Ran full test suite (`npm run test -- --run --coverage`) successfully. All 848 tests pass and test coverage remains within thresholds.
- Received positive code review feedback confirming safe and effective extraction.

✨ Result: A much cleaner, flatter `GeometryStatus` component that acts as a container, delegating complex rendering logic to clearly defined sub-components.

---
*PR created automatically by Jules for task [925005086001850035](https://jules.google.com/task/925005086001850035) started by @2fst4u*