### PR TITLE
test: make coverage thresholds floors instead of exact pins

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,11 +8,16 @@ export default defineConfig({
     setupFiles: ['./vitest.setup.ts'],
     coverage: {
       provider: 'v8',
+      // Floors, not high-water marks. Keep these as round numbers a little
+      // below actual coverage: pinning them to the exact current percentage
+      // makes every refactor that shifts a line count fail the build and
+      // forces unrelated edits to this file. Raise a floor deliberately when
+      // coverage has moved up for good, not reflexively in each PR.
       thresholds: {
-        statements: 72.79,
-        branches: 64.77,
-        functions: 77.93,
-        lines: 94.81,
+        statements: 72,
+        branches: 64,
+        functions: 77,
+        lines: 94,
       }
     }
   },


### PR DESCRIPTION
## What

Change the vitest coverage thresholds from exact pins to round floors, and document why.

```
statements: 72.79 → 72
branches:   64.77 → 64
functions:  77.93 → 77
lines:      94.81 → 94
```

## Why

The old values were pinned to the *exact* current coverage percentage, so any change that shifted a line or statement count by one failed `npm run test`. That turned `vitest.config.ts` into a mandatory edit for unrelated refactors — and a conflict point between them.

Of the 25 PRs open against `main` right now, 11 touch this file, each nudging the same four numbers to a different value. None of those edits carry information; they are all just re-pinning to whatever the number happened to become. Any two of them conflict on merge.

Floors set a little below actual coverage still fail on a real regression (dropping a test file, deleting assertions) while letting a refactor that moves a few lines through untouched.

## Verification

`npx vitest run --coverage` passes: statements 72.79%, branches 64.77%, functions 77.93%, lines 94.81% — all comfortably above the new floors.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqC6prCLj2afKkAL7Bq4jz)_