### PR TITLE
refactor: flatten the remaining isNaN guards in numeric input handlers

### DIFF
--- a/src/components/Panel/Feedline/DipoleOffsetControl.tsx
+++ b/src/components/Panel/Feedline/DipoleOffsetControl.tsx
@@ -40,7 +40,8 @@ export function DipoleOffsetControl({
           aria-describedby="feedline-offset-hint"
           onChange={(e) => {
             const val = parseFloat(e.target.value);
-            if (!isNaN(val)) setFeedlineOffset(fromDisplayLength(val, units));
+            if (isNaN(val)) return;
+            setFeedlineOffset(fromDisplayLength(val, units));
           }}
         />
         <button

--- a/src/components/Panel/Feedline/SyncedLengthInput.tsx
+++ b/src/components/Panel/Feedline/SyncedLengthInput.tsx
@@ -55,9 +55,8 @@ export function SyncedLengthInput({
           const s = e.target.value;
           setLocalVal(s);
           const val = parseFloat(s);
-          if (!isNaN(val)) {
-            onChange(fromDisplayLength(val, units));
-          }
+          if (isNaN(val)) return;
+          onChange(fromDisplayLength(val, units));
         }}
         onBlur={() => {
           setIsFocused(false);

--- a/src/components/Panel/Propagation/PropagationInputs.tsx
+++ b/src/components/Panel/Propagation/PropagationInputs.tsx
@@ -98,7 +98,8 @@ function TIndexInput() {
             const s = e.target.value;
             setLocalTIndex(s);
             const v = parseFloat(s);
-            if (!isNaN(v)) setTIndex(v);
+            if (isNaN(v)) return;
+            setTIndex(v);
           }}
           onBlur={() => {
             setIsTIndexFocused(false);


### PR DESCRIPTION
## What

Applies the `if (isNaN(val)) return;` shape to the last three numeric `onChange` handlers still using `if (!isNaN(val)) { ... }`:

- `Panel/Propagation/PropagationInputs.tsx` — T-index
- `Panel/Feedline/SyncedLengthInput.tsx`
- `Panel/Feedline/DipoleOffsetControl.tsx`

## Why

This pattern was being cleaned up one file per pull request — #560 (FrequencyControl), #567 (six handlers in GeometryControl), #569 (two in GroundControl), plus #563 and #568 which duplicated those. Three call sites were left over, which is three more PRs' worth of the same change.

`grep -rn "if (!isNaN" src/` now returns nothing, so the convention is uniform and there's nothing left for a follow-up to find.

Behaviour is unchanged in all three: the guard rejects exactly the same inputs, it just returns early instead of nesting the body.

## Verification

- `npx tsc --noEmit -p tsconfig.app.json` — clean
- `npm run lint` — clean
- `npm run test` — 885 passed, 74 files

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqC6prCLj2afKkAL7Bq4jz)_