### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix missing origin validation in physics worker

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -30,3 +30,7 @@
 **Vulnerability:** Similar to UI exception handling, the raw solver error output from the worker (`error` string passed from `nec2c` engine) was exposed directly to the end user in the `LiveAntennaScene` component within `src/App.tsx`. This could leak stderr output from the WASM engine, potentially exposing internal compilation artifacts or paths.
 **Learning:** Any dynamic string originating from an underlying system process, shell, or solver engine should be considered untrusted for user-display purposes in production. Even if it's "just" an engine error, it should fail securely to avoid information leakage.
 **Prevention:** Extend the pattern of checking `import.meta.env.DEV` to all error messages rendered in the DOM, including those mapped from application state (like `error` from a Zustand store), replacing them with generic fallback messages in production.
+## 2025-02-14 - Web Worker Message Origin Validation
+**Vulnerability:** The physics worker accepted messages from any origin. If the worker was unintentionally or maliciously exposed or if messages were somehow relayed cross-origin, an attacker could potentially execute simulated workloads or cause denial of service.
+**Learning:** Web Workers should validate the `origin` of incoming `message` events, especially if they handle complex logic or perform intensive computations.
+**Prevention:** Implement an origin check in the worker's `message` event listener (`if (ev.origin && ev.origin !== '' && ev.origin !== self.location.origin) return;`) to ensure only same-origin messages are processed.

--- a/src/workers/physicsWorker.ts
+++ b/src/workers/physicsWorker.ts
@@ -91,6 +91,11 @@ engine
   });
 
 ctx.addEventListener('message', (ev: MessageEvent<WorkerRequest>) => {
+  // Security: drop cross-origin messages
+  if (ev.origin && ev.origin !== '' && ev.origin !== self.location.origin) {
+    console.warn('[worker] dropping cross-origin message from', ev.origin);
+    return;
+  }
   const msg = ev.data;
   if (msg.type === 'simulate') {
     const feedpointInput = msg.feedpointInput;

--- a/tests/physicsWorker.test.ts
+++ b/tests/physicsWorker.test.ts
@@ -218,4 +218,33 @@ describe('physicsWorker error path test', () => {
       message: 'String Error'
     });
   });
+
+  it('ignores messages from unauthorized origins', async () => {
+    mockEngineInstance.init.mockResolvedValue(undefined);
+
+    let messageHandler: (msg: any) => void; // eslint-disable-line @typescript-eslint/no-explicit-any
+    addEventListenerSpy.mockImplementation((type, handler) => {
+      if (type === 'message') messageHandler = handler;
+    });
+
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await import('../src/workers/physicsWorker');
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    postMessageSpy.mockClear();
+
+    messageHandler({
+      origin: 'https://evil.com',
+      data: { id: 126, type: 'simulate', input: { frequency: 14 } }
+    });
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(consoleWarnSpy).toHaveBeenCalledWith('[worker] dropping cross-origin message from', 'https://evil.com');
+    expect(mockEngineInstance.simulate).not.toHaveBeenCalled();
+    expect(postMessageSpy).not.toHaveBeenCalled();
+
+    consoleWarnSpy.mockRestore();
+  });
 });


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The dedicated physics Web Worker accepted `postMessage` events indiscriminately from any origin. If the worker reference was leaked or framed contextually, an attacker could potentially invoke intensive calculations or cause a denial-of-service condition within the client.
🎯 Impact: An attacker could potentially abuse worker processing power or inject malicious data points leading to application instability or compute starvation.
🔧 Fix: Implemented an explicit cross-origin validation check in `src/workers/physicsWorker.ts`. The worker will now check the `origin` property of incoming `MessageEvent`s and drop any requests not matching `self.location.origin`. Since some environments leave `.origin` empty for Web Workers, the check gracefully permits empty origins but explicitly blocks known cross-origin requests.
✅ Verification: Added a dedicated Vitest coverage block inside `tests/physicsWorker.test.ts` to mock and verify that cross-origin messages correctly trigger a console warning and are dropped safely without invoking the solver engine. Tests pass at 100%.

---
*PR created automatically by Jules for task [6844473920446666526](https://jules.google.com/task/6844473920446666526) started by @2fst4u*