### PR TITLE
🎨 Palette: Add animated chevron to disclosure widget

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -20,3 +20,7 @@
 ## 2026-07-24 - Added aria-controls to Ground Settings toggle
 **Learning:** When using `aria-expanded` on a toggle button to reveal conditionally rendered React content, ensure the target content is wrapped in a container element with an explicit ID, and link the button via `aria-controls` to maintain strict accessibility semantics.
 **Action:** Always check that toggle buttons with `aria-expanded` also have a matching `aria-controls` attribute, and refactor React fragments to `div`s if an ID anchor is missing.
+
+## 2025-02-26 - Add animated chevron to disclosure widget
+**Learning:** Disclosure widgets (like the "Model & assumptions" button) benefit greatly from a visual indicator showing their state. An animated chevron provides clear visual affordance and smooth feedback, improving discoverability and making it obvious that the component is an accordion/disclosure.
+**Action:** Use inline SVG chevrons with `transform: rotate()` transitions tied to `aria-expanded` state on disclosure buttons.

--- a/src/components/Panel/Propagation/ConditionsReadout.tsx
+++ b/src/components/Panel/Propagation/ConditionsReadout.tsx
@@ -103,8 +103,21 @@ export function ConditionsReadout({ prediction, haveTakeoff, units }: Conditions
         style={{
           marginTop: 10, background: 'transparent', border: 'none',
           color: 'var(--accent)', padding: 0, fontSize: 11, cursor: 'pointer',
+          display: 'inline-flex', alignItems: 'center', gap: 4,
         }}
       >
+        <svg
+          width="10" height="10" viewBox="0 0 24 24"
+          fill="none" stroke="currentColor" strokeWidth="3"
+          strokeLinecap="round" strokeLinejoin="round"
+          style={{
+            transform: showAssumptions ? 'rotate(90deg)' : 'rotate(0deg)',
+            transition: 'transform 0.2s ease-in-out'
+          }}
+          aria-hidden="true"
+        >
+          <path d="M9 18l6-6-6-6" />
+        </svg>
         {showAssumptions ? 'Hide model assumptions' : 'Model & assumptions'}
       </button>
       {showAssumptions && (


### PR DESCRIPTION
💡 What: Added an animated inline SVG chevron to the "Model & assumptions" disclosure button in the Propagation section.
🎯 Why: Disclosure widgets without a visual state indicator can be difficult to discover as expandable. Adding an animated chevron provides a clear visual affordance and smooth feedback for the toggle state.
📸 Before/After: Verified visually via screenshot using playwright. The chevron renders alongside the text and rotates when expanded.
♿ Accessibility: The SVG is marked with `aria-hidden="true"` so it doesn't pollute screen reader output, and the layout styling is done via safe flexbox rules. The existing `aria-expanded` implementation remains intact.

---
*PR created automatically by Jules for task [1750491994135860631](https://jules.google.com/task/1750491994135860631) started by @2fst4u*