### PR TITLE
🎨 Palette: Add visual indicator to Custom Ground disclosure button

### DIFF
--- a/src/components/Panel/GroundControl.tsx
+++ b/src/components/Panel/GroundControl.tsx
@@ -50,13 +50,28 @@ export function GroundControl() {
       <h2>
         <label htmlFor="ground-preset" style={{ display: 'inline-block' }}>Ground</label>
         <button
-          style={{ padding: '2px 8px', fontSize: 11, marginLeft: 8 }}
+          style={{
+            padding: '2px 8px', fontSize: 11, marginLeft: 8,
+            display: 'inline-flex', alignItems: 'center', gap: 4
+          }}
           onClick={() => setExpanded((v) => !v)}
           aria-expanded={expanded}
           aria-controls="custom-ground-settings"
           aria-label={expanded ? 'Simple: Hide custom ground settings' : 'Custom: Show custom ground settings'}
           title={expanded ? 'Hide custom settings' : 'Show custom settings'}
         >
+          <svg
+            width="10" height="10" viewBox="0 0 24 24"
+            fill="none" stroke="currentColor" strokeWidth="3"
+            strokeLinecap="round" strokeLinejoin="round"
+            style={{
+              transform: expanded ? 'rotate(90deg)' : 'rotate(0deg)',
+              transition: 'transform 0.2s ease-in-out'
+            }}
+            aria-hidden="true"
+          >
+            <path d="M9 18l6-6-6-6" />
+          </svg>
           {expanded ? 'Simple' : 'Custom'}
         </button>
       </h2>


### PR DESCRIPTION
💡 **What:** Added an inline SVG chevron to the "Custom Ground" disclosure button that animates (rotates 90 degrees) when expanded.
🎯 **Why:** Disclosure widgets (like accordions) benefit greatly from a clear visual indicator showing their expandable nature. It provides immediate affordance to the user.
📸 **Before/After:** The button previously only had text. Now it has a chevron that aligns with the existing pattern used in the Propagation readout.
♿ **Accessibility:** Maintained `aria-hidden="true"` on the SVG so it is ignored by screen readers, while preserving the existing semantic `aria-expanded` and `aria-controls` attributes on the button.

---
*PR created automatically by Jules for task [2944318994975678956](https://jules.google.com/task/2944318994975678956) started by @2fst4u*