### PR TITLE
📚 Archivist: Fix Folded Dipole feedline support documentation drift

### DIFF
--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -143,3 +143,6 @@
 ## 2025-03-02 - [Markdown Drift from Code Cleanup]
 **Learning:** Static analysis tools (like Knip) only search source code. When developers rename or consolidate duplicate exported constants (e.g., `TERMINATED_DELTA_CENTRE_GAP_M` to `FEED_BRIDGE_LENGTH_M`), Markdown documentation goes out of sync because these tools don't flag string occurrences in `docs/`.
 **Action:** When performing or verifying codebase cleanups (especially removing/renaming variables), always run a global search (e.g., `grep -r "VARIABLE_NAME" .`) to ensure technical documentation is updated alongside the codebase.
+## 2026-08-01 - Folded Dipole Feedline Support Documentation Drift
+**Learning:** The `docs/antenna-spec.md` falsely claimed that feedline support was "Not currently modelled" for the Folded Dipole. However, the codebase (`src/store/antennaStore.ts`) explicitly includes `folded-dipole` in `FEEDLINE_SUPPORTED_TYPES`, and the geometry engine fully generates the feedline shield layout for it just like standard dipoles. The documentation drifted from the implemented physics model.
+**Action:** The documentation in `docs/antenna-spec.md` was updated for the Folded Dipole to remove the false claim and explicitly clarify that feedline support is implemented using the standard radiating shield and NEC TL card at the centre bridge.

--- a/docs/antenna-spec.md
+++ b/docs/antenna-spec.md
@@ -399,7 +399,7 @@ Every type below uses the coordinate conventions of Part I §1 and the glossary 
 
 - **NEC Excitation:** Segment 1 of `FEED_BRIDGE_TAG` (3) at the centre of the lower conductor — handled by the existing `hasBridge` excitation path.
 - **Feed Type:** Single-segment voltage source on the bridge; balanced.
-- **Feedline Support:** Not currently modelled (the antenna is balanced and typically fed via 300 Ω twin-lead or a 4:1 balun). The transformer/balun post-processing control is available.
+- **Feedline Support:** Supported (Radiating shield + NEC `TL` card; feedpoint always at the centre bridge, offset is not applicable).
 - **Feedpoint Impedance:** Approximately 4× a plain dipole (~300 Ω) for equal-diameter conductors, largely independent of spacing. A 4:1 balun brings this to ~75 Ω; a 6:1 brings it to ~50 Ω for direct coax use. 300 Ω twin-lead matches it directly.
 
 ### 13.3 Termination Definition


### PR DESCRIPTION
💡 Problem: The documentation in `docs/antenna-spec.md` for the Folded Dipole stated that Feedline Support was "Not currently modelled". However, looking at the code in `src/store/antennaStore.ts`, `folded-dipole` is explicitly included in `FEEDLINE_SUPPORTED_TYPES`, and the geometry engine actively supports rendering and simulating a feedline shield at the centre bridge for it.

🎯 Fix: Updated `docs/antenna-spec.md` to clarify that feedline support is implemented for the Folded Dipole, replacing the incorrect bullet point. Added an entry to the archivist journal detailing the drift.

🧪 Verification: Verified by inspecting `src/store/antennaStore.ts` (specifically `FEEDLINE_SUPPORTED_TYPES` and `buildWires` shield generation). Ran the full test suite (`npm run test -- --run`) and linter (`npm run lint`), which all passed perfectly.

🔎 Scope: This PR contains ONLY documentation changes and internal LLM journal updates.

---
*PR created automatically by Jules for task [7541492693606484884](https://jules.google.com/task/7541492693606484884) started by @2fst4u*