### PR TITLE
🛡️ Sentinel: [HIGH] Fix insecure GitHub Actions trigger for issue comments

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,10 +13,12 @@ on:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association))
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -34,3 +34,7 @@
 **Vulnerability:** The physics worker accepted messages from any origin. If the worker was unintentionally or maliciously exposed or if messages were somehow relayed cross-origin, an attacker could potentially execute simulated workloads or cause denial of service.
 **Learning:** Web Workers should validate the `origin` of incoming `message` events, especially if they handle complex logic or perform intensive computations.
 **Prevention:** Implement an origin check in the worker's `message` event listener (`if (ev.origin && ev.origin !== '' && ev.origin !== self.location.origin) return;`) to ensure only same-origin messages are processed.
+## 2025-02-04 - Fix insecure GitHub Actions trigger for issue comments
+**Vulnerability:** The Claude action was triggering on `issue_comment`, `pull_request_review_comment`, `pull_request_review`, and `issues` events by solely checking if the payload contained `@claude`. This allowed anyone to trigger the workflow and potentially execute arbitrary code or consume resources.
+**Learning:** GitHub Actions workflows triggered by comment and issue events without strict author validation can be exploited by unprivileged users. Always validate the `author_association` when responding to user-generated content in automated workflows.
+**Prevention:** Ensured the `if` condition in the workflow checks the `author_association` of the event's actor, restricting it to `OWNER`, `MEMBER`, or `COLLABORATOR` before execution.


### PR DESCRIPTION
🎯 **What:** The `claude.yml` workflow was triggering on issue and pull request comment events solely based on the presence of the `@claude` string, without verifying the permissions of the commenter.
⚠️ **Risk:** If left unfixed, this "Pwn Request" vulnerability would allow any unprivileged user, including outside contributors or malicious actors, to trigger the automated CI workflow, potentially executing arbitrary code within the GitHub Actions runner, consuming CI minutes, or accessing sensitive workflow tokens.
🛡️ **Solution:** Modified the `if` condition for all affected event types (`issue_comment`, `pull_request_review_comment`, `pull_request_review`, `issues`) to mandate an authorization check. The workflow will now only execute if the event actor's `author_association` is verified as `OWNER`, `MEMBER`, or `COLLABORATOR`.

---
*PR created automatically by Jules for task [10850371101721196040](https://jules.google.com/task/10850371101721196040) started by @2fst4u*