### PR TITLE
🧪 [testing improvement] Add error handling test for NEC2 simulate execution failure

### DIFF
--- a/tests/nec2Engine.error.test.ts
+++ b/tests/nec2Engine.error.test.ts
@@ -127,4 +127,40 @@ describe('Nec2Engine error handling', () => {
       'NEC-2 sweep missing impedance result for frequency 14 MHz'
     );
   });
+
+  it('throws a general execution exception and cleans up lock when simulate fails', async () => {
+    const engine = new Nec2Engine({ baseUrl: '/' });
+
+    // Mock the init promise to bypass actual wasm loading
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (engine as any).ready = true;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (engine as any).factory = {}; // just to bypass the factory check
+
+    // intercept runJob to throw an error
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.spyOn(engine as any, 'runJob').mockRejectedValue(new Error('Simulated execution failure'));
+
+    const dummyInput: SimulationInput = {
+      wires: [{ start: [0, 0, 1], end: [0, 0, 2], radius: 0.001, segments: 11, tag: 1 }],
+      frequencyMHz: 14,
+      ground: { type: 'free' },
+      excitation: { wireTag: 1, segment: 6 },
+      patternResolution: { thetaSteps: 5, phiSteps: 8 },
+    };
+
+    await expect(engine.simulate(dummyInput)).rejects.toThrow('Simulated execution failure');
+
+    // Ensure that the lock has been released
+    // The lock is stored in engine['lock'], which is a promise that resolves.
+    // If we can acquire the lock again, it means it was released properly.
+    // However, since simulate() resolves the lock promise in a finally block,
+    // if we just await another method that acquires the lock, it shouldn't block.
+
+    // intercept runJob again to return valid output to test lock acquisition
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.spyOn(engine as any, 'runJob').mockResolvedValue('Dummy output with pattern and impedance\nRUN TIME=0.001\n                                 - - - RADIATION PATTERNS - - -\n  THETA    PHI    VERT    HORIZ    TOTAL\n    0.00    0.00   -1.00   -2.00   10.00\n                                 - - - ANTENNA INPUT PARAMETERS - - -\n  TAG   SEG       VOLTAGE (VOLTS)         CURRENT (AMPS)         IMPEDANCE (OHMS)        ADMITTANCE (MHOS)     POWER\n  NO.   NO.     REAL      IMAG.         REAL      IMAG.         REAL      IMAG.         REAL      IMAG.       (WATTS)\n    1     6  1.000E+00  0.000E+00    1.00E-02  2.00E-02    1.00E+01  2.00E+01    1.00E-03  2.00E-03    1.00E+00\n');
+
+    await expect(engine.simulate(dummyInput)).resolves.toBeDefined();
+  });
 });


### PR DESCRIPTION
🎯 **What:** Added a missing error test for `Nec2Engine.simulate()` execution failures to verify that generic exceptions thrown by the underlying `runJob` mechanism are correctly propagated to the caller, and internal resources (specifically the concurrency lock) are released properly.
📊 **Coverage:** Now tests the error and cleanup path for a general execution exception in `simulate()`.
✨ **Result:** Test coverage improved, preventing regressions that could cause silent deadlocks or swallowed errors during simulation failures.

---
*PR created automatically by Jules for task [17189001844304078922](https://jules.google.com/task/17189001844304078922) started by @2fst4u*