### PR TITLE
🧹 [code health] Decouple TerminatedDeltaElement from Theme

### DIFF
--- a/src/components/Scene/AntennaWire.tsx
+++ b/src/components/Scene/AntennaWire.tsx
@@ -39,7 +39,7 @@ export function AntennaWire(props: AntennaWireProps) {
       {terminatedDeltaSplit && (
         <TerminatedDeltaElement
           split={terminatedDeltaSplit}
-          theme={theme}
+          color={wireColor}
           terminatingResistor={terminatingResistor}
         />
       )}

--- a/src/components/Scene/TerminatedDeltaElement.tsx
+++ b/src/components/Scene/TerminatedDeltaElement.tsx
@@ -1,13 +1,12 @@
-import { THEME_COLORS, type Theme } from '../../utils/themeColors';
 import type { TerminatedDeltaSplitResult } from './useAntennaGeometry';
 
 export interface TerminatedDeltaElementProps {
   split: TerminatedDeltaSplitResult;
-  theme: Theme;
+  color: string;
   terminatingResistor: number;
 }
 
-export function TerminatedDeltaElement({ split, theme, terminatingResistor }: TerminatedDeltaElementProps) {
+export function TerminatedDeltaElement({ split, color, terminatingResistor }: TerminatedDeltaElementProps) {
   return (
     <>
       {/* Always show small marker spheres at each half-base inner end —
@@ -17,8 +16,8 @@ export function TerminatedDeltaElement({ split, theme, terminatingResistor }: Te
       <mesh position={split.leftInner}>
         <sphereGeometry args={[0.11, 12, 12]} />
         <meshStandardMaterial
-          color={THEME_COLORS[theme].wire}
-          emissive={THEME_COLORS[theme].wire}
+          color={color}
+          emissive={color}
           emissiveIntensity={0.2}
           metalness={0.8}
           roughness={0.4}
@@ -27,8 +26,8 @@ export function TerminatedDeltaElement({ split, theme, terminatingResistor }: Te
       <mesh position={split.rightInner}>
         <sphereGeometry args={[0.11, 12, 12]} />
         <meshStandardMaterial
-          color={THEME_COLORS[theme].wire}
-          emissive={THEME_COLORS[theme].wire}
+          color={color}
+          emissive={color}
           emissiveIntensity={0.2}
           metalness={0.8}
           roughness={0.4}


### PR DESCRIPTION
🎯 **What:** Removed the unused/unnecessary `Theme` and `THEME_COLORS` dependency from `TerminatedDeltaElement.tsx` by replacing the `theme` prop with a primitive `color` prop.

💡 **Why:** This resolves an 'Unused Import' code health issue by decoupling the low-level rendering component from the global theme structure. The parent component (`AntennaWire`) now evaluates the theme to a color string before passing it down. This makes `TerminatedDeltaElement` more reusable and predictable.

✅ **Verification:**
- Ran format and lint checks.
- Ran the full test suite (`npm run test -- --run --coverage`) to verify the type refactoring and ensure coverage metrics remained above the threshold (886/886 tests passed).
- Verified `AntennaWire.tsx` correctly provides the `wireColor` string to the modified component.

✨ **Result:** Cleaner component boundaries and elimination of an unnecessary domain import.

---
*PR created automatically by Jules for task [15058264714680952256](https://jules.google.com/task/15058264714680952256) started by @2fst4u*