### PR TITLE
🧹 [code health] Refactor AtuSection to decouple FeedlinePreset

### DIFF
--- a/src/components/Panel/Feedline/AtuSection.tsx
+++ b/src/components/Panel/Feedline/AtuSection.tsx
@@ -1,14 +1,9 @@
-import {
-  type FeedlinePreset,
-  feedlineLossDb,
-} from '../../../physics/constants';
 import { SyncedLengthInput } from './SyncedLengthInput';
 
 export interface AtuSectionProps {
   units: 'metric' | 'imperial';
   unit: string;
-  frequency: number;
-  preset: FeedlinePreset;
+  mainRunLossDb: number;
   atuEnabled: boolean;
   atuMainFeedlineLength: number;
   setAtuEnabled: (val: boolean) => void;
@@ -18,15 +13,12 @@ export interface AtuSectionProps {
 export function AtuSection({
   units,
   unit,
-  frequency,
-  preset,
+  mainRunLossDb,
   atuEnabled,
   atuMainFeedlineLength,
   setAtuEnabled,
   setAtuMainFeedlineLength,
 }: AtuSectionProps) {
-  const mainRunLossDb = preset.id !== 'none' ? feedlineLossDb(preset, frequency, atuMainFeedlineLength) : 0;
-
   return (
     <div style={{ marginTop: 12, borderTop: '1px solid var(--border)', paddingTop: 10 }}>
       <label

--- a/src/components/Panel/FeedlineControl.tsx
+++ b/src/components/Panel/FeedlineControl.tsx
@@ -67,6 +67,7 @@ export function FeedlineControl() {
   if (!SUPPORTED_ANTENNA_TYPES.has(antennaType)) return null;
 
   const lossDb = enabled ? feedlineLossDb(preset, frequency, feedlineLength) : 0;
+  const atuMainRunLossDb = enabled ? feedlineLossDb(preset, frequency, atuMainFeedlineLength) : 0;
 
   return (
     <section className="panel-section">
@@ -121,8 +122,7 @@ export function FeedlineControl() {
           <AtuSection
             units={units}
             unit={unit}
-            frequency={frequency}
-            preset={preset}
+            mainRunLossDb={atuMainRunLossDb}
             atuEnabled={atuEnabled}
             atuMainFeedlineLength={atuMainFeedlineLength}
             setAtuEnabled={setAtuEnabled}

--- a/tests/components/Panel/Feedline/AtuSection.test.tsx
+++ b/tests/components/Panel/Feedline/AtuSection.test.tsx
@@ -1,28 +1,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen, fireEvent, cleanup } from '@testing-library/react';
 import { AtuSection } from '../../../../src/components/Panel/Feedline/AtuSection';
-import type { FeedlinePreset } from '../../../../src/physics/constants';
-
-const nonePreset: FeedlinePreset = {
-  id: 'none',
-  label: 'No feedline',
-  z0: 0,
-  velocityFactor: 1,
-  lossK1: 0,
-  lossK2: 0,
-};
-
-const rg8Preset: FeedlinePreset = {
-  id: 'rg8',
-  label: 'RG-8',
-  z0: 50,
-  velocityFactor: 0.82,
-  // Using simple values to make math easy:
-  // lossPer100m = 1 * sqrt(16) + 0 * 16 = 4.
-  // if length is 50m, loss = 4 * 0.5 = 2.
-  lossK1: 1,
-  lossK2: 0,
-};
+// Removed FeedlinePreset mocks as they are no longer used by the component.
 
 describe('AtuSection', () => {
   afterEach(() => {
@@ -37,8 +16,7 @@ describe('AtuSection', () => {
       <AtuSection
         units="metric"
         unit="m"
-        frequency={14}
-        preset={nonePreset}
+        mainRunLossDb={0}
         atuEnabled={false}
         atuMainFeedlineLength={10}
         setAtuEnabled={setAtuEnabled}
@@ -63,8 +41,7 @@ describe('AtuSection', () => {
       <AtuSection
         units="metric"
         unit="m"
-        frequency={14}
-        preset={nonePreset}
+        mainRunLossDb={0}
         atuEnabled={false}
         atuMainFeedlineLength={10}
         setAtuEnabled={setAtuEnabled}
@@ -85,8 +62,7 @@ describe('AtuSection', () => {
       <AtuSection
         units="metric"
         unit="m"
-        frequency={16}
-        preset={rg8Preset}
+        mainRunLossDb={2}
         atuEnabled={true}
         atuMainFeedlineLength={50}
         setAtuEnabled={setAtuEnabled}
@@ -116,8 +92,7 @@ describe('AtuSection', () => {
       <AtuSection
         units="imperial"
         unit="ft"
-        frequency={14}
-        preset={rg8Preset}
+        mainRunLossDb={0}
         atuEnabled={true}
         atuMainFeedlineLength={30.48}
         setAtuEnabled={vi.fn()}
@@ -138,8 +113,7 @@ describe('AtuSection', () => {
       <AtuSection
         units="imperial"
         unit="ft"
-        frequency={14}
-        preset={nonePreset}
+        mainRunLossDb={0}
         atuEnabled={true}
         atuMainFeedlineLength={100}
         setAtuEnabled={setAtuEnabled}


### PR DESCRIPTION
🎯 **What:** Removed the `FeedlinePreset` type import and internal loss computation from `AtuSection.tsx`, replacing it with a simple primitive prop `mainRunLossDb: number`. The computation was lifted to the parent component `FeedlineControl.tsx`. `AtuSection.test.tsx` was also updated to remove mocked presets and pass `mainRunLossDb` values directly.

💡 **Why:** `FeedlinePreset` was reported as an unused import. While it was technically used in the props just to compute a derived numeric value (`mainRunLossDb`), this coupled the component to global preset logic unnecessarily. Extracting the calculation to the parent decoupling the child makes the component purer, resolves the code health issue logically, and satisfies static analysis properly rather than hacking linter rules.

✅ **Verification:** Verified by executing the test suite (`npm run test -- --run --coverage`) which passed completely with no drop in coverage. The component and UI render logic works effectively as before.

✨ **Result:** Improved maintainability by decoupling a pure presentation component from global types. The code health unused import issue is fundamentally resolved.

---
*PR created automatically by Jules for task [11929308695397609250](https://jules.google.com/task/11929308695397609250) started by @2fst4u*