### PR TITLE
🧪 [testing improvement] Add error coverage for nec2 sweep execution failure

### DIFF
--- a/tests/nec2Engine.error.test.ts
+++ b/tests/nec2Engine.error.test.ts
@@ -105,6 +105,7 @@ describe('Nec2Engine error handling', () => {
       'NEC-2 did not produce an impedance result.'
     );
   });
+
   it('throws an error when sweep missing impedance result', async () => {
     const engine = new Nec2Engine({ baseUrl: '/' });
 
@@ -126,5 +127,37 @@ describe('Nec2Engine error handling', () => {
     await expect(engine.sweepImpedance(dummyInput, { points: 1, window: { startMHz: 14, endMHz: 14 } })).rejects.toThrow(
       'NEC-2 sweep missing impedance result for frequency 14 MHz'
     );
+  });
+
+  it('releases lock when solveImpedanceSweep execution fails', async () => {
+    const engine = new Nec2Engine({ baseUrl: '/' });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (engine as any).ready = true;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (engine as any).factory = async () => ({});
+
+    let lockReleased = false;
+    // Mock acquire to return a function that sets our flag
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.spyOn(engine as any, 'acquire').mockResolvedValue(() => {
+      lockReleased = true;
+    });
+
+    // Mock runJob to throw an error
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.spyOn(engine as any, 'runJob').mockRejectedValue(new Error('Sweep execution failed'));
+
+    const dummyInput: SimulationInput = {
+      wires: [{ start: [0, 0, 1], end: [0, 0, 2], radius: 0.001, segments: 11, tag: 1 }],
+      frequencyMHz: 14,
+      ground: { type: 'free' },
+      excitation: { wireTag: 1, segment: 6 },
+      patternResolution: { thetaSteps: 5, phiSteps: 8 },
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await expect((engine as any).solveImpedanceSweep(dummyInput, 1, 14, 0)).rejects.toThrow('Sweep execution failed');
+    expect(lockReleased).toBe(true);
   });
 });


### PR DESCRIPTION
🎯 **What:** Adds missing error coverage in `solveImpedanceSweep` within `Nec2Engine`.
📊 **Coverage:** Specifically verifies that if the core execution (`runJob`) throws an exception during an impedance sweep, the semaphore lock (obtained via `acquire()`) is safely released in the `finally` block before bubbling up the error.
✨ **Result:** Improved test reliability ensuring concurrent calls to the engine won't deadlock if a sweep fails mid-execution.

---
*PR created automatically by Jules for task [4732904729869968392](https://jules.google.com/task/4732904729869968392) started by @2fst4u*