### PR TITLE
🧪 [testing improvement] Add missing edge cases for HHmmToHour empty string handling

### DIFF
--- a/tests/PropagationInputs.test.tsx
+++ b/tests/PropagationInputs.test.tsx
@@ -254,6 +254,12 @@ describe('PropagationInputs time parsers', () => {
       expect(HHmmToHour('12345')).toBe(null);
     });
 
+    it('returns null for empty strings or strings stripping to empty', () => {
+      expect(HHmmToHour('')).toBe(null);
+      expect(HHmmToHour('   ')).toBe(null);
+      expect(HHmmToHour('abc')).toBe(null);
+    });
+
     it('returns null for out-of-bounds hours or minutes', () => {
       expect(HHmmToHour('24:00')).toBe(null); // h=24 is invalid
       expect(HHmmToHour('25:00')).toBe(null);


### PR DESCRIPTION
🎯 **What:** Added tests to cover the edge case where the string input to `HHmmToHour` is empty, or gets stripped to an empty string (e.g. whitespace or alphabetic characters). 
📊 **Coverage:** Empty strings, whitespace-only strings, and non-numeric strings are now explicitly verified to return `null`.
✨ **Result:** Enhanced test coverage guarantees robust parsing of time strings within the `PropagationInputs` test suite.

---
*PR created automatically by Jules for task [4463745555362382142](https://jules.google.com/task/4463745555362382142) started by @2fst4u*