### PR TITLE
🧪 [testing improvement] Add edge case tests for computeStats

### DIFF
--- a/tests/swrChartUtils.test.ts
+++ b/tests/swrChartUtils.test.ts
@@ -198,23 +198,6 @@ describe('computeStats', () => {
     expect(result?.minFreq).toBe(7.1);
   });
 
-  it('handles undefined optional parameters (transformerInDisplay, transformerRatio)', () => {
-    const sweep: SweepPoint[] = [
-      { frequencyMHz: 7.0, R: 50, X: 0, swr: 1.2 },
-    ];
-    // Cast to any to simulate JavaScript calling it with missing parameters that might bypass type safety if it were exposed
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const result = computeStats({ sweep } as any);
-    expect(result).not.toBeNull();
-    expect(result?.minSWR).toBe(1.2);
-  });
-
-  it('returns null when sweep array is completely empty', () => {
-    // Tests explicit edge case of length = 0
-    const result = computeStats({ sweep: [] });
-    expect(result).toBeNull();
-  });
-
   it('evaluates minSWR, minFreq, and bands with active transformer', () => {
     // With a 4:1 transformer, impedance gets divided by 4 before SWR is calculated.
     // 50 Ohm vs 50 Ohm -> SWR 1.0 (Raw SWR)

--- a/tests/swrChartUtils.test.ts
+++ b/tests/swrChartUtils.test.ts
@@ -9,7 +9,7 @@ describe('computeChartData', () => {
     { frequencyMHz: 7.1, R: 100, X: 0, swr: 2.0 },
   ];
 
-  const mockReference: ComparisonSnapshot = {
+  const mockReference: Partial<ComparisonSnapshot> = {
     antennaType: 'dipole',
     height: 10,
     sweep: [
@@ -47,7 +47,7 @@ describe('computeChartData', () => {
     const result = computeChartData({
       ...baseArgs,
       comparisonActive: true,
-      reference: mockReference,
+      reference: mockReference as ComparisonSnapshot,
     });
 
     expect(result.datasets).toHaveLength(2);
@@ -91,7 +91,7 @@ describe('computeChartData', () => {
     const result = computeChartData({
       ...baseArgs,
       comparisonActive: true,
-      reference: mockReference,
+      reference: mockReference as ComparisonSnapshot,
       transformerInDisplay: true,
       transformerRatio: 2, // 2:1 balun => divides impedance by 2
       // At 7.0 MHz, R is 50. Post-balun R = 25. SWR for 25 vs 50 is 2.0.
@@ -163,6 +163,55 @@ describe('computeStats', () => {
     expect(band.lowClipped).toBe(true);
     expect(band.fHigh).toBeCloseTo(7.19, 3);
     expect(band.highClipped).toBe(false);
+  });
+
+  it('handles single-point sweep array safely', () => {
+    const sweep: SweepPoint[] = [{ frequencyMHz: 7.0, R: 50, X: 0, swr: 1.5 }];
+    const result = computeStats({ sweep });
+    expect(result).not.toBeNull();
+    expect(result?.minSWR).toBe(1.5);
+    expect(result?.minFreq).toBe(7.0);
+    expect(result?.bands).toHaveLength(1); // The single point evaluates to <=2, forming a band with fLow=fHigh
+    expect(result?.bands[0].fLow).toBe(7.0);
+    expect(result?.bands[0].fHigh).toBe(7.0);
+  });
+
+  it('handles sweep with NaN swr values gracefully', () => {
+    const sweep: SweepPoint[] = [
+      { frequencyMHz: 7.0, R: 50, X: 0, swr: NaN },
+      { frequencyMHz: 7.1, R: 50, X: 0, swr: 2.0 },
+    ];
+    const result = computeStats({ sweep });
+    expect(result).not.toBeNull();
+    expect(result?.minSWR).toBe(2.0);
+    expect(result?.minFreq).toBe(7.1);
+  });
+
+  it('handles sweep with Infinity swr values gracefully', () => {
+    const sweep: SweepPoint[] = [
+      { frequencyMHz: 7.0, R: 0, X: 0, swr: Infinity },
+      { frequencyMHz: 7.1, R: 50, X: 0, swr: 1.5 },
+    ];
+    const result = computeStats({ sweep });
+    expect(result).not.toBeNull();
+    expect(result?.minSWR).toBe(1.5);
+    expect(result?.minFreq).toBe(7.1);
+  });
+
+  it('handles undefined optional parameters (transformerInDisplay, transformerRatio)', () => {
+    const sweep: SweepPoint[] = [
+      { frequencyMHz: 7.0, R: 50, X: 0, swr: 1.2 },
+    ];
+    // Cast to any to simulate JavaScript calling it with missing parameters that might bypass type safety if it were exposed
+    const result = computeStats({ sweep } as any);
+    expect(result).not.toBeNull();
+    expect(result?.minSWR).toBe(1.2);
+  });
+
+  it('returns null when sweep array is completely empty', () => {
+    // Tests explicit edge case of length = 0
+    const result = computeStats({ sweep: [] });
+    expect(result).toBeNull();
   });
 
   it('evaluates minSWR, minFreq, and bands with active transformer', () => {
@@ -285,7 +334,7 @@ describe('computeYMax', () => {
     { frequencyMHz: 7.1, R: 50, X: 0, swr: 1.8 },
   ];
 
-  const mockReference: ComparisonSnapshot = {
+  const mockReference: Partial<ComparisonSnapshot> = {
     antennaType: 'dipole',
     height: 10,
     sweep: [
@@ -339,7 +388,7 @@ describe('computeYMax', () => {
     expect(computeYMax({
       ...baseArgs,
       comparisonActive: true,
-      reference: mockReference,
+      reference: mockReference as ComparisonSnapshot,
     })).toBe(4);
   });
 

--- a/tests/swrChartUtils.test.ts
+++ b/tests/swrChartUtils.test.ts
@@ -203,6 +203,7 @@ describe('computeStats', () => {
       { frequencyMHz: 7.0, R: 50, X: 0, swr: 1.2 },
     ];
     // Cast to any to simulate JavaScript calling it with missing parameters that might bypass type safety if it were exposed
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const result = computeStats({ sweep } as any);
     expect(result).not.toBeNull();
     expect(result?.minSWR).toBe(1.2);


### PR DESCRIPTION
🎯 **What:** The `computeStats` function in `swrChartUtils` had gaps in edge case coverage, specifically regarding single-point arrays, malformed `NaN`/`Infinity` sweep values, explicit undefined parameters, and the explicit empty array edge case.
  📊 **Coverage:** Added tests specifically checking how `computeStats` handles single-element arrays, sweeps with malformed objects (NaN/Infinity), empty arrays, and implicitly bypassed optional parameters. Also resolved an existing Type casting issue in a mock (`mockReference`).
  ✨ **Result:** Test coverage for `computeStats` is now thoroughly validated against irregular input shapes and malformed objects, increasing overall suite reliability.

---
*PR created automatically by Jules for task [5186335488467279054](https://jules.google.com/task/5186335488467279054) started by @2fst4u*