### PR TITLE
🎨 Palette: Fix broken aria-controls references on disclosure widgets

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -28,3 +28,6 @@
 ## 2024-07-31 - Semantic feedback on custom input validation
 **Learning:** In custom text inputs that accept parsed formats (like a UTC hour "HH:mm" input), when an invalid format is typed, the internal parser naturally returns null. If the input silently ignores it, screen readers receive no feedback that the value is invalid.
 **Action:** Always dynamically bind `aria-invalid` to the result of the validation/parsing function (e.g., `aria-invalid={parse(value) === null}`) to provide immediate semantic feedback to screen readers for custom inputs.
+## 2024-10-27 - Fix ARIA Controls Missing Element
+**Learning:** When using `aria-controls` on a disclosure button, the controlled element MUST remain in the DOM even when collapsed. Conditionally rendering the target element (e.g., `{show && <div id="...">}`) causes the screen reader to lose track of the controlled element.
+**Action:** Use the `hidden` attribute (`<div id="..." hidden={!show}>`) instead of conditional mounting for elements controlled by `aria-controls`. When updating this logic, remember to update the corresponding tests (e.g., from `toBeNull()` to checking the `hidden` property on the wrapper element).

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -28,6 +28,6 @@
 ## 2024-07-31 - Semantic feedback on custom input validation
 **Learning:** In custom text inputs that accept parsed formats (like a UTC hour "HH:mm" input), when an invalid format is typed, the internal parser naturally returns null. If the input silently ignores it, screen readers receive no feedback that the value is invalid.
 **Action:** Always dynamically bind `aria-invalid` to the result of the validation/parsing function (e.g., `aria-invalid={parse(value) === null}`) to provide immediate semantic feedback to screen readers for custom inputs.
-## 2024-10-27 - Fix ARIA Controls Missing Element
+## 2026-08-02 - Fix ARIA Controls Missing Element
 **Learning:** When using `aria-controls` on a disclosure button, the controlled element MUST remain in the DOM even when collapsed. Conditionally rendering the target element (e.g., `{show && <div id="...">}`) causes the screen reader to lose track of the controlled element.
 **Action:** Use the `hidden` attribute (`<div id="..." hidden={!show}>`) instead of conditional mounting for elements controlled by `aria-controls`. When updating this logic, remember to update the corresponding tests (e.g., from `toBeNull()` to checking the `hidden` property on the wrapper element).

--- a/src/components/Panel/GroundControl.tsx
+++ b/src/components/Panel/GroundControl.tsx
@@ -84,8 +84,7 @@ export function GroundControl() {
       <div id="ground-hint" aria-live="polite" style={{ marginTop: 6, fontSize: 11, color: 'var(--text-muted)' }}>
         {GROUND_PRESET_MAP.get(groundId)?.hint ?? 'Custom ground parameters.'}
       </div>
-      {(expanded || groundId === 'custom') && (
-        <div id="custom-ground-settings">
+      <div id="custom-ground-settings" hidden={!(expanded || groundId === 'custom')}>
           <label htmlFor="custom-ground-sigma" style={{ marginTop: 10 }}>Conductivity σ (S/m)</label>
           <input
             id="custom-ground-sigma"
@@ -127,7 +126,6 @@ export function GroundControl() {
             }}
           />
         </div>
-      )}
     </section>
   );
 }

--- a/src/components/Panel/GroundControl.tsx
+++ b/src/components/Panel/GroundControl.tsx
@@ -85,47 +85,47 @@ export function GroundControl() {
         {GROUND_PRESET_MAP.get(groundId)?.hint ?? 'Custom ground parameters.'}
       </div>
       <div id="custom-ground-settings" hidden={!(expanded || groundId === 'custom')}>
-          <label htmlFor="custom-ground-sigma" style={{ marginTop: 10 }}>Conductivity σ (S/m)</label>
-          <input
-            id="custom-ground-sigma"
-            type="number"
-            min={0}
-            step={0.001}
-            value={localSigma}
-            onFocus={() => setIsSigmaFocused(true)}
-            onChange={(e) => {
-              const s = e.target.value;
-              setLocalSigma(s);
-              const val = parseFloat(s);
-              if (isNaN(val)) return;
-              setCustomGround(val, epsilon);
-            }}
-            onBlur={() => {
-              setIsSigmaFocused(false);
-              setLocalSigma(sigma.toString());
-            }}
-          />
-          <label htmlFor="custom-ground-epsilon" style={{ marginTop: 6 }}>Permittivity εr</label>
-          <input
-            id="custom-ground-epsilon"
-            type="number"
-            min={1}
-            step={0.5}
-            value={localEpsilon}
-            onFocus={() => setIsEpsilonFocused(true)}
-            onChange={(e) => {
-              const s = e.target.value;
-              setLocalEpsilon(s);
-              const val = parseFloat(s);
-              if (isNaN(val)) return;
-              setCustomGround(sigma, val);
-            }}
-            onBlur={() => {
-              setIsEpsilonFocused(false);
-              setLocalEpsilon(epsilon.toString());
-            }}
-          />
-        </div>
+        <label htmlFor="custom-ground-sigma" style={{ marginTop: 10 }}>Conductivity σ (S/m)</label>
+        <input
+          id="custom-ground-sigma"
+          type="number"
+          min={0}
+          step={0.001}
+          value={localSigma}
+          onFocus={() => setIsSigmaFocused(true)}
+          onChange={(e) => {
+            const s = e.target.value;
+            setLocalSigma(s);
+            const val = parseFloat(s);
+            if (isNaN(val)) return;
+            setCustomGround(val, epsilon);
+          }}
+          onBlur={() => {
+            setIsSigmaFocused(false);
+            setLocalSigma(sigma.toString());
+          }}
+        />
+        <label htmlFor="custom-ground-epsilon" style={{ marginTop: 6 }}>Permittivity εr</label>
+        <input
+          id="custom-ground-epsilon"
+          type="number"
+          min={1}
+          step={0.5}
+          value={localEpsilon}
+          onFocus={() => setIsEpsilonFocused(true)}
+          onChange={(e) => {
+            const s = e.target.value;
+            setLocalEpsilon(s);
+            const val = parseFloat(s);
+            if (isNaN(val)) return;
+            setCustomGround(sigma, val);
+          }}
+          onBlur={() => {
+            setIsEpsilonFocused(false);
+            setLocalEpsilon(epsilon.toString());
+          }}
+        />
+      </div>
     </section>
   );
 }

--- a/src/components/Panel/Propagation/ConditionsReadout.tsx
+++ b/src/components/Panel/Propagation/ConditionsReadout.tsx
@@ -121,25 +121,25 @@ export function ConditionsReadout({ prediction, haveTakeoff, units }: Conditions
         {showAssumptions ? 'Hide model assumptions' : 'Model & assumptions'}
       </button>
       <div id="assumptions-panel" hidden={!showAssumptions} style={{ fontSize: 11, color: 'var(--text-muted)', marginTop: 6, lineHeight: 1.5 }}>
-          <p style={{ marginTop: 0 }}>
-            This is a closed-form approximation, not IRI / ASAPS / VOACAP.
-            It captures the right monotonic behaviours (foF2 rises with
-            T-index, MUF rises with shallower take-off) but is not a
-            propagation-prediction product.
-          </p>
-          <ul style={{ paddingLeft: 18, margin: '6px 0' }}>
-            <li>foF2 from T-index, solar zenith angle, latitude (no URSI/CCIR maps).</li>
-            <li>hmF2 from a simple day/night sinusoid centred on canonical values.</li>
-            <li>MUF: secant law with curved-Earth correction.</li>
-            <li>Range is ray geometry from elevation and hmF2. Gain and SWR affect signal quality, not skip distance.</li>
-            <li>
-              <strong>LUF: heuristic from D-layer absorption.</strong> Treat with caution
-              — least reliable part of the model, especially near sunrise/sunset.
-            </li>
-            <li>User latitude is taken as the path-midpoint latitude (fine for short hops).</li>
-            <li>No sporadic-E, auroral, or polar effects.</li>
-          </ul>
-        </div>
+        <p style={{ marginTop: 0 }}>
+          This is a closed-form approximation, not IRI / ASAPS / VOACAP.
+          It captures the right monotonic behaviours (foF2 rises with
+          T-index, MUF rises with shallower take-off) but is not a
+          propagation-prediction product.
+        </p>
+        <ul style={{ paddingLeft: 18, margin: '6px 0' }}>
+          <li>foF2 from T-index, solar zenith angle, latitude (no URSI/CCIR maps).</li>
+          <li>hmF2 from a simple day/night sinusoid centred on canonical values.</li>
+          <li>MUF: secant law with curved-Earth correction.</li>
+          <li>Range is ray geometry from elevation and hmF2. Gain and SWR affect signal quality, not skip distance.</li>
+          <li>
+            <strong>LUF: heuristic from D-layer absorption.</strong> Treat with caution
+            — least reliable part of the model, especially near sunrise/sunset.
+          </li>
+          <li>User latitude is taken as the path-midpoint latitude (fine for short hops).</li>
+          <li>No sporadic-E, auroral, or polar effects.</li>
+        </ul>
+      </div>
     </>
   );
 }

--- a/src/components/Panel/Propagation/ConditionsReadout.tsx
+++ b/src/components/Panel/Propagation/ConditionsReadout.tsx
@@ -120,8 +120,7 @@ export function ConditionsReadout({ prediction, haveTakeoff, units }: Conditions
         </svg>
         {showAssumptions ? 'Hide model assumptions' : 'Model & assumptions'}
       </button>
-      {showAssumptions && (
-        <div id="assumptions-panel" style={{ fontSize: 11, color: 'var(--text-muted)', marginTop: 6, lineHeight: 1.5 }}>
+      <div id="assumptions-panel" hidden={!showAssumptions} style={{ fontSize: 11, color: 'var(--text-muted)', marginTop: 6, lineHeight: 1.5 }}>
           <p style={{ marginTop: 0 }}>
             This is a closed-form approximation, not IRI / ASAPS / VOACAP.
             It captures the right monotonic behaviours (foF2 rises with
@@ -141,7 +140,6 @@ export function ConditionsReadout({ prediction, haveTakeoff, units }: Conditions
             <li>No sporadic-E, auroral, or polar effects.</li>
           </ul>
         </div>
-      )}
     </>
   );
 }

--- a/tests/GroundControl.test.tsx
+++ b/tests/GroundControl.test.tsx
@@ -101,15 +101,15 @@ describe('GroundControl', () => {
     render(<GroundControl />);
 
     // Initially custom inputs are not visible
-    expect(screen.queryByLabelText('Conductivity σ (S/m)')).toBeNull();
-    expect(screen.queryByLabelText('Permittivity εr')).toBeNull();
+    expect(screen.getByLabelText('Conductivity σ (S/m)').closest('div')).toHaveProperty('hidden', true);
+    expect(screen.getByLabelText('Permittivity εr').closest('div')).toHaveProperty('hidden', true);
 
     const expandButton = screen.getByRole('button', { name: /Custom/i });
     fireEvent.click(expandButton);
 
     // After clicking, they should be visible
-    expect(screen.getByLabelText('Conductivity σ (S/m)')).toBeDefined();
-    expect(screen.getByLabelText('Permittivity εr')).toBeDefined();
+    expect(screen.getByLabelText('Conductivity σ (S/m)').closest('div')).toHaveProperty('hidden', false);
+    expect(screen.getByLabelText('Permittivity εr').closest('div')).toHaveProperty('hidden', false);
   });
 
   it('collapses the custom inputs again via the Simple toggle', () => {
@@ -118,11 +118,11 @@ describe('GroundControl', () => {
     render(<GroundControl />);
 
     fireEvent.click(screen.getByRole('button', { name: /Custom/i }));
-    expect(screen.getByLabelText('Conductivity σ (S/m)')).toBeDefined();
+    expect(screen.getByLabelText('Conductivity σ (S/m)').closest('div')).toHaveProperty('hidden', false);
 
     // Once expanded the toggle reads "Simple" and hides the inputs again.
     fireEvent.click(screen.getByRole('button', { name: /Simple/i }));
-    expect(screen.queryByLabelText('Conductivity σ (S/m)')).toBeNull();
+    expect(screen.getByLabelText('Conductivity σ (S/m)').closest('div')).toHaveProperty('hidden', true);
   });
 
   it('resets the sigma field to the store value on blur', () => {

--- a/tests/components/Panel/Propagation/ConditionsReadout.test.tsx
+++ b/tests/components/Panel/Propagation/ConditionsReadout.test.tsx
@@ -100,13 +100,13 @@ describe('ConditionsReadout', () => {
     );
 
     const button = screen.getByRole('button', { name: /Model & assumptions/i });
-    expect(screen.queryByText(/This is a closed-form approximation/i)).toBeNull();
+    expect(screen.getByText(/This is a closed-form approximation/i).closest('div')).toHaveProperty('hidden', true);
 
     fireEvent.click(button);
-    expect(screen.getByText(/This is a closed-form approximation/i)).toBeDefined();
+    expect(screen.getByText(/This is a closed-form approximation/i).closest('div')).toHaveProperty('hidden', false);
 
     fireEvent.click(button);
-    expect(screen.queryByText(/This is a closed-form approximation/i)).toBeNull();
+    expect(screen.getByText(/This is a closed-form approximation/i).closest('div')).toHaveProperty('hidden', true);
   });
 
   it('displays ranges in km when units is metric', () => {


### PR DESCRIPTION
Fixes an accessibility issue where `aria-controls` points to an element that gets conditionally removed from the DOM. Using the `hidden` attribute instead of conditionally rendering ensures the ID always exists in the DOM for screen readers to reference.

---
*PR created automatically by Jules for task [4507693787860298270](https://jules.google.com/task/4507693787860298270) started by @2fst4u*