### PR TITLE
🧪 [testing improvement] Add missing edge case test for negative length in clampSpan

### DIFF
--- a/tests/sweep.test.ts
+++ b/tests/sweep.test.ts
@@ -45,6 +45,16 @@ describe('sweep functions', () => {
       expect(result.end).toBe(7.1);
     });
 
+    it('handles negative spanFraction resulting in start > end', () => {
+      const result = clampSpan(14, -0.1);
+      // freq = 14, spanFraction = -0.1
+      // start = 14 * (1 - (-0.05)) = 14 * 1.05 = 14.7
+      // end = 14 * (1 + (-0.05)) = 14 * 0.95 = 13.3
+      expect(result.start).toBeCloseTo(14.7, 6);
+      expect(result.end).toBeCloseTo(13.3, 6);
+      expect(result.start).toBeGreaterThan(result.end);
+    });
+
     it('clamps to min/max HF bounds', () => {
       expect(clampSpan(1, 1).start).toBe(SWEEP_F_MIN_MHZ);
       expect(clampSpan(30, 1).end).toBe(SWEEP_F_MAX_MHZ);


### PR DESCRIPTION
🎯 **What:** Added a missing test case for `clampSpan` to handle negative `spanFraction`.
📊 **Coverage:** The edge case where `spanFraction < 0` resulting in `start > end` is now tested.
✨ **Result:** Test coverage improved, ensuring future refactoring is safe regarding this behavior.

---
*PR created automatically by Jules for task [1747138179120843944](https://jules.google.com/task/1747138179120843944) started by @2fst4u*