### PR TITLE
🧪 [testing improvement] Add exception handling test for Nec2Engine sweepImpedance

### DIFF
--- a/tests/nec2Engine.error.test.ts
+++ b/tests/nec2Engine.error.test.ts
@@ -160,6 +160,37 @@ describe('Nec2Engine error handling', () => {
     await expect(engine.simulate(dummyInput)).resolves.toBeDefined();
   });
 
+
+  it('throws a general execution exception and cleans up lock when sweep fails', async () => {
+    const engine = new Nec2Engine({ baseUrl: '/' });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (engine as any).ready = true;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (engine as any).factory = {}; // bypass factory check
+
+    // intercept runJob to throw an error
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.spyOn(engine as any, 'runJob').mockRejectedValue(new Error('Sweep execution failure'));
+
+    const dummyInput: SimulationInput = {
+      wires: [{ start: [0, 0, 1], end: [0, 0, 2], radius: 0.001, segments: 11, tag: 1 }],
+      frequencyMHz: 14,
+      ground: { type: 'free' },
+      excitation: { wireTag: 1, segment: 6 },
+      patternResolution: { thetaSteps: 5, phiSteps: 8 },
+    };
+
+    // Use specific bounds so sweep doesn't do multiple adaptive passes that all fail
+    await expect(engine.sweepImpedance(dummyInput, { points: 1, window: { startMHz: 14, endMHz: 14 } })).rejects.toThrow('Sweep execution failure');
+
+    // Check that lock was released by doing a successful simulation next
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.spyOn(engine as any, 'runJob').mockResolvedValue('Dummy output\nRUN TIME=0.001\n                                 - - - RADIATION PATTERNS - - -\n  THETA    PHI    VERT    HORIZ    TOTAL\n    0.00    0.00   -1.00   -2.00   10.00\n                                 - - - ANTENNA INPUT PARAMETERS - - -\n  TAG   SEG       VOLTAGE (VOLTS)         CURRENT (AMPS)         IMPEDANCE (OHMS)        ADMITTANCE (MHOS)     POWER\n  NO.   NO.     REAL      IMAG.         REAL      IMAG.         REAL      IMAG.         REAL      IMAG.       (WATTS)\n    1     6  1.000E+00  0.000E+00    1.00E-02  2.00E-02    1.00E+01  2.00E+01    1.00E-03  2.00E-03    1.00E+00\n');
+
+    await expect(engine.simulate(dummyInput)).resolves.toBeDefined();
+  });
+
   it('releases lock when solveImpedanceSweep execution fails', async () => {
     const engine = new Nec2Engine({ baseUrl: '/' });
 


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of test coverage for general execution exceptions during the `sweepImpedance` execution block (specifically the inner `runJob` call). It was untested if the lock was being appropriately released during failure.
📊 **Coverage:** A new test has been added to `tests/nec2Engine.error.test.ts` to cover the scenario where `runJob` rejects due to an exception while called from `solveImpedanceSweep`.
✨ **Result:** Test coverage for error propagation and semaphore lock management is complete, ensuring that the engine doesn't deadlock if a specific sweep execution process internally aborts.

---
*PR created automatically by Jules for task [7560521393604552315](https://jules.google.com/task/7560521393604552315) started by @2fst4u*