### PR TITLE
🧪 Add test for NEC2 simulate execution failure

### DIFF
--- a/tests/nec2Engine.test.ts
+++ b/tests/nec2Engine.test.ts
@@ -62,11 +62,15 @@ describe('Nec2Engine unit tests', () => {
   it('simulate() propagates runJob execution error and releases lock', async () => {
     const engine = new Nec2Engine();
     // Bypass actual wasm loading
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (engine as any).ready = true;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (engine as any).factory = {}; // bypass factory check
 
     let lockReleased = false;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const originalAcquire = (engine as any).acquire.bind(engine);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (engine as any).acquire = async () => {
       const release = await originalAcquire();
       return () => {
@@ -76,6 +80,7 @@ describe('Nec2Engine unit tests', () => {
     };
 
     // Intercept runJob to throw an error
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (engine as any).runJob = async () => {
       throw new Error('Simulated execution failure');
     };

--- a/tests/nec2Engine.test.ts
+++ b/tests/nec2Engine.test.ts
@@ -48,20 +48,47 @@ describe('Nec2Engine unit tests', () => {
 
     const dummyInput = {
       frequencyMHz: 14.1,
-      wires: [],
-      ground: { type: 'perfect' },
-      excitation: {
-        wireTag: 1,
-        segment: 1,
-        voltage: 1,
-      },
-      patternResolution: { thetaSteps: 1, phiSteps: 1 },
-      loads: [],
-      transmissionLines: [],
+      wires: [{ start: [0, 0, 1], end: [0, 0, 2], radius: 0.001, segments: 11, tag: 1 }],
+      ground: { type: 'free' },
+      excitation: { wireTag: 1, segment: 6 },
+      patternResolution: { thetaSteps: 5, phiSteps: 8 },
     } as unknown as SimulationInput;
 
     await expect(engine.sweepImpedance(dummyInput)).rejects.toThrow(
       'nec2c sweep exited with status 1. some error line 1 | some error line 2'
     );
+  });
+
+  it('simulate() propagates runJob execution error and releases lock', async () => {
+    const engine = new Nec2Engine();
+    // Bypass actual wasm loading
+    (engine as any).ready = true;
+    (engine as any).factory = {}; // bypass factory check
+
+    let lockReleased = false;
+    const originalAcquire = (engine as any).acquire.bind(engine);
+    (engine as any).acquire = async () => {
+      const release = await originalAcquire();
+      return () => {
+        lockReleased = true;
+        release();
+      };
+    };
+
+    // Intercept runJob to throw an error
+    (engine as any).runJob = async () => {
+      throw new Error('Simulated execution failure');
+    };
+
+    const dummyInput = {
+      frequencyMHz: 14.1,
+      wires: [{ start: [0, 0, 1], end: [0, 0, 2], radius: 0.001, segments: 11, tag: 1 }],
+      ground: { type: 'free' },
+      excitation: { wireTag: 1, segment: 6 },
+      patternResolution: { thetaSteps: 5, phiSteps: 8 },
+    } as unknown as SimulationInput;
+
+    await expect(engine.simulate(dummyInput)).rejects.toThrow('Simulated execution failure');
+    expect(lockReleased).toBe(true);
   });
 });


### PR DESCRIPTION
🎯 **What:** Added a missing error test for `Nec2Engine.simulate()` execution failures, which was identified as a gap in test coverage.
📊 **Coverage:** Specifically tests that an execution failure (simulated by throwing an error in the mocked `runJob` method) correctly rejects the promise with the thrown error and cleans up the engine's internal concurrency lock by releasing it properly.
✨ **Result:** Improved test reliability and ensured that `simulate()` won't leave the engine in an unrecoverable locked state if `runJob` fails mid-execution. Coverage is maintained.

---
*PR created automatically by Jules for task [6426457899950560127](https://jules.google.com/task/6426457899950560127) started by @2fst4u*