### PR TITLE
🎨 Palette: Use hidden attribute for aria-controls targets

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -28,3 +28,6 @@
 ## 2024-07-31 - Semantic feedback on custom input validation
 **Learning:** In custom text inputs that accept parsed formats (like a UTC hour "HH:mm" input), when an invalid format is typed, the internal parser naturally returns null. If the input silently ignores it, screen readers receive no feedback that the value is invalid.
 **Action:** Always dynamically bind `aria-invalid` to the result of the validation/parsing function (e.g., `aria-invalid={parse(value) === null}`) to provide immediate semantic feedback to screen readers for custom inputs.
+## 2026-08-02 - DOM Presence for aria-controls
+**Learning:** When using `aria-controls` to link a disclosure button to its target, conditionally unmounting the target in React breaks the accessibility reference because the ID disappears from the DOM.
+**Action:** Use the HTML `hidden` attribute instead of conditional React rendering so the target element's ID always remains in the DOM.

--- a/src/components/Panel/GroundControl.tsx
+++ b/src/components/Panel/GroundControl.tsx
@@ -84,8 +84,7 @@ export function GroundControl() {
       <div id="ground-hint" aria-live="polite" style={{ marginTop: 6, fontSize: 11, color: 'var(--text-muted)' }}>
         {GROUND_PRESET_MAP.get(groundId)?.hint ?? 'Custom ground parameters.'}
       </div>
-      {(expanded || groundId === 'custom') && (
-        <div id="custom-ground-settings">
+      <div id="custom-ground-settings" hidden={!(expanded || groundId === 'custom')}>
           <label htmlFor="custom-ground-sigma" style={{ marginTop: 10 }}>Conductivity σ (S/m)</label>
           <input
             id="custom-ground-sigma"
@@ -127,7 +126,6 @@ export function GroundControl() {
             }}
           />
         </div>
-      )}
     </section>
   );
 }

--- a/src/components/Panel/Propagation/ConditionsReadout.tsx
+++ b/src/components/Panel/Propagation/ConditionsReadout.tsx
@@ -120,8 +120,7 @@ export function ConditionsReadout({ prediction, haveTakeoff, units }: Conditions
         </svg>
         {showAssumptions ? 'Hide model assumptions' : 'Model & assumptions'}
       </button>
-      {showAssumptions && (
-        <div id="assumptions-panel" style={{ fontSize: 11, color: 'var(--text-muted)', marginTop: 6, lineHeight: 1.5 }}>
+      <div id="assumptions-panel" hidden={!showAssumptions} style={{ fontSize: 11, color: 'var(--text-muted)', marginTop: 6, lineHeight: 1.5 }}>
           <p style={{ marginTop: 0 }}>
             This is a closed-form approximation, not IRI / ASAPS / VOACAP.
             It captures the right monotonic behaviours (foF2 rises with
@@ -141,7 +140,6 @@ export function ConditionsReadout({ prediction, haveTakeoff, units }: Conditions
             <li>No sporadic-E, auroral, or polar effects.</li>
           </ul>
         </div>
-      )}
     </>
   );
 }

--- a/tests/GroundControl.test.tsx
+++ b/tests/GroundControl.test.tsx
@@ -101,8 +101,8 @@ describe('GroundControl', () => {
     render(<GroundControl />);
 
     // Initially custom inputs are not visible
-    expect(screen.queryByLabelText('Conductivity σ (S/m)')).toBeNull();
-    expect(screen.queryByLabelText('Permittivity εr')).toBeNull();
+    expect(screen.queryByLabelText('Conductivity σ (S/m)')?.parentElement).toHaveProperty('hidden', true);
+    expect(screen.queryByLabelText('Permittivity εr')?.parentElement).toHaveProperty('hidden', true);
 
     const expandButton = screen.getByRole('button', { name: /Custom/i });
     fireEvent.click(expandButton);
@@ -122,7 +122,7 @@ describe('GroundControl', () => {
 
     // Once expanded the toggle reads "Simple" and hides the inputs again.
     fireEvent.click(screen.getByRole('button', { name: /Simple/i }));
-    expect(screen.queryByLabelText('Conductivity σ (S/m)')).toBeNull();
+    expect(screen.queryByLabelText('Conductivity σ (S/m)')?.parentElement).toHaveProperty('hidden', true);
   });
 
   it('resets the sigma field to the store value on blur', () => {

--- a/tests/components/Panel/Propagation/ConditionsReadout.test.tsx
+++ b/tests/components/Panel/Propagation/ConditionsReadout.test.tsx
@@ -100,13 +100,13 @@ describe('ConditionsReadout', () => {
     );
 
     const button = screen.getByRole('button', { name: /Model & assumptions/i });
-    expect(screen.queryByText(/This is a closed-form approximation/i)).toBeNull();
+    expect(screen.queryByText(/This is a closed-form approximation/i)?.parentElement).toHaveProperty('hidden', true);
 
     fireEvent.click(button);
     expect(screen.getByText(/This is a closed-form approximation/i)).toBeDefined();
 
     fireEvent.click(button);
-    expect(screen.queryByText(/This is a closed-form approximation/i)).toBeNull();
+    expect(screen.queryByText(/This is a closed-form approximation/i)?.parentElement).toHaveProperty('hidden', true);
   });
 
   it('displays ranges in km when units is metric', () => {


### PR DESCRIPTION
💡 **What:** Replaced conditional React unmounting (`{condition && <div id="target">...</div>}`) with the HTML `hidden` attribute (`<div id="target" hidden={!condition}>...</div>`) for disclosure targets linked via `aria-controls` in `GroundControl.tsx` and `ConditionsReadout.tsx`.

🎯 **Why:** When `aria-controls` points to an ID that is unmounted and removed from the DOM by React, the accessibility reference is broken. Screen reader users are informed that a button controls an element that no longer exists. By using the `hidden` attribute, the element and its ID remain in the DOM, keeping the reference valid regardless of the expanded/collapsed state.

♿ **Accessibility:** Fixes broken `aria-controls` references for the "Custom" ground settings panel and the "Model & assumptions" panel.

✅ **Verification:**
- Validated via `pnpm lint`.
- Updated test assertions in `GroundControl.test.tsx` and `ConditionsReadout.test.tsx` to assert `.toHaveProperty('hidden', true)` instead of `.toBeNull()`.
- Validated via `pnpm test -- --run` (all 894 tests pass).

---
*PR created automatically by Jules for task [15887388536186129399](https://jules.google.com/task/15887388536186129399) started by @2fst4u*