### PR TITLE
🎨 Palette: Fix missing aria-controls references for disclosure widgets

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -28,3 +28,6 @@
 ## 2024-07-31 - Semantic feedback on custom input validation
 **Learning:** In custom text inputs that accept parsed formats (like a UTC hour "HH:mm" input), when an invalid format is typed, the internal parser naturally returns null. If the input silently ignores it, screen readers receive no feedback that the value is invalid.
 **Action:** Always dynamically bind `aria-invalid` to the result of the validation/parsing function (e.g., `aria-invalid={parse(value) === null}`) to provide immediate semantic feedback to screen readers for custom inputs.
+## 2025-02-09 - Fix invalid aria-controls references for disclosure widgets
+**Learning:** React conditional rendering (`{expanded && <div id="panel">}`) breaks `aria-controls` because the target ID must remain in the DOM even when the panel is collapsed, otherwise screen readers report a broken reference.
+**Action:** Use the HTML `hidden` attribute (e.g., `<div id="panel" hidden={!expanded}>`) for the content container of any disclosure widget instead of unmounting the element from the DOM entirely.

--- a/src/components/Panel/GroundControl.tsx
+++ b/src/components/Panel/GroundControl.tsx
@@ -84,9 +84,8 @@ export function GroundControl() {
       <div id="ground-hint" aria-live="polite" style={{ marginTop: 6, fontSize: 11, color: 'var(--text-muted)' }}>
         {GROUND_PRESET_MAP.get(groundId)?.hint ?? 'Custom ground parameters.'}
       </div>
-      {(expanded || groundId === 'custom') && (
-        <div id="custom-ground-settings">
-          <label htmlFor="custom-ground-sigma" style={{ marginTop: 10 }}>Conductivity σ (S/m)</label>
+      <div id="custom-ground-settings" hidden={!(expanded || groundId === 'custom')}>
+        <label htmlFor="custom-ground-sigma" style={{ marginTop: 10 }}>Conductivity σ (S/m)</label>
           <input
             id="custom-ground-sigma"
             type="number"
@@ -126,8 +125,7 @@ export function GroundControl() {
               setLocalEpsilon(epsilon.toString());
             }}
           />
-        </div>
-      )}
+      </div>
     </section>
   );
 }

--- a/src/components/Panel/Propagation/ConditionsReadout.tsx
+++ b/src/components/Panel/Propagation/ConditionsReadout.tsx
@@ -120,9 +120,8 @@ export function ConditionsReadout({ prediction, haveTakeoff, units }: Conditions
         </svg>
         {showAssumptions ? 'Hide model assumptions' : 'Model & assumptions'}
       </button>
-      {showAssumptions && (
-        <div id="assumptions-panel" style={{ fontSize: 11, color: 'var(--text-muted)', marginTop: 6, lineHeight: 1.5 }}>
-          <p style={{ marginTop: 0 }}>
+      <div id="assumptions-panel" hidden={!showAssumptions} style={{ fontSize: 11, color: 'var(--text-muted)', marginTop: 6, lineHeight: 1.5 }}>
+        <p style={{ marginTop: 0 }}>
             This is a closed-form approximation, not IRI / ASAPS / VOACAP.
             It captures the right monotonic behaviours (foF2 rises with
             T-index, MUF rises with shallower take-off) but is not a
@@ -139,9 +138,8 @@ export function ConditionsReadout({ prediction, haveTakeoff, units }: Conditions
             </li>
             <li>User latitude is taken as the path-midpoint latitude (fine for short hops).</li>
             <li>No sporadic-E, auroral, or polar effects.</li>
-          </ul>
-        </div>
-      )}
+        </ul>
+      </div>
     </>
   );
 }

--- a/tests/GroundControl.test.tsx
+++ b/tests/GroundControl.test.tsx
@@ -101,15 +101,15 @@ describe('GroundControl', () => {
     render(<GroundControl />);
 
     // Initially custom inputs are not visible
-    expect(screen.queryByLabelText('Conductivity σ (S/m)')).toBeNull();
-    expect(screen.queryByLabelText('Permittivity εr')).toBeNull();
+    expect(screen.getByLabelText('Conductivity σ (S/m)').closest('div')).toHaveProperty('hidden', true);
+    expect(screen.getByLabelText('Permittivity εr').closest('div')).toHaveProperty('hidden', true);
 
     const expandButton = screen.getByRole('button', { name: /Custom/i });
     fireEvent.click(expandButton);
 
     // After clicking, they should be visible
-    expect(screen.getByLabelText('Conductivity σ (S/m)')).toBeDefined();
-    expect(screen.getByLabelText('Permittivity εr')).toBeDefined();
+    expect(screen.getByLabelText('Conductivity σ (S/m)').closest('div')).toHaveProperty('hidden', false);
+    expect(screen.getByLabelText('Permittivity εr').closest('div')).toHaveProperty('hidden', false);
   });
 
   it('collapses the custom inputs again via the Simple toggle', () => {
@@ -122,7 +122,7 @@ describe('GroundControl', () => {
 
     // Once expanded the toggle reads "Simple" and hides the inputs again.
     fireEvent.click(screen.getByRole('button', { name: /Simple/i }));
-    expect(screen.queryByLabelText('Conductivity σ (S/m)')).toBeNull();
+    expect(screen.getByLabelText('Conductivity σ (S/m)').closest('div')).toHaveProperty('hidden', true);
   });
 
   it('resets the sigma field to the store value on blur', () => {

--- a/tests/components/Panel/Propagation/ConditionsReadout.test.tsx
+++ b/tests/components/Panel/Propagation/ConditionsReadout.test.tsx
@@ -100,13 +100,13 @@ describe('ConditionsReadout', () => {
     );
 
     const button = screen.getByRole('button', { name: /Model & assumptions/i });
-    expect(screen.queryByText(/This is a closed-form approximation/i)).toBeNull();
+    expect(screen.getByText(/This is a closed-form approximation/i).closest('div')).toHaveProperty('hidden', true);
 
     fireEvent.click(button);
-    expect(screen.getByText(/This is a closed-form approximation/i)).toBeDefined();
+    expect(screen.getByText(/This is a closed-form approximation/i).closest('div')).toHaveProperty('hidden', false);
 
     fireEvent.click(button);
-    expect(screen.queryByText(/This is a closed-form approximation/i)).toBeNull();
+    expect(screen.getByText(/This is a closed-form approximation/i).closest('div')).toHaveProperty('hidden', true);
   });
 
   it('displays ranges in km when units is metric', () => {


### PR DESCRIPTION
💡 What: Replaced conditional React rendering with the HTML `hidden` attribute for disclosure widget containers (in `GroundControl` and `ConditionsReadout`).
🎯 Why: When a widget is collapsed and completely unmounted from the DOM, the `aria-controls` attribute on its toggle button points to a missing ID, breaking the reference for screen readers. Keeping the element in the DOM with the `hidden` attribute maintains the valid ID reference while visually hiding the content.
📸 Before/After: Visual presentation remains identical.
♿ Accessibility: Ensures valid `aria-controls` target resolution at all times, making the UI robust for screen reader navigation. Fixed broken tests by updating `.toBeNull()` checks to assert on the `hidden` property.

---
*PR created automatically by Jules for task [18156160330829551245](https://jules.google.com/task/18156160330829551245) started by @2fst4u*