### PR TITLE
🧹 Sweep: Remove unused export for GradedSegmentPlan

### DIFF
--- a/.jules/sweep.md
+++ b/.jules/sweep.md
@@ -107,3 +107,6 @@
 ## 2025-03-02 - [Remove duplicate TERMINATED_DELTA_CENTRE_GAP_M export]
 **Learning:** When Knip flags duplicate exports that are simply aliases of each other, they should be cleaned up by keeping only the canonical constant and removing the alias. Also, removing imports without removing their usage causes AST parsing errors (`[PARSE_ERROR] Identifier X has already been declared`), so it's critical to ensure tests pass after modifying both the export and the consuming files.
 **Action:** Use a regex or simple find-and-replace to migrate consuming files to use the canonical name before deleting the alias.
+## 2024-05-30 - False Positives in Knip Analysis
+**Learning:** Knip static analysis might falsely flag exports that are actively used if it doesn't parse dynamically or if it's explicitly run with `--production`, which ignores usages inside test files. Wait to use `grep` everywhere to verify.
+**Action:** Always verify a Knip suggestion via a global text search (`grep -rn`) before including its deletion in the execution plan.

--- a/src/store/antennaGeometry.ts
+++ b/src/store/antennaGeometry.ts
@@ -49,7 +49,7 @@ export const MAX_SEGS_PER_LEG = 100;
  * than ~2× in length, otherwise basis functions can't resolve the rapid
  * current variation at the source.
  */
-export interface GradedSegmentPlan {
+interface GradedSegmentPlan {
   /** Lengths of the geometrically-growing prefix segments (short → long). */
   readonly prefixLens: number[];
   /** Length of each uniform tail segment (0 if no tail). */


### PR DESCRIPTION
💡 What: Removed the `export` keyword from `GradedSegmentPlan` interface in `src/store/antennaGeometry.ts`.
🎯 Why: `GradedSegmentPlan` was identified as an unused export by Knip. A global text search confirmed it is not imported or used outside of `src/store/antennaGeometry.ts`.
🔬 Verification: Ran `grep -rn "GradedSegmentPlan" src tests` to confirm it is not used elsewhere. Verified `npx knip --production` no longer flags it. Ran `pnpm lint`, `pnpm build`, and `pnpm test` to ensure functionality remains unchanged.

---
*PR created automatically by Jules for task [4407782759443375641](https://jules.google.com/task/4407782759443375641) started by @2fst4u*