### PR TITLE
Type-check the test suite in CI and fix the 88 errors it surfaced

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,5 +27,8 @@ jobs:
       - name: Run ESLint
         run: npm run lint
 
+      - name: Type check
+        run: npm run typecheck
+
       - name: Run Vitest
         run: npm run test

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "typecheck": "tsc -b && tsc -p tsconfig.test.json --noEmit",
     "preview": "vite preview",
     "lint": "eslint .",
     "test": "vitest run",

--- a/tests/AntennaScene.test.tsx
+++ b/tests/AntennaScene.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, cleanup } from '@testing-library/react';
 import { AntennaScene } from '../src/components/Scene/AntennaScene';
-import { useAntennaStore } from '../src/store/antennaStore';
+import { mockAntennaStore } from './helpers/mockStore';
+import { makeSimulationResult } from './helpers/factories';
 import React from 'react';
 
 // Mock specific three.js components to avoid jsdom warnings
@@ -48,8 +49,7 @@ describe('AntennaScene', () => {
       console.warn(msg); // log others as warn to see them
     });
 
-    vi.mocked(useAntennaStore).mockImplementation((selector: (s: unknown) => unknown) => {
-      const state = {
+    mockAntennaStore({
         antennaType: 'dipole',
         length: 20,
         height: 10,
@@ -57,22 +57,20 @@ describe('AntennaScene', () => {
         wireRadius: 0.001,
         segments: 21,
         groundId: 'pastoral',
-        result: { maxGainDbi: 2.15 },
+        result: makeSimulationResult({ maxGainDbi: 2.15 }),
         feedlineId: 'coax',
         feedlineLength: 15,
         feedlineOffset: 0.5,
-        whipCounterpoise: 0,
+        whipCounterpoise: false,
         showGrid: true,
         showAxes: false,
         patternScale: 1,
         dbRange: 40,
         colorMaxDb: 0,
         colormap: 'viridis',
-        mode: 'standard',
+        mode: 'normal',
         theme: 'dark',
-      };
-      return selector(state);
-    });
+      });
   });
 
   afterEach(() => {
@@ -94,7 +92,7 @@ describe('AntennaScene', () => {
     // RadiationPattern should receive live state props
     const radiationPattern = getByTestId('radiation-pattern');
     const patternProps = JSON.parse(radiationPattern.getAttribute('data-props') || '{}');
-    expect(patternProps.result).toEqual({ maxGainDbi: 2.15 });
+    expect(patternProps.result.maxGainDbi).toBe(2.15);
 
     // GroundPlane should receive live state props
     const groundPlane = getByTestId('ground-plane');
@@ -146,14 +144,11 @@ describe('AntennaScene', () => {
   });
 
   it('shows axes when showAxes is true', () => {
-    vi.mocked(useAntennaStore).mockImplementation((selector: (s: unknown) => unknown) => {
-      const state = {
+    mockAntennaStore({
         antennaType: 'dipole',
         showAxes: true,
         theme: 'dark',
-      };
-      return selector(state);
-    });
+      });
 
     const { container } = render(<AntennaScene />);
     expect(container.innerHTML).toContain('<axeshelper'); // axesHelper might be lowercase in DOM

--- a/tests/AntennaWire.test.tsx
+++ b/tests/AntennaWire.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, cleanup } from '@testing-library/react';
 import { AntennaWire } from '../src/components/Scene/AntennaWire';
-import { useAntennaStore } from '../src/store/antennaStore';
+import { mockAntennaStore } from './helpers/mockStore';
 
 // Mock specific three.js components to avoid jsdom warnings
 vi.mock('@react-three/fiber', () => ({
@@ -29,17 +29,14 @@ describe('AntennaWire', () => {
       console.warn(msg, ...args);
     });
 
-    vi.mocked(useAntennaStore).mockImplementation((selector: (s: unknown) => unknown) => {
-      const state = {
+    mockAntennaStore({
         theme: 'dark',
         transformerEnabled: false,
         terminatingResistor: 0,
         vAngle: 120,
         legSlope: 0,
         frequency: 14.1,
-      };
-      return selector(state);
-    });
+      });
   });
 
   afterEach(() => {
@@ -54,6 +51,10 @@ describe('AntennaWire', () => {
         length={10}
         height={5}
         orientation="EW"
+        vAngle={120}
+        legSlope={0}
+        frequency={14.1}
+        foldedDipoleAperture={0.1}
         wireRadius={0.001}
         segments={11}
         feedlineId="none"
@@ -72,17 +73,14 @@ describe('AntennaWire', () => {
   });
 
   it('renders a terminated delta split wire', () => {
-    vi.mocked(useAntennaStore).mockImplementation((selector: (s: unknown) => unknown) => {
-      const state = {
+    mockAntennaStore({
         theme: 'dark',
         transformerEnabled: false,
         terminatingResistor: 500, // Non-zero terminating resistor
         vAngle: 120,
         legSlope: 0,
         frequency: 14.1,
-      };
-      return selector(state);
-    });
+      });
 
     const { container } = render(
       <AntennaWire
@@ -90,6 +88,10 @@ describe('AntennaWire', () => {
         length={20}
         height={10}
         orientation="EW"
+        vAngle={120}
+        legSlope={0}
+        frequency={14.1}
+        foldedDipoleAperture={0.1}
         wireRadius={0.001}
         segments={21}
         feedlineId="none"
@@ -105,17 +107,14 @@ describe('AntennaWire', () => {
   });
 
   it('renders a feedline shield and transformer', () => {
-    vi.mocked(useAntennaStore).mockImplementation((selector: (s: unknown) => unknown) => {
-      const state = {
+    mockAntennaStore({
         theme: 'dark',
         transformerEnabled: true,
         terminatingResistor: 0,
         vAngle: 120,
         legSlope: 0,
         frequency: 14.1,
-      };
-      return selector(state);
-    });
+      });
 
     const { container } = render(
       <AntennaWire
@@ -123,6 +122,10 @@ describe('AntennaWire', () => {
         length={10}
         height={5}
         orientation="EW"
+        vAngle={120}
+        legSlope={0}
+        frequency={14.1}
+        foldedDipoleAperture={0.1}
         wireRadius={0.001}
         segments={11}
         feedlineId="rg58" // Use a real feedlineId to enable shield

--- a/tests/App.test.tsx
+++ b/tests/App.test.tsx
@@ -127,7 +127,7 @@ describe('App', () => {
             groundId: 'pastoral',
             result: { maxGainDbi: 2.15, swr: 1.5, impedance: { r: 50, x: 0 }, efficiency: 100 },
             sweep: []
-        } as unknown as import('../src/physics/types').SimulationSnapshot
+        } as unknown as import('../src/store/antennaStore').ComparisonSnapshot
       });
       render(<App />);
 

--- a/tests/ColormapLegend.test.tsx
+++ b/tests/ColormapLegend.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, afterEach } from 'vitest';
 import { render, screen, cleanup } from '@testing-library/react';
 import { ColormapLegend } from '../src/components/Scene/ColormapLegend';
 import { useAntennaStore } from '../src/store/antennaStore';
-import type { SimulationResult } from '../src/physics/types';
+import { makeSimulationResult } from './helpers/factories';
 
 describe('ColormapLegend', () => {
   const originalState = useAntennaStore.getState();
@@ -12,25 +12,13 @@ describe('ColormapLegend', () => {
     useAntennaStore.setState(originalState, true);
   });
 
-  const mockResult: SimulationResult = {
-    pattern: {
-      powerMax: 10,
-      thetas: new Float32Array(),
-      phis: new Float32Array(),
-      powers: new Float32Array(),
-    },
+  const mockResult = makeSimulationResult({
     maxGainDbi: 5,
     takeoffElevationDeg: 45,
     takeoffAzimuthDeg: 90,
-    impedance: {
-      r: 50,
-      x: 0,
-      magnitude: 50,
-      phaseDeg: 0,
-    },
     swr: 1.0,
     efficiency: 1.0,
-  };
+  });
 
   it('renders nothing when result is null', () => {
     const { container } = render(<ColormapLegend result={null} />);

--- a/tests/ComparisonControl.test.tsx
+++ b/tests/ComparisonControl.test.tsx
@@ -1,7 +1,8 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, cleanup } from '@testing-library/react';
 import { ComparisonControl } from '../src/components/Panel/ComparisonControl';
-import { useAntennaStore } from '../src/store/antennaStore';
+import { mockAntennaStore } from './helpers/mockStore';
+import { makeComparisonSnapshot, makeSimulationResult } from './helpers/factories';
 
 // Mock the store
 vi.mock('../src/store/antennaStore', async () => {
@@ -19,26 +20,22 @@ describe('ComparisonControl', () => {
   });
 
   it('renders nothing when mode is not comparison', () => {
-    vi.mocked(useAntennaStore).mockImplementation((selector: (s: unknown) => unknown) => {
-      const state = {
-        mode: 'standard',
+    mockAntennaStore({
+        mode: 'normal',
         units: 'metric',
         result: null,
         sweep: [],
         comparisonReference: null,
         captureComparisonReference: vi.fn(),
         clearComparisonReference: vi.fn(),
-      };
-      return selector(state);
-    });
+      });
 
     const { container } = render(<ComparisonControl />);
     expect(container.firstChild).toBeNull();
   });
 
   it('renders buttons but disabled when no result available', () => {
-    vi.mocked(useAntennaStore).mockImplementation((selector: (s: unknown) => unknown) => {
-      const state = {
+    mockAntennaStore({
         mode: 'comparison',
         units: 'metric',
         result: null,
@@ -46,9 +43,7 @@ describe('ComparisonControl', () => {
         comparisonReference: null,
         captureComparisonReference: vi.fn(),
         clearComparisonReference: vi.fn(),
-      };
-      return selector(state);
-    });
+      });
 
     render(<ComparisonControl />);
 
@@ -65,18 +60,15 @@ describe('ComparisonControl', () => {
 
   it('enables capture button when result is available', () => {
     const captureComparisonReference = vi.fn();
-    vi.mocked(useAntennaStore).mockImplementation((selector: (s: unknown) => unknown) => {
-      const state = {
+    mockAntennaStore({
         mode: 'comparison',
         units: 'metric',
-        result: { maxGainDbi: 2.15, swr: 1.5 },
-        sweep: [ { frequency: 14.1, swr: 1.5, impedance: { real: 50, imag: 0 } } ],
+        result: makeSimulationResult({ maxGainDbi: 2.15, swr: 1.5 }),
+        sweep: [{ frequencyMHz: 14.1, swr: 1.5, R: 50, X: 0 }],
         comparisonReference: null,
         captureComparisonReference,
         clearComparisonReference: vi.fn(),
-      };
-      return selector(state);
-    });
+      });
 
     render(<ComparisonControl />);
 
@@ -89,26 +81,23 @@ describe('ComparisonControl', () => {
 
   it('displays reference and enables clear button when reference is captured', () => {
     const clearComparisonReference = vi.fn();
-    vi.mocked(useAntennaStore).mockImplementation((selector: (s: unknown) => unknown) => {
-      const state = {
+    mockAntennaStore({
         mode: 'comparison',
         units: 'metric',
-        result: { maxGainDbi: 2.15, swr: 1.5 },
-        sweep: [ { frequency: 14.1, swr: 1.5, impedance: { real: 50, imag: 0 } } ],
-        comparisonReference: {
+        result: makeSimulationResult({ maxGainDbi: 2.15, swr: 1.5 }),
+        sweep: [{ frequencyMHz: 14.1, swr: 1.5, R: 50, X: 0 }],
+        comparisonReference: makeComparisonSnapshot({
           capturedAt: 1680000000000,
           frequency: 14.1,
           length: 10,
           height: 5,
           orientation: 'NS',
           groundId: 'pastoral',
-          result: { maxGainDbi: 2.15, swr: 1.5 },
-        },
+          result: makeSimulationResult({ maxGainDbi: 2.15, swr: 1.5 }),
+        }),
         captureComparisonReference: vi.fn(),
         clearComparisonReference,
-      };
-      return selector(state);
-    });
+      });
 
     render(<ComparisonControl />);
 
@@ -126,26 +115,23 @@ describe('ComparisonControl', () => {
   });
 
   it('displays custom ground correctly', () => {
-    vi.mocked(useAntennaStore).mockImplementation((selector: (s: unknown) => unknown) => {
-      const state = {
+    mockAntennaStore({
         mode: 'comparison',
         units: 'metric',
         result: null,
         sweep: [],
-        comparisonReference: {
+        comparisonReference: makeComparisonSnapshot({
           capturedAt: 1680000000000,
           frequency: 14.1,
           length: 10,
           height: 5,
           orientation: 45,
           groundId: 'custom',
-          result: { maxGainDbi: 2.15, swr: 1.5 },
-        },
+          result: makeSimulationResult({ maxGainDbi: 2.15, swr: 1.5 }),
+        }),
         captureComparisonReference: vi.fn(),
         clearComparisonReference: vi.fn(),
-      };
-      return selector(state);
-    });
+      });
 
     render(<ComparisonControl />);
     expect(screen.getByText('Custom')).toBeTruthy();

--- a/tests/GeometryControl.test.tsx
+++ b/tests/GeometryControl.test.tsx
@@ -1,13 +1,7 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, cleanup } from '@testing-library/react';
 import { GeometryControl } from '../src/components/Panel/GeometryControl';
-import { useAntennaStore } from '../src/store/antennaStore';
-
-function mockStore(state: MockState) {
-  vi.mocked(useAntennaStore).mockImplementation((selector: (s: MockState) => unknown) =>
-    selector(state),
-  );
-}
+import { mockAntennaStore, type MockAntennaState } from './helpers/mockStore';
 
 // Mock the store
 vi.mock('../src/store/antennaStore', async () => {
@@ -18,33 +12,7 @@ vi.mock('../src/store/antennaStore', async () => {
   };
 });
 
-interface MockState {
-  units: string;
-  antennaType: string;
-  length: number;
-  height: number;
-  frequency: number;
-  orientation: string | number;
-  vAngle: number;
-  foldedDipoleAperture: number;
-  wireRadius: number;
-  terminatingResistor: number;
-  whipCounterpoise: boolean;
-  transformerEnabled: boolean;
-  transformerRatio: number;
-  setAntennaType: () => void;
-  setLength: () => void;
-  setHalfWaveLength: () => void;
-  setLegLengthMultiple: () => void;
-  setHeight: () => void;
-  setOrientation: (o: string | number) => void;
-  setVAngle: () => void;
-  setFoldedDipoleAperture: (a: number) => void;
-  setWhipCounterpoise: (w: boolean) => void;
-  setTerminatingResistor: () => void;
-  setTransformerEnabled: () => void;
-  setTransformerRatio: () => void;
-}
+type MockState = MockAntennaState;
 
 function buildMockState(overrides: Partial<MockState> = {}): MockState {
   return {
@@ -80,13 +48,11 @@ function buildMockState(overrides: Partial<MockState> = {}): MockState {
 describe('GeometryControl', () => {
   it('updates V angle when input changes', () => {
     const setVAngle = vi.fn();
-    vi.mocked(useAntennaStore).mockImplementation((selector: (s: MockState) => unknown) => {
-      return selector(buildMockState({
+    mockAntennaStore(buildMockState({
         antennaType: 'sloping-v',
         vAngle: 120,
         setVAngle
       }));
-    });
 
     render(<GeometryControl />);
 
@@ -98,13 +64,11 @@ describe('GeometryControl', () => {
 
   it('toggles whip counterpoise when antenna is vertical-whip', () => {
     const setWhipCounterpoise = vi.fn();
-    vi.mocked(useAntennaStore).mockImplementation((selector: (s: MockState) => unknown) => {
-      return selector(buildMockState({
+    mockAntennaStore(buildMockState({
         antennaType: 'vertical-whip',
         whipCounterpoise: false,
         setWhipCounterpoise
       }));
-    });
 
     render(<GeometryControl />);
 
@@ -116,13 +80,11 @@ describe('GeometryControl', () => {
 
   it('updates aperture when antenna is folded-dipole', () => {
     const setFoldedDipoleAperture = vi.fn();
-    vi.mocked(useAntennaStore).mockImplementation((selector: (s: MockState) => unknown) => {
-      return selector(buildMockState({
+    mockAntennaStore(buildMockState({
         antennaType: 'folded-dipole',
         foldedDipoleAperture: 0.1,
         setFoldedDipoleAperture
       }));
-    });
 
     render(<GeometryControl />);
 
@@ -139,9 +101,7 @@ describe('GeometryControl', () => {
 
   it('updates orientation when numeric input changes', () => {
     const setOrientation = vi.fn();
-    vi.mocked(useAntennaStore).mockImplementation((selector: (s: MockState) => unknown) => {
-      return selector(buildMockState({ setOrientation }));
-    });
+    mockAntennaStore(buildMockState({ setOrientation }));
 
     render(<GeometryControl />);
 
@@ -153,9 +113,7 @@ describe('GeometryControl', () => {
 
   it('updates orientation when preset buttons are clicked', () => {
     const setOrientation = vi.fn();
-    vi.mocked(useAntennaStore).mockImplementation((selector: (s: MockState) => unknown) => {
-      return selector(buildMockState({ setOrientation }));
-    });
+    mockAntennaStore(buildMockState({ setOrientation }));
 
     render(<GeometryControl />);
 
@@ -166,9 +124,7 @@ describe('GeometryControl', () => {
   });
 
   it('embeds the transformer subsection inside the Antenna panel', () => {
-    vi.mocked(useAntennaStore).mockImplementation((selector: (s: MockState) => unknown) => {
-      return selector(buildMockState());
-    });
+    mockAntennaStore(buildMockState());
 
     render(<GeometryControl />);
 
@@ -182,9 +138,7 @@ describe('GeometryControl', () => {
 
   it('updates antenna type when changed', () => {
     const setAntennaType = vi.fn();
-    vi.mocked(useAntennaStore).mockImplementation((selector: (s: MockState) => unknown) => {
-      return selector(buildMockState({ setAntennaType }));
-    });
+    mockAntennaStore(buildMockState({ setAntennaType }));
 
     render(<GeometryControl />);
 
@@ -196,13 +150,11 @@ describe('GeometryControl', () => {
 
   it('updates terminating resistor when input changes', () => {
     const setTerminatingResistor = vi.fn();
-    vi.mocked(useAntennaStore).mockImplementation((selector: (s: MockState) => unknown) => {
-      return selector(buildMockState({
+    mockAntennaStore(buildMockState({
         antennaType: 'terminated-delta',
         terminatingResistor: 0,
         setTerminatingResistor
       }));
-    });
 
     render(<GeometryControl />);
 
@@ -214,12 +166,10 @@ describe('GeometryControl', () => {
 
   it('updates inverted-l orientation when input changes', () => {
     const setOrientation = vi.fn();
-    vi.mocked(useAntennaStore).mockImplementation((selector: (s: MockState) => unknown) => {
-      return selector(buildMockState({
+    mockAntennaStore(buildMockState({
         antennaType: 'inverted-l',
         setOrientation
       }));
-    });
 
     render(<GeometryControl />);
 
@@ -231,7 +181,7 @@ describe('GeometryControl', () => {
 
   it('updates length and resets the local value on blur', () => {
     const setLength = vi.fn();
-    mockStore(buildMockState({ length: 20, setLength }));
+    mockAntennaStore(buildMockState({ length: 20, setLength }));
 
     render(<GeometryControl />);
 
@@ -250,7 +200,7 @@ describe('GeometryControl', () => {
 
   it('ignores non-numeric length input', () => {
     const setLength = vi.fn();
-    mockStore(buildMockState({ setLength }));
+    mockAntennaStore(buildMockState({ setLength }));
 
     render(<GeometryControl />);
 
@@ -262,7 +212,7 @@ describe('GeometryControl', () => {
 
   it('resonates the antenna to ½λ when the resonate button is clicked', () => {
     const setHalfWaveLength = vi.fn();
-    mockStore(buildMockState({ antennaType: 'dipole', setHalfWaveLength }));
+    mockAntennaStore(buildMockState({ antennaType: 'dipole', setHalfWaveLength }));
 
     render(<GeometryControl />);
 
@@ -274,7 +224,7 @@ describe('GeometryControl', () => {
 
   it('applies the 1.25λ Extended Double Zepp preset for a dipole', () => {
     const setLength = vi.fn();
-    mockStore(buildMockState({ antennaType: 'dipole', frequency: 7.1, setLength }));
+    mockAntennaStore(buildMockState({ antennaType: 'dipole', frequency: 7.1, setLength }));
 
     render(<GeometryControl />);
 
@@ -287,7 +237,7 @@ describe('GeometryControl', () => {
 
   it('sets the leg-length multiple for a sloping-v', () => {
     const setLegLengthMultiple = vi.fn();
-    mockStore(buildMockState({ antennaType: 'sloping-v', setLegLengthMultiple }));
+    mockAntennaStore(buildMockState({ antennaType: 'sloping-v', setLegLengthMultiple }));
 
     render(<GeometryControl />);
 
@@ -299,7 +249,7 @@ describe('GeometryControl', () => {
 
   it('updates height when the slider changes', () => {
     const setHeight = vi.fn();
-    mockStore(buildMockState({ setHeight }));
+    mockAntennaStore(buildMockState({ setHeight }));
 
     render(<GeometryControl />);
 
@@ -311,7 +261,7 @@ describe('GeometryControl', () => {
 
   it('sets the terminating resistor to Z₀ for a folded dipole', () => {
     const setTerminatingResistor = vi.fn();
-    mockStore(buildMockState({
+    mockAntennaStore(buildMockState({
       antennaType: 'folded-dipole',
       foldedDipoleAperture: 0.1,
       wireRadius: 0.001,
@@ -331,7 +281,7 @@ describe('GeometryControl', () => {
 
   it('turns the termination off and resets the resistor field on blur', () => {
     const setTerminatingResistor = vi.fn();
-    mockStore(buildMockState({
+    mockAntennaStore(buildMockState({
       antennaType: 'terminated-delta',
       terminatingResistor: 600,
       setTerminatingResistor,
@@ -353,7 +303,7 @@ describe('GeometryControl', () => {
   });
 
   it('renders the counterpoise-enabled hint for a vertical whip', () => {
-    mockStore(buildMockState({ antennaType: 'vertical-whip', whipCounterpoise: true }));
+    mockAntennaStore(buildMockState({ antennaType: 'vertical-whip', whipCounterpoise: true }));
 
     render(<GeometryControl />);
 
@@ -364,7 +314,7 @@ describe('GeometryControl', () => {
 
   it('selects an inverted-l horizontal direction preset', () => {
     const setOrientation = vi.fn();
-    mockStore(buildMockState({ antennaType: 'inverted-l', setOrientation }));
+    mockAntennaStore(buildMockState({ antennaType: 'inverted-l', setOrientation }));
 
     render(<GeometryControl />);
 
@@ -377,7 +327,7 @@ describe('GeometryControl', () => {
   });
 
   it('reconciles the length field when the store value changes while unfocused', () => {
-    mockStore(buildMockState({ length: 20 }));
+    mockAntennaStore(buildMockState({ length: 20 }));
 
     const { rerender } = render(<GeometryControl />);
     const lengthInput = document.getElementById('dipole-length') as HTMLInputElement;
@@ -385,7 +335,7 @@ describe('GeometryControl', () => {
 
     // External store update (e.g. a resonate click elsewhere) should flow into
     // the controlled input because the field is not focused.
-    mockStore(buildMockState({ length: 42 }));
+    mockAntennaStore(buildMockState({ length: 42 }));
     rerender(<GeometryControl />);
 
     expect(lengthInput.value).toBe('42.00');

--- a/tests/GroundControl.test.tsx
+++ b/tests/GroundControl.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, cleanup } from '@testing-library/react';
 import { GroundControl } from '../src/components/Panel/GroundControl';
-import { useAntennaStore } from '../src/store/antennaStore';
+import { mockAntennaStore, type MockAntennaState } from './helpers/mockStore';
 
 // Mock the store
 vi.mock('../src/store/antennaStore', async () => {
@@ -12,13 +12,7 @@ vi.mock('../src/store/antennaStore', async () => {
   };
 });
 
-interface MockState {
-  groundId: string;
-  groundSigma: number;
-  groundEpsilon: number;
-  setGround: (id: string) => void;
-  setCustomGround: (sigma: number, epsilon: number) => void;
-}
+type MockState = MockAntennaState;
 
 function mockGround(overrides: Partial<MockState> = {}) {
   const state: MockState = {
@@ -29,9 +23,7 @@ function mockGround(overrides: Partial<MockState> = {}) {
     setCustomGround: vi.fn(),
     ...overrides,
   };
-  vi.mocked(useAntennaStore).mockImplementation((selector: (s: MockState) => unknown) =>
-    selector(state),
-  );
+  mockAntennaStore(state);
   return state;
 }
 
@@ -43,16 +35,13 @@ describe('GroundControl', () => {
 
   it('updates groundId when selection changes', () => {
     const setGround = vi.fn();
-    vi.mocked(useAntennaStore).mockImplementation((selector: (s: MockState) => unknown) => {
-      const state: MockState = {
+    mockAntennaStore({
         groundId: 'pastoral',
         groundSigma: 0.005,
         groundEpsilon: 13,
         setGround,
         setCustomGround: vi.fn(),
-      };
-      return selector(state);
-    });
+      });
 
     render(<GroundControl />);
 
@@ -64,16 +53,13 @@ describe('GroundControl', () => {
 
   it('shows custom inputs and updates them when custom is selected', () => {
     const setCustomGround = vi.fn();
-    vi.mocked(useAntennaStore).mockImplementation((selector: (s: MockState) => unknown) => {
-      const state: MockState = {
+    mockAntennaStore({
         groundId: 'custom',
         groundSigma: 0.005,
         groundEpsilon: 13,
         setGround: vi.fn(),
         setCustomGround,
-      };
-      return selector(state);
-    });
+      });
 
     render(<GroundControl />);
 
@@ -87,16 +73,13 @@ describe('GroundControl', () => {
   });
 
   it('shows custom inputs when expanded button is clicked', () => {
-    vi.mocked(useAntennaStore).mockImplementation((selector: (s: MockState) => unknown) => {
-      const state: MockState = {
+    mockAntennaStore({
         groundId: 'pastoral',
         groundSigma: 0.005,
         groundEpsilon: 13,
         setGround: vi.fn(),
         setCustomGround: vi.fn(),
-      };
-      return selector(state);
-    });
+      });
 
     render(<GroundControl />);
 

--- a/tests/GroundPlane.test.tsx
+++ b/tests/GroundPlane.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { render, cleanup } from '@testing-library/react';
 import { GroundPlane } from '../src/components/Scene/GroundPlane';
-import { useAntennaStore } from '../src/store/antennaStore';
+import { mockAntennaStore } from './helpers/mockStore';
 import React from 'react';
 
 // Mock the store
@@ -28,10 +28,7 @@ afterEach(() => {
 
 describe('GroundPlane', () => {
   it('renders correctly with grid visible', () => {
-    vi.mocked(useAntennaStore).mockImplementation((selector: (s: { theme: string, antennaType: string }) => unknown) => {
-      const state = { theme: 'light', antennaType: 'dipole' };
-      return selector(state);
-    });
+    mockAntennaStore({ theme: 'light', antennaType: 'dipole' });
 
     const { container, getByTestId } = render(<GroundPlane groundId="pastoral" height={10} showGrid={true} antennaType="dipole" />);
 
@@ -46,50 +43,35 @@ describe('GroundPlane', () => {
   });
 
   it('renders nothing when height <= 0 and antenna is not vertical-whip', () => {
-    vi.mocked(useAntennaStore).mockImplementation((selector: (s: { theme: string, antennaType: string }) => unknown) => {
-      const state = { theme: 'light', antennaType: 'dipole' };
-      return selector(state);
-    });
+    mockAntennaStore({ theme: 'light', antennaType: 'dipole' });
 
     const { container } = render(<GroundPlane groundId="pastoral" height={0} showGrid={true} antennaType="dipole" />);
     expect(container.innerHTML).toBe('');
   });
 
   it('renders when height <= 0 and antenna IS vertical-whip', () => {
-    vi.mocked(useAntennaStore).mockImplementation((selector: (s: { theme: string, antennaType: string }) => unknown) => {
-      const state = { theme: 'light', antennaType: 'vertical-whip' };
-      return selector(state);
-    });
+    mockAntennaStore({ theme: 'light', antennaType: 'vertical-whip' });
 
     const { container } = render(<GroundPlane groundId="pastoral" height={0} showGrid={true} antennaType="vertical-whip" />);
     expect(container.innerHTML).not.toBe('');
   });
 
   it('renders when height <= 0 and antenna IS inverted-l', () => {
-    vi.mocked(useAntennaStore).mockImplementation((selector: (s: { theme: string }) => unknown) => {
-      const state = { theme: 'light' };
-      return selector(state);
-    });
+    mockAntennaStore({ theme: 'light' });
 
     const { container } = render(<GroundPlane groundId="pastoral" height={0} showGrid={true} antennaType="inverted-l" />);
     expect(container.innerHTML).not.toBe('');
   });
 
   it('renders nothing when groundId is "free"', () => {
-    vi.mocked(useAntennaStore).mockImplementation((selector: (s: { theme: string, antennaType: string }) => unknown) => {
-      const state = { theme: 'light', antennaType: 'dipole' };
-      return selector(state);
-    });
+    mockAntennaStore({ theme: 'light', antennaType: 'dipole' });
 
     const { container } = render(<GroundPlane groundId="free" height={10} showGrid={true} antennaType="dipole" />);
     expect(container.innerHTML).toBe('');
   });
 
   it('does not render grid when showGrid is false', () => {
-    vi.mocked(useAntennaStore).mockImplementation((selector: (s: { theme: string, antennaType: string }) => unknown) => {
-      const state = { theme: 'light', antennaType: 'dipole' };
-      return selector(state);
-    });
+    mockAntennaStore({ theme: 'light', antennaType: 'dipole' });
 
     const { container, queryByTestId } = render(<GroundPlane groundId="pastoral" height={10} showGrid={false} antennaType="dipole" />);
     expect(container.innerHTML).not.toBe('');

--- a/tests/PolarPlots.test.tsx
+++ b/tests/PolarPlots.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it, beforeEach, vi } from 'vitest';
 import { render, cleanup } from '@testing-library/react';
 import { PolarPlots } from '../src/components/Charts/PolarPlots';
 import { useAntennaStore } from '../src/store/antennaStore';
+import { makeSimulationResult } from './helpers/factories';
 
 const { tickCbs } = vi.hoisted(() => ({ tickCbs: [] as Array<(v: number) => string> }));
 
@@ -27,7 +28,7 @@ describe('PolarPlots', () => {
       orientation: 'NS',
       dbRange: 40,
       theme: 'light',
-      result: {
+      result: makeSimulationResult({
         swr: 1.5,
         computeTimeMs: 10,
         impedance: { R: 50, X: 0 },
@@ -41,7 +42,7 @@ describe('PolarPlots', () => {
           dTheta: 1,
           dPhi: 5,
         },
-      },
+      }),
     });
   });
 
@@ -98,7 +99,7 @@ describe('PolarPlots', () => {
       dbRange: 40,
       transformerEnabled: false,
       feedlineId: 'none',
-      result: {
+      result: makeSimulationResult({
         swr: 60.89,
         computeTimeMs: 10,
         impedance: { R: 1.7, X: 50.9 },
@@ -107,7 +108,7 @@ describe('PolarPlots', () => {
         takeoffElevationDeg: 90,
         takeoffAzimuthDeg: 0,
         pattern: { data: new Float32Array(0), thetaSteps: 91, phiSteps: 72, dTheta: 1, dPhi: 5 },
-      } as unknown as import('../src/physics/types').SimulationResult,
+      }),
     });
     render(<PolarPlots />);
     // val = dbRange maps to the outer ring; it should read the realized peak.
@@ -121,7 +122,7 @@ describe('PolarPlots', () => {
       dbRange: 40,
       transformerEnabled: false,
       feedlineId: 'none',
-      result: {
+      result: makeSimulationResult({
         swr: 1.5,
         computeTimeMs: 10,
         impedance: { R: 50, X: 0 },
@@ -130,7 +131,7 @@ describe('PolarPlots', () => {
         takeoffElevationDeg: 30,
         takeoffAzimuthDeg: 0,
         pattern: { data: new Float32Array(0), thetaSteps: 91, phiSteps: 72, dTheta: 1, dPhi: 5 },
-      } as unknown as import('../src/physics/types').SimulationResult,
+      }),
     });
     render(<PolarPlots />);
     expect(tickCbs[0]!(40)).toBe('6 dBi');

--- a/tests/PropagationControl.test.tsx
+++ b/tests/PropagationControl.test.tsx
@@ -1,8 +1,7 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, cleanup } from '@testing-library/react';
 import { PropagationControl } from '../src/components/Panel/PropagationControl';
-import { useAntennaStore } from '../src/store/antennaStore';
-import type { SimulationResult } from '../src/physics/types';
+import { mockAntennaStore, type MockAntennaState } from './helpers/mockStore';
 
 // Mock the store
 vi.mock('../src/store/antennaStore', async () => {
@@ -18,21 +17,7 @@ vi.mock('../src/components/Charts/PropagationRadar', () => ({
   PropagationRadar: () => <div data-testid="propagation-radar" />,
 }));
 
-interface MockState {
-  frequency: number;
-  tIndex: number;
-  latitudeDeg: number | null;
-  longitudeDeg: number | null;
-  monthOverride: number | null;
-  utcHourOverride: number | null;
-  units: 'metric' | 'imperial';
-  result: SimulationResult | null;
-  setTIndex: (v: number) => void;
-  setLatitude: (v: number | null) => void;
-  setMonthOverride: (v: number | null) => void;
-  setUtcHourOverride: (v: number | null) => void;
-  geolocationStatus: string;
-}
+type MockState = MockAntennaState;
 
 describe('PropagationControl - time override visibility', () => {
   const mockSetMonthOverride = vi.fn();
@@ -44,8 +29,7 @@ describe('PropagationControl - time override visibility', () => {
   });
 
   const setupMockStore = (overrides: Partial<MockState> = {}) => {
-    vi.mocked(useAntennaStore).mockImplementation((selector: (s: MockState) => unknown) => {
-      const state: MockState = {
+    mockAntennaStore({
         frequency: 7.1,
         tIndex: 30,
         latitudeDeg: null,
@@ -60,9 +44,7 @@ describe('PropagationControl - time override visibility', () => {
         setUtcHourOverride: mockSetUtcHourOverride,
         geolocationStatus: 'idle',
         ...overrides,
-      };
-      return selector(state);
-    });
+      });
   };
 
   it('renders Month and UTC Hour inputs by default', () => {
@@ -166,8 +148,7 @@ describe('PropagationControl - T-index Input Bug', () => {
     const setTIndex = vi.fn();
     let currentTIndex = 30;
 
-    vi.mocked(useAntennaStore).mockImplementation((selector: (s: MockState) => unknown) => {
-      const state: MockState = {
+    mockAntennaStore(() => ({
         frequency: 7.1,
         tIndex: currentTIndex,
         setTIndex: (v: number) => {
@@ -184,9 +165,7 @@ describe('PropagationControl - T-index Input Bug', () => {
         result: null,
         units: 'metric',
         geolocationStatus: 'idle',
-      };
-      return selector(state);
-    });
+      }));
 
     const { getByLabelText } = render(<PropagationControl />);
     const tInput = getByLabelText('Ionospheric T-index') as HTMLInputElement;
@@ -211,8 +190,7 @@ describe('PropagationControl - T-index Input Bug', () => {
     const setTIndex = vi.fn();
     let currentTIndex = 30;
 
-    vi.mocked(useAntennaStore).mockImplementation((selector: (s: MockState) => unknown) => {
-      const state: MockState = {
+    mockAntennaStore(() => ({
         frequency: 7.1,
         tIndex: currentTIndex,
         setTIndex,
@@ -226,9 +204,7 @@ describe('PropagationControl - T-index Input Bug', () => {
         result: null,
         units: 'metric',
         geolocationStatus: 'idle',
-      };
-      return selector(state);
-    });
+      }));
 
     const { getByLabelText, rerender } = render(<PropagationControl />);
     const tInput = getByLabelText('Ionospheric T-index') as HTMLInputElement;

--- a/tests/PropagationRadar.test.tsx
+++ b/tests/PropagationRadar.test.tsx
@@ -2,35 +2,32 @@ import { render, screen } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 import { PropagationRadar } from '../src/components/Charts/PropagationRadar';
 import type { PropagationPrediction } from '../src/physics/propagation';
+import { makeAzimuthalHop, makeHop, makePropagationPrediction } from './helpers/factories';
 
 describe('PropagationRadar', () => {
   it('renders radar with rings', () => {
-    const prediction: PropagationPrediction = {
-      mode: 'skywave',
-      criticalFreqMhz: 10,
+    const prediction: PropagationPrediction = makePropagationPrediction({
       hops: [
-        { n: 1, rangeKm: 1000, status: 'open', linkQuality: 'useful' },
-        { n: 2, rangeKm: 2000, status: 'marginal', linkQuality: 'weak' },
+        makeHop({ n: 1, rangeKm: 1000, status: 'open', linkQuality: 'useful' }),
+        makeHop({ n: 2, rangeKm: 2000, status: 'marginal', linkQuality: 'weak' }),
       ],
-    };
+    });
     render(<PropagationRadar prediction={prediction} units="metric" size={300} />);
     expect(screen.getByRole('img', { name: /radar plot/i })).toBeTruthy();
   });
 
   it('renders azimuthal hop wedges', () => {
-    const prediction: PropagationPrediction = {
-      mode: 'skywave',
-      criticalFreqMhz: 10,
+    const prediction: PropagationPrediction = makePropagationPrediction({
       hops: [
-        { n: 1, rangeKm: 1000, status: 'open', linkQuality: 'useful' },
+        makeHop({ n: 1, rangeKm: 1000, status: 'open', linkQuality: 'useful' }),
       ],
       azimuthalHops: [
-        { phiDeg: 0, rangeKm: [1000], status: 'open', linkQuality: 'useful' },
-        { phiDeg: 90, rangeKm: [1000], status: 'marginal', linkQuality: 'weak' },
-        { phiDeg: 180, rangeKm: [1000], status: 'open', linkQuality: 'useful' },
-        { phiDeg: 270, rangeKm: [1000], status: 'closed', linkQuality: 'unusable' },
+        makeAzimuthalHop({ phiDeg: 0, rangeKm: [1000], status: 'open', linkQuality: 'useful' }),
+        makeAzimuthalHop({ phiDeg: 90, rangeKm: [1000], status: 'marginal', linkQuality: 'weak' }),
+        makeAzimuthalHop({ phiDeg: 180, rangeKm: [1000], status: 'open', linkQuality: 'useful' }),
+        makeAzimuthalHop({ phiDeg: 270, rangeKm: [1000], status: 'closed', linkQuality: 'unusable' }),
       ],
-    };
+    });
     const { container } = render(<PropagationRadar prediction={prediction} units="metric" size={300} />);
     // Look for wedges
     const polygons = container.querySelectorAll('polygon');

--- a/tests/SWRChart.test.tsx
+++ b/tests/SWRChart.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, cleanup, fireEvent } from '@testing-library/react';
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { SWRChart } from '../src/components/Charts/SWRChart';
 import { useAntennaStore } from '../src/store/antennaStore';
+import { makeSimulationResult } from './helpers/factories';
 
 // Mock chart.js so canvas rendering doesn't crash jsdom
 vi.mock('react-chartjs-2', () => ({
@@ -29,7 +30,7 @@ describe('SWRChart', () => {
         { frequencyMHz: 14.0, R: 50, X: 0, swr: 1 },
         { frequencyMHz: 14.2, R: 50, X: 0, swr: 1 },
       ],
-      result: { R: 50, X: 0, swr: 1, gainMax: 0, efficiency: 1, maxGainElevation: 0, maxGainAzimuth: 0 },
+      result: makeSimulationResult({ swr: 1, maxGainDbi: 0, efficiency: 1 }),
     });
     render(<SWRChart />);
     expect(screen.getAllByTestId('mock-line-chart')[0]).toBeDefined();
@@ -43,7 +44,7 @@ describe('SWRChart', () => {
         { frequencyMHz: 14.1, R: 50, X: 0, swr: 1.1 },
         { frequencyMHz: 14.2, R: 50, X: 0, swr: 1.5 },
       ],
-      result: { R: 50, X: 0, swr: 1.1, gainMax: 0, efficiency: 1, maxGainElevation: 0, maxGainAzimuth: 0 },
+      result: makeSimulationResult({ swr: 1.1, maxGainDbi: 0, efficiency: 1 }),
     });
     render(<SWRChart />);
 
@@ -60,7 +61,7 @@ describe('SWRChart', () => {
         { frequencyMHz: 14.1, R: 50, X: 0, swr: 2.5 },
         { frequencyMHz: 14.2, R: 50, X: 0, swr: 3.0 },
       ],
-      result: { R: 50, X: 0, swr: 2.5, gainMax: 0, efficiency: 1, maxGainElevation: 0, maxGainAzimuth: 0 },
+      result: makeSimulationResult({ swr: 2.5, maxGainDbi: 0, efficiency: 1 }),
     });
     render(<SWRChart />);
 
@@ -77,7 +78,7 @@ describe('SWRChart', () => {
         { frequencyMHz: 14.0, R: 50, X: 0, swr: 1 },
         { frequencyMHz: 14.2, R: 50, X: 0, swr: 1 },
       ],
-      result: { R: 50, X: 0, swr: 1, gainMax: 0, efficiency: 1, maxGainElevation: 0, maxGainAzimuth: 0 },
+      result: makeSimulationResult({ swr: 1, maxGainDbi: 0, efficiency: 1 }),
       zoomSwrView: zoomSwrViewMock,
       panSwrView: panSwrViewMock,
       resetSwrView: resetSwrViewMock,
@@ -114,7 +115,7 @@ describe('SWRChart', () => {
         { frequencyMHz: 14.0, R: 50, X: 0, swr: 1 },
         { frequencyMHz: 14.2, R: 50, X: 0, swr: 1 },
       ],
-      result: { R: 50, X: 0, swr: 1, gainMax: 0, efficiency: 1, maxGainElevation: 0, maxGainAzimuth: 0 },
+      result: makeSimulationResult({ swr: 1, maxGainDbi: 0, efficiency: 1 }),
       zoomSwrView: zoomSwrViewMock,
     });
 
@@ -136,7 +137,7 @@ describe('SWRChart', () => {
         { frequencyMHz: 14.0, R: 50, X: 0, swr: 1 },
         { frequencyMHz: 14.2, R: 50, X: 0, swr: 1 },
       ],
-      result: { R: 50, X: 0, swr: 1, gainMax: 0, efficiency: 1, maxGainElevation: 0, maxGainAzimuth: 0 },
+      result: makeSimulationResult({ swr: 1, maxGainDbi: 0, efficiency: 1 }),
       panSwrViewByMHz: panSwrViewByMHzMock,
       swrViewSpanMHz: 0.2,
       swrViewCenterMHz: 14.1,

--- a/tests/TerminatedDeltaElement.test.tsx
+++ b/tests/TerminatedDeltaElement.test.tsx
@@ -39,7 +39,7 @@ describe('TerminatedDeltaElement', () => {
     const { container } = render(
       <TerminatedDeltaElement
         split={mockSplit}
-        theme="dark"
+        color="#e8e8e8"
         terminatingResistor={0}
       />
     );
@@ -55,7 +55,7 @@ describe('TerminatedDeltaElement', () => {
     const { container } = render(
       <TerminatedDeltaElement
         split={mockSplit}
-        theme="dark"
+        color="#e8e8e8"
         terminatingResistor={500}
       />
     );
@@ -71,7 +71,7 @@ describe('TerminatedDeltaElement', () => {
     const { container } = render(
       <TerminatedDeltaElement
         split={{ ...mockSplit, bridgeLen: 0.0001 }}
-        theme="dark"
+        color="#e8e8e8"
         terminatingResistor={500}
       />
     );

--- a/tests/antennaGeometry.test.ts
+++ b/tests/antennaGeometry.test.ts
@@ -622,7 +622,7 @@ describe('buildInvertedVWires', () => {
   const baseParams = {
     length: 20, // total length
     height: 10,
-    orientation: 'N' as const,
+    orientation: 'NS' as const,
     wireRadius: 0.001,
     segments: 51,
     frequency: 14.15,

--- a/tests/antennaStore.test.ts
+++ b/tests/antennaStore.test.ts
@@ -1144,7 +1144,7 @@ describe("antennaStore actions", () => {
     it("produces exactly 3 wires with distinct tags", () => {
       const wires = buildWires(baseState);
       expect(wires).toHaveLength(3);
-      const tags = wires.map((w) => w.tag).sort((a, b) => a - b);
+      const tags = wires.map((w) => w.tag!).sort((a, b) => a - b);
       expect(tags).toEqual([LEFT_LEG_TAG, RIGHT_LEG_TAG, DELTA_BASE_TAG]);
     });
 
@@ -1251,7 +1251,7 @@ describe("antennaStore actions", () => {
       const input = selectSimulationInput(state as AntennaState);
       // 5 wires: left leg (1), right leg (2), bridge (3), shield (4), base (6)
       expect(input.wires).toHaveLength(5);
-      const tags = input.wires.map((w) => w.tag).sort((a, b) => a - b);
+      const tags = input.wires.map((w) => w.tag!).sort((a, b) => a - b);
       expect(tags).toEqual([1, 2, 3, 4, 6]);
       // Excitation moves to shield bottom
       expect(input.excitation.wireTag).toBe(4);

--- a/tests/bandwidth.test.tsx
+++ b/tests/bandwidth.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it, beforeEach, vi } from 'vitest';
 import { render, cleanup } from '@testing-library/react';
 import { SWRChart } from '../src/components/Charts/SWRChart';
 import { useAntennaStore } from '../src/store/antennaStore';
+import { makeComparisonSnapshot, makeSimulationResult } from './helpers/factories';
 
 // Mock Chart.js to avoid canvas rendering issues in test environment
 vi.mock('react-chartjs-2', () => ({
@@ -17,7 +18,7 @@ describe('SWRChart Bandwidth Calculation', () => {
   beforeEach(() => {
     cleanup();
     useAntennaStore.setState({
-      result: {
+      result: makeSimulationResult({
         swr: 1.5,
         computeTimeMs: 10,
         impedance: { R: 50, X: 0 },
@@ -31,7 +32,7 @@ describe('SWRChart Bandwidth Calculation', () => {
           dTheta: 0,
           dPhi: 0,
         },
-      },
+      }),
       sweep: [],
       frequency: 7.1,
     });
@@ -87,7 +88,7 @@ describe('SWRChart Bandwidth Calculation', () => {
   it('renders correctly when comparison mode is active', () => {
     useAntennaStore.setState({
       mode: 'comparison',
-      comparisonReference: {
+      comparisonReference: makeComparisonSnapshot({
         sweep: [
           { frequencyMHz: 7.0, swr: 3.0, R: 50, X: 0 },
           { frequencyMHz: 7.1, swr: 1.5, R: 50, X: 0 }, // Below 2
@@ -95,7 +96,7 @@ describe('SWRChart Bandwidth Calculation', () => {
         ],
         antennaType: 'dipole',
         frequency: 7.1,
-        result: {
+        result: makeSimulationResult({
           swr: 1.5,
           computeTimeMs: 10,
           impedance: { R: 50, X: 0 },
@@ -109,8 +110,8 @@ describe('SWRChart Bandwidth Calculation', () => {
             dTheta: 0,
             dPhi: 0,
           },
-        },
-      },
+        }),
+      }),
       sweep: [
         { frequencyMHz: 7.0, swr: 50, R: 50, X: 0 },
         { frequencyMHz: 7.1, swr: 40, R: 50, X: 0 },

--- a/tests/components/Panel/Propagation/ConditionsReadout.test.tsx
+++ b/tests/components/Panel/Propagation/ConditionsReadout.test.tsx
@@ -2,23 +2,23 @@ import { describe, expect, it } from 'vitest';
 import { render, screen, fireEvent, cleanup } from '@testing-library/react';
 import { ConditionsReadout } from '../../../../src/components/Panel/Propagation/ConditionsReadout';
 import type { PropagationPrediction } from '../../../../src/physics/propagation';
+import { makeHop } from '../../../helpers/factories';
 
 describe('ConditionsReadout', () => {
   it('assigns correct colors based on hop status', () => {
     // Construct a mock prediction with all hop statuses
     const mockPrediction: PropagationPrediction = {
-      mode: 'skywave',
-      criticalFreqMhz: 5,
       foF2MHz: 5.5,
       hmF2Km: 300,
       mufMHz: 14.2,
       lufMHz: 3.5,
       selectedTakeoffElevationDeg: 15,
       mismatchLossDb: 0,
+      solarZenithDeg: 45,
       hops: [
-        { n: 1, rangeKm: 1000, status: 'open', linkQuality: 'useful', reason: 'Open path' },
-        { n: 2, rangeKm: 2000, status: 'marginal', linkQuality: 'weak', reason: 'Marginal path' },
-        { n: 3, rangeKm: 3000, status: 'closed', linkQuality: 'unusable', reason: 'Closed path' },
+        makeHop(makeHop({ reason: 'Open path' })),
+        makeHop({ n: 2, rangeKm: 2000, status: 'marginal', linkQuality: 'weak', reason: 'Marginal path' }),
+        makeHop({ n: 3, rangeKm: 3000, status: 'closed', linkQuality: 'unusable', reason: 'Closed path' }),
       ],
       azimuthalHops: []
     };
@@ -50,14 +50,13 @@ describe('ConditionsReadout', () => {
 
   it('renders "Computing antenna pattern..." when haveTakeoff is false', () => {
     const mockPrediction: PropagationPrediction = {
-      mode: 'skywave',
-      criticalFreqMhz: 5,
       foF2MHz: 5.5,
       hmF2Km: 300,
       mufMHz: 14.2,
       lufMHz: 3.5,
       selectedTakeoffElevationDeg: 15,
       mismatchLossDb: 0,
+      solarZenithDeg: 45,
       hops: [],
       azimuthalHops: []
     };
@@ -77,14 +76,13 @@ describe('ConditionsReadout', () => {
 
   it('toggles assumptions panel visibility', () => {
     const mockPrediction: PropagationPrediction = {
-      mode: 'skywave',
-      criticalFreqMhz: 5,
       foF2MHz: 5.5,
       hmF2Km: 300,
       mufMHz: 14.2,
       lufMHz: 3.5,
       selectedTakeoffElevationDeg: 15,
       mismatchLossDb: 0,
+      solarZenithDeg: 45,
       hops: [],
       azimuthalHops: []
     };
@@ -111,16 +109,15 @@ describe('ConditionsReadout', () => {
 
   it('displays ranges in km when units is metric', () => {
     const mockPrediction: PropagationPrediction = {
-      mode: 'skywave',
-      criticalFreqMhz: 5,
       foF2MHz: 5.5,
       hmF2Km: 300,
       mufMHz: 14.2,
       lufMHz: 3.5,
       selectedTakeoffElevationDeg: 15,
       mismatchLossDb: 0,
+      solarZenithDeg: 45,
       hops: [
-        { n: 1, rangeKm: 1000, status: 'open', linkQuality: 'useful', reason: 'Open path' },
+        makeHop(makeHop({ reason: 'Open path' })),
       ],
       azimuthalHops: []
     };
@@ -141,16 +138,15 @@ describe('ConditionsReadout', () => {
 
   it('displays ranges in miles when units is imperial', () => {
     const mockPrediction: PropagationPrediction = {
-      mode: 'skywave',
-      criticalFreqMhz: 5,
       foF2MHz: 5.5,
       hmF2Km: 300,
       mufMHz: 14.2,
       lufMHz: 3.5,
       selectedTakeoffElevationDeg: 15,
       mismatchLossDb: 0,
+      solarZenithDeg: 45,
       hops: [
-        { n: 1, rangeKm: 1609.344, status: 'open', linkQuality: 'useful', reason: 'Open path' },
+        makeHop({ rangeKm: 1609.344 }),
       ],
       azimuthalHops: []
     };

--- a/tests/foldedDipole.test.ts
+++ b/tests/foldedDipole.test.ts
@@ -51,7 +51,7 @@ describe('folded dipole geometry', () => {
     const wires = foldedAntennaWires({ height: 12 });
     // Fed conductor wires (left half, bridge, right half) must be at z = 12.
     const fedTags = new Set([LEFT_LEG_TAG, RIGHT_LEG_TAG, FEED_BRIDGE_TAG]);
-    for (const w of wires.filter((w) => fedTags.has(w.tag))) {
+    for (const w of wires.filter((w) => w.tag !== undefined && fedTags.has(w.tag))) {
       expect(w.start[2]).toBeCloseTo(12, 9);
       expect(w.end[2]).toBeCloseTo(12, 9);
     }

--- a/tests/helpers/factories.ts
+++ b/tests/helpers/factories.ts
@@ -1,0 +1,144 @@
+// Builders for the domain objects tests need to hand to components.
+//
+// These types carry a lot of required fields that most tests don't care
+// about — a component test for the polar plot has no opinion on the power
+// budget. Each builder fills in a valid default and takes an override patch,
+// so a test only spells out the fields it's actually asserting on, and adding
+// a required field to the underlying type doesn't mean touching every mock.
+
+import type {
+  GainPattern,
+  ImpedanceResult,
+  PowerBudget,
+  SimulationResult,
+  TerminationDiagnostics,
+} from '../../src/physics/types';
+import type { ComparisonSnapshot } from '../../src/store/antennaStore';
+import type { HopPrediction, PropagationPrediction } from '../../src/physics/propagation';
+
+/** Flat pattern with a mild gradient, so cuts and peak-finding have something to bite on. */
+export function makeGainPattern(overrides: Partial<GainPattern> = {}): GainPattern {
+  const thetaSteps = overrides.thetaSteps ?? 19;
+  const phiSteps = overrides.phiSteps ?? 36;
+  const data = overrides.data ?? new Float32Array(thetaSteps * phiSteps);
+  return {
+    data,
+    thetaSteps,
+    phiSteps,
+    dTheta: 180 / (thetaSteps - 1),
+    dPhi: 360 / phiSteps,
+    ...overrides,
+  };
+}
+
+export function makePowerBudget(overrides: Partial<PowerBudget> = {}): PowerBudget {
+  return {
+    inputW: 100,
+    radiatedW: 90,
+    structureLossW: 10,
+    networkLossW: 0,
+    efficiencyPct: 90,
+    ...overrides,
+  };
+}
+
+export function makeTerminationDiagnostics(
+  overrides: Partial<TerminationDiagnostics> = {},
+): TerminationDiagnostics {
+  return {
+    currentRippleByTag: [],
+    powerBudget: makePowerBudget(),
+    frontBackDb: null,
+    ...overrides,
+  };
+}
+
+export function makeImpedance(overrides: Partial<ImpedanceResult> = {}): ImpedanceResult {
+  return { R: 50, X: 0, ...overrides };
+}
+
+export function makeSimulationResult(
+  overrides: Partial<SimulationResult> = {},
+): SimulationResult {
+  return {
+    pattern: makeGainPattern(),
+    maxGainDbi: 2.15,
+    takeoffElevationDeg: 30,
+    takeoffAzimuthDeg: 0,
+    impedance: makeImpedance(),
+    swr: 1.5,
+    computeTimeMs: 1,
+    terminationDiagnostics: makeTerminationDiagnostics(),
+    ...overrides,
+  };
+}
+
+export function makeComparisonSnapshot(
+  overrides: Partial<ComparisonSnapshot> = {},
+): ComparisonSnapshot {
+  return {
+    frequency: 14.1,
+    antennaType: 'dipole',
+    length: 20,
+    height: 10,
+    orientation: 'EW',
+    wireRadius: 0.001,
+    segments: 21,
+    vAngle: 120,
+    legSlope: 0,
+    foldedDipoleAperture: 0.1,
+    groundId: 'pastoral',
+    groundSigma: 0.005,
+    groundEpsilon: 13,
+    feedlineId: 'none',
+    feedlineLength: 0,
+    feedlineOffset: 0,
+    whipCounterpoise: false,
+    result: makeSimulationResult(),
+    sweep: [],
+    capturedAt: 0,
+    ...overrides,
+  };
+}
+
+export function makeHop(overrides: Partial<HopPrediction> = {}): HopPrediction {
+  return {
+    n: 1,
+    rangeKm: 1000,
+    status: 'open',
+    reason: 'Open path',
+    linkQuality: 'useful',
+    takeoffElevationDeg: 15,
+    ...overrides,
+  };
+}
+
+type AzimuthalHop = NonNullable<PropagationPrediction['azimuthalHops']>[number];
+
+export function makeAzimuthalHop(overrides: Partial<AzimuthalHop> = {}): AzimuthalHop {
+  return {
+    phiDeg: 0,
+    takeoffElevationDeg: 15,
+    rangeKm: [1000],
+    status: 'open',
+    reason: 'Open path',
+    linkQuality: 'useful',
+    ...overrides,
+  };
+}
+
+export function makePropagationPrediction(
+  overrides: Partial<PropagationPrediction> = {},
+): PropagationPrediction {
+  return {
+    foF2MHz: 5.5,
+    hmF2Km: 300,
+    mufMHz: 14.2,
+    lufMHz: 3.5,
+    hops: [makeHop()],
+    selectedTakeoffElevationDeg: 15,
+    mismatchLossDb: 0,
+    solarZenithDeg: 45,
+    ...overrides,
+  };
+}

--- a/tests/helpers/mockStore.ts
+++ b/tests/helpers/mockStore.ts
@@ -1,0 +1,39 @@
+// Helper for tests that mock `useAntennaStore` and drive a component from a
+// hand-built slice of state.
+//
+// Those tests supply only the handful of fields the component under test
+// reads, so the object genuinely isn't a full `AntennaState`. Annotating the
+// selector with the narrower mock type doesn't type-check — selector
+// parameters are contravariant, so a selector declared over the full state
+// isn't assignable to one declared over a subset. Casting the state at the
+// single point where it's handed to the selector keeps the selector itself
+// correctly typed and confines the unsoundness to one place.
+//
+// Callers must `vi.mock` the store module first; this only sets the
+// implementation.
+
+import { vi } from 'vitest';
+import { useAntennaStore, type AntennaState } from '../../src/store/antennaStore';
+
+/**
+ * Partial state — every field is optional, and only what the component reads
+ * need be present. Field *types* are still checked against the real store, so
+ * a misspelled or wrongly-typed mock field is a compile error rather than an
+ * `undefined` the component silently renders around.
+ */
+export type MockAntennaState = Partial<AntennaState>;
+
+/**
+ * Make the mocked `useAntennaStore` resolve selectors against `state`.
+ *
+ * Pass a thunk when the test mutates a captured variable between renders to
+ * simulate an external store update — the thunk is re-run on every hook call,
+ * so the new value is picked up. A plain object is snapshotted once.
+ */
+export function mockAntennaStore(state: MockAntennaState | (() => MockAntennaState)): void {
+  const read = typeof state === 'function' ? state : () => state;
+  vi.mocked(useAntennaStore).mockImplementation((selector?: (s: AntennaState) => unknown) => {
+    const current = read() as unknown as AntennaState;
+    return selector ? selector(current) : current;
+  });
+}

--- a/tests/nec2Engine.error.test.ts
+++ b/tests/nec2Engine.error.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { Nec2Engine } from '../src/physics/nec2Engine';
-import { SimulationInput } from '../src/physics/types';
+import type { SimulationInput } from '../src/physics/types';
 
 describe('Nec2Engine error handling', () => {
   it('throws an error with stderr when nec2c exits with a non-zero status code', async () => {

--- a/tests/nec2Engine.test.ts
+++ b/tests/nec2Engine.test.ts
@@ -43,7 +43,7 @@ describe('Nec2Engine unit tests', () => {
           readFile: () => new Uint8Array([]),
         },
         callMain: () => 1, // Non-zero exit code
-      } as unknown;
+      } as unknown as NonNullable<Awaited<ReturnType<NonNullable<typeof engine['factory']>>>>;
     };
 
     const dummyInput = {

--- a/tests/physicsWorker.test.ts
+++ b/tests/physicsWorker.test.ts
@@ -91,7 +91,7 @@ describe('physicsWorker error path test', () => {
   it('posts result message when simulate succeeds', async () => {
     mockEngineInstance.init.mockResolvedValue(undefined);
 
-    let messageHandler: (msg: any) => void; // eslint-disable-line @typescript-eslint/no-explicit-any
+    let messageHandler!: (msg: any) => void; // eslint-disable-line @typescript-eslint/no-explicit-any
     addEventListenerSpy.mockImplementation((type, handler) => {
       if (type === 'message') messageHandler = handler;
     });
@@ -117,7 +117,7 @@ describe('physicsWorker error path test', () => {
   it('posts error message when simulate fails', async () => {
     mockEngineInstance.init.mockResolvedValue(undefined);
 
-    let messageHandler: (msg: any) => void; // eslint-disable-line @typescript-eslint/no-explicit-any
+    let messageHandler!: (msg: any) => void; // eslint-disable-line @typescript-eslint/no-explicit-any
     addEventListenerSpy.mockImplementation((type, handler) => {
       if (type === 'message') messageHandler = handler;
     });
@@ -141,7 +141,7 @@ describe('physicsWorker error path test', () => {
 
   it('handles worker error events', async () => {
     mockEngineInstance.init.mockResolvedValue(undefined);
-    let errorHandler: (ev: any) => void; // eslint-disable-line @typescript-eslint/no-explicit-any
+    let errorHandler!: (ev: any) => void; // eslint-disable-line @typescript-eslint/no-explicit-any
     addEventListenerSpy.mockImplementation((type, handler) => {
       if (type === 'error') errorHandler = handler;
     });
@@ -156,7 +156,7 @@ describe('physicsWorker error path test', () => {
 
   it('handles worker unhandledrejection events', async () => {
     mockEngineInstance.init.mockResolvedValue(undefined);
-    let rejectionHandler: (ev: any) => void; // eslint-disable-line @typescript-eslint/no-explicit-any
+    let rejectionHandler!: (ev: any) => void; // eslint-disable-line @typescript-eslint/no-explicit-any
     addEventListenerSpy.mockImplementation((type, handler) => {
       if (type === 'unhandledrejection') rejectionHandler = handler;
     });
@@ -172,7 +172,7 @@ describe('physicsWorker error path test', () => {
   it('ignores messages with unknown types', async () => {
     mockEngineInstance.init.mockResolvedValue(undefined);
 
-    let messageHandler: (msg: any) => void; // eslint-disable-line @typescript-eslint/no-explicit-any
+    let messageHandler!: (msg: any) => void; // eslint-disable-line @typescript-eslint/no-explicit-any
     addEventListenerSpy.mockImplementation((type, handler) => {
       if (type === 'message') messageHandler = handler;
     });
@@ -197,7 +197,7 @@ describe('physicsWorker error path test', () => {
   it('posts error message when simulate fails with a non-Error object', async () => {
     mockEngineInstance.init.mockResolvedValue(undefined);
 
-    let messageHandler: (msg: any) => void; // eslint-disable-line @typescript-eslint/no-explicit-any
+    let messageHandler!: (msg: any) => void; // eslint-disable-line @typescript-eslint/no-explicit-any
     addEventListenerSpy.mockImplementation((type, handler) => {
       if (type === 'message') messageHandler = handler;
     });
@@ -222,7 +222,7 @@ describe('physicsWorker error path test', () => {
   it('ignores messages from unauthorized origins', async () => {
     mockEngineInstance.init.mockResolvedValue(undefined);
 
-    let messageHandler: (msg: any) => void; // eslint-disable-line @typescript-eslint/no-explicit-any
+    let messageHandler!: (msg: any) => void; // eslint-disable-line @typescript-eslint/no-explicit-any
     addEventListenerSpy.mockImplementation((type, handler) => {
       if (type === 'message') messageHandler = handler;
     });

--- a/tests/usePhysicsEngine.test.tsx
+++ b/tests/usePhysicsEngine.test.tsx
@@ -97,7 +97,7 @@ describe('usePhysicsEngine', () => {
     // Get the message handler
     const messageHandler = worker.addEventListener.mock.calls.find(
       (call: unknown[]) => call[0] === 'message'
-    )[1];
+    )![1];
 
     // Mock ready
     act(() => {
@@ -248,12 +248,12 @@ describe('usePhysicsEngine', () => {
     // Get the error handler
     const errorHandler = worker.addEventListener.mock.calls.find(
       (call: unknown[]) => call[0] === 'error'
-    )[1];
+    )![1];
 
     // Get the messageerror handler
     const messageErrorHandler = worker.addEventListener.mock.calls.find(
       (call: unknown[]) => call[0] === 'messageerror'
-    )[1];
+    )![1];
 
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.app.json",
   "compilerOptions": {
-    "types": ["vite/client", "node"],
+    "types": ["vite/client", "vite-plugin-pwa/client", "node"],
     "noUnusedLocals": false,
     "noUnusedParameters": false
   },


### PR DESCRIPTION
Follow-up to the open-PR triage. While reviewing #605 I found its `mockReference` supplied 3 of ~20 required `ComparisonSnapshot` fields and still type-checked. The reason turned out to be structural rather than local to that PR.

## The gap

`tsconfig.test.json` exists and is fully configured, but `tsconfig.json` references only `tsconfig.app.json` and `tsconfig.node.json`. `tsc -b` therefore never built it, and **nothing type-checked `tests/` at all**.

CI compounds this: `.github/workflows/test.yml` runs ESLint and Vitest and no `tsc`, so type errors in `src/` wouldn't have failed a build either.

Running the test project directly surfaced **88 errors**.

## What that was hiding

Most were stale mocks describing shapes the production types have since moved away from. Vitest stayed green throughout because React ignores unknown props and components read `undefined` without complaint.

| Test | Mock said | Type says |
|---|---|---|
| `ColormapLegend` | pattern `{powerMax, thetas, phis, powers}`, impedance `{r, x, magnitude, phaseDeg}` | `GainPattern {data, thetaSteps, phiSteps, dTheta, dPhi}`, `ImpedanceResult {R, X}` |
| `ComparisonControl` | sweep `{frequency, swr, impedance:{real, imag}}` | `SweepPoint {frequencyMHz, swr, R, X}` |
| `SWRChart` | `R`/`X` on the result | on `result.impedance` |
| `TerminatedDeltaElement` | `theme="dark"` | prop became `color` in #596 |
| `ConditionsReadout`, `PropagationRadar` | `mode`, `criticalFreqMhz` | neither exists; required `solarZenithDeg` was missing |
| `App` | `SimulationSnapshot` | no such export — it's `ComparisonSnapshot` |
| `antennaGeometry` | `orientation: 'N'` | not an `OrientationPreset` |

Not one of these was a live failure, but every one of them meant a test asserting against a value the component never actually received.

The `'N'` case is behaviour-preserving: it falls through the `switch` in `orientationVector` to `deg = 0`, which is exactly what `'NS'` produces.

## Changes

- **`npm run typecheck`** — `tsc -b && tsc -p tsconfig.test.json --noEmit`, wired into CI as its own step. Kept separate from `build` so the production bundle doesn't depend on test types.
- **`tests/helpers/factories.ts`** — builders for `SimulationResult`, `ComparisonSnapshot`, `GainPattern`, `HopPrediction`, `PropagationPrediction`. Mocks now spell out only the fields they assert on, so adding a required field to a domain type no longer means touching every mock.
- **`tests/helpers/mockStore.ts`** — replaces 33 repetitions of the `useAntennaStore` selector boilerplate. Those all annotated the selector with a narrowed mock type, which is what made them unassignable (selector parameters are contravariant); the helper keeps the selector correctly typed and confines the cast to one place.
- Fixed all 88 errors.

## A note on the store helper

Two tests mutate a captured variable between renders to simulate an external store update. Converting them mechanically made the state eager and silently broke that — ESLint's `no-useless-assignment` caught it, and the test would have started asserting against a stale value. `mockAntennaStore` now also accepts a thunk, which those two use.

## Verification

`npm run typecheck`, `npm run lint`, `npm run test` (75 files, 894 tests), and `npm run build` all pass.

I also confirmed the new gate earns its place — reintroducing a single misspelled mock field:

```
tests/PolarPlots.test.tsx(34,22): error TS2561: Object literal may only specify known
properties, but 'r' does not exist in type 'ImpedanceResult'. Did you mean to write 'R'?
```

while `vitest run tests/PolarPlots.test.tsx` reports 10 passed. That's the class of defect this closes.

## Not included

`.jules/bolt.md` has grown to 56 entries with 12 duplicated titles (plus two separate `Math.hypot` lessons). It's worth consolidating, but every in-flight agent PR appends to that file — I hit exactly that conflict merging #606 — so folding it in here would collide with anything currently open. Better as a standalone change when the queue is quiet.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MWa9hnvd1TmTAgVuzsM14j)_