### PR TITLE
Narrow PolarPlots memo deps to the values actually read

### DIFF
--- a/src/components/Charts/PolarPlots.tsx
+++ b/src/components/Charts/PolarPlots.tsx
@@ -175,12 +175,12 @@ function AzimuthPlot({ result, dbRange, options }: { result: SimulationResult, d
     // NEC theta = 90 - elevation. 0 elevation (horizon) is 90 theta (from zenith).
     const thetaDeg = 90 - result.takeoffElevationDeg;
     return cutAzimuth(result.pattern, thetaDeg);
-  }, [result]);
+  }, [result.pattern, result.takeoffElevationDeg]);
 
   const data = useMemo(() => {
     return normaliseForPolar(cut, result.maxGainDbi, dbRange);
   }, [cut, result.maxGainDbi, dbRange]);
-  const labels = useMemo(() => getAzimuthLabels(result.pattern), [result]);
+  const labels = useMemo(() => getAzimuthLabels(result.pattern), [result.pattern]);
 
   return (
     <PolarPlotPanel
@@ -195,12 +195,12 @@ function AzimuthPlot({ result, dbRange, options }: { result: SimulationResult, d
 function ElevationPlot({ title, result, dbRange, azimuth, options }: { title: string, result: SimulationResult, dbRange: number, azimuth: number, options: ComponentProps<typeof PolarPlotPanel>['options'] }) {
   const cut = useMemo(() => {
     return cutElevation(result.pattern, azimuth);
-  }, [result, azimuth]);
+  }, [result.pattern, azimuth]);
 
   const data = useMemo(() => {
     return normaliseForPolar(cut, result.maxGainDbi, dbRange);
   }, [cut, result.maxGainDbi, dbRange]);
-  const labels = useMemo(() => getElevationLabels(result.pattern), [result]);
+  const labels = useMemo(() => getElevationLabels(result.pattern), [result.pattern]);
 
   return (
     <PolarPlotPanel


### PR DESCRIPTION
Six PRs so far (#595, #611, #612, #616, #617, and partly #591) have proposed the same optimisation for `PolarPlots.tsx`. The observation behind them is correct, so this lands it in the form that doesn't need a lint suppression — and closes the others.

## The observation

`AzimuthPlot` and `ElevationPlot` key their `cut` and `labels` memos on the whole `result` object, but only read `result.pattern` and `result.takeoffElevationDeg`. Any other field changing — a new `swr`, a new `computeTimeMs` — rebuilds a cut and a label array that can't have changed.

## Why not the suppression

All five proposed narrowing to nested primitives with `// eslint-disable-next-line react-hooks/exhaustive-deps`. Listing the two values the memo actually reads achieves the same skipped work and keeps the rule active:

```js
}, [result.pattern, result.takeoffElevationDeg]);
```

`exhaustive-deps` is satisfied because these *are* the exhaustive deps — `eslint .` passes with no suppressions.

Keeping the rule on matters here, and not hypothetically. #617 keyed the azimuth labels on `[result.pattern.phiSteps]`, but `getAzimuthLabels` reads both `p.phiSteps` and `p.dPhi`:

```js
for (let pi = 0; pi < p.phiSteps; pi++) {
  const phiDeg = pi * p.dPhi;
```

so labels would go stale if `dPhi` changed while `phiSteps` held. It's masked today because callers derive `dPhi = 360 / phiSteps`, but nothing in `GainPattern` requires that. The suppression is precisely what stopped the linter from flagging the missing dep. #616 has the same gap on the elevation side (`thetaSteps` listed, `dTheta` read).

## Effect

`result.pattern` is a fresh object per simulation, so this skips work whenever `result` changes without a new pattern — and rebuilds correctly when one arrives.

## Verification

`npm run typecheck`, `eslint .` (no new suppressions), and the full suite pass — 75 files, 895 tests.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MWa9hnvd1TmTAgVuzsM14j)_