### PR TITLE
Deduplicate agent journals and document journal hygiene

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -16,67 +16,6 @@
 
 ## 2025-02-18 - [Batching WebAssembly Engine Execution]
 
-**Learning:** Instantiating the Emscripten WASM module and interacting with its virtual filesystem repeatedly inside a `for` loop (as seen in sequential sweeps) is a major performance bottleneck due the engine's internal concurrency lock and initialization overhead.
-**Action:** Always batch related simulations at the lowest possible layer. For the NEC-2 engine, this means generating a single input deck using the `FR` card's linear sweep capability (`FR 0 nfreq ...`) and parsing the multiple concatenated outputs in a single execution context.
-
-## 2025-03-02 - Hot Loop Math and Inlining Optimization in 3D Rendering
-
-**Learning:** In hot loops such as 3D geometry and color computation (like `RadiationPattern.tsx`), function calls and certain math functions incur high overhead when invoked millions of times per frame. `Math.pow(10, x)` is measurably slower than calculating the precomputed natural exponential `Math.exp(x * (Math.LN10 / 20))`. Additionally, inlining simple linear interpolation or condition checks inside hot loops avoids function stack overhead, yielding up to a 20-25% performance improvement in heavy 3D visualizations.
-**Action:** Always precompute invariant scaling factors outside of hot loops and prefer `Math.exp()` with an `LN10` scale over `Math.pow(10, ...)` for power calculations. Inline simple value clamping and mapping logic rather than calling utility functions during inner rendering loops.
-
-## 2025-05-05 - Avoid Math.hypot in bounded rendering loops
-
-**Learning:** `Math.hypot` is significantly slower than doing a manual sum of squares and `Math.sqrt`, especially in V8 and other modern JS engines. The overhead of handling an arbitrary number of arguments and ensuring protection against overflow/underflow makes `Math.hypot` roughly 10-12x slower than standard `Math.sqrt(x*x + y*y + z*z)` when iterating over thousands of vertices.
-**Action:** Always prefer `Math.sqrt` with manual squaring for simple 2D or 3D distance calculations in tight rendering or geometry loops where numbers are bounded (e.g. unit sphere coordinates). Avoid this optimization for unbounded numeric domains like complex magnitude or impedance calculations, where `Math.hypot`'s overflow/underflow protections are necessary.
-
-## 2025-05-18 - Precompute Elevation-Dependent Math Outside Hot Loops
-
-**Learning:** In the propagation physics engine (`predictPropagation`), estimating MUF and calculating hop range involves expensive operations like `Math.asin`, `Math.cos`, and custom scaling. Calculating this for every combination of azimuth (`phi`) and elevation (`theta`) (i.e. $O(P \times T)$) is highly redundant because these geometric constraints depend _only_ on the elevation angle.
-**Action:** Precompute these elevation-dependent metrics (MUF, range, path status) into a 1D array (`baseRays[theta]`) first. Inside the $O(P \times T)$ loop, simply combine the precomputed ray with the direction-specific gain. This optimization changes expensive math from $O(P \times T)$ to $O(T)$ plus simple assignments, significantly improving rendering and sweep speed.
-
-## 2025-05-18 - Maintainability in Inner Loops
-
-**Learning:** Reconstructing complex state strings (like `LinkQuality`) from integer rank metrics (like `0`/`1`/`2`) inside an inner loop using ternary operators is brittle and presents a maintainability hazard. If rank values or the states they represent ever evolve, the hardcoded ternary mappings become bugs.
-**Action:** Instead of dynamically reconstructing states from arbitrary integer ranks, simply maintain explicit variables representing the best actual states found along with the rank used for comparison (e.g. `let bestLinkQuality: LinkQuality = 'unusable'`). This completely eliminates brittle conversions and avoids logic duplication later when producing output.
-
-## 2024-05-17 - Optimize multiple Zustand selectors with useShallow
-
-**Learning:** Selecting multiple separate fields from a Zustand store using separate `useStore(s => s.field)` calls incurs significant React hook overhead in highly-re-rendering components.
-**Action:** When a component needs to select many fields from the store (e.g. 18 separate values), group them into a single object returned from a single hook call wrapped in `useShallow` from `zustand/react/shallow`. This cuts down overhead and batches state checks efficiently.
-
-## 2025-05-18 - Batch Zustand React Hooks with useShallow
-
-**Learning:** Selecting multiple separate fields from a Zustand store using individual `useAntennaStore((s) => s.field)` calls creates excessive subscriber listeners and hook allocation overhead, noticeably impacting rendering performance when global state properties update rapidly in complex UI controls.
-**Action:** Use `useShallow` from `zustand/react/shallow` to group multiple properties into a single object return in one hook call. This pattern minimizes re-renders to only when the specific destructured fields change and reduces React hook lifecycle overhead.
-
-## 2025-05-18 - Do not use shallow reference equality on selectors that allocate new objects
-
-**Learning:** Shallow `!==` comparison (iterating `Object.keys`) only works correctly when the compared objects hold primitive values. When a selector like `selectSimulationInput` allocates new arrays and object literals on every call (e.g. `buildWires(state)`, `{ wireTag: ... }`, `buildGroundParams(state)`), every key comparison will be `true` regardless of the underlying data, causing `schedule()` to fire on every store update — worse than the original.
-**Action:** Use `JSON.stringify` for change-detection on derived selector objects that contain nested arrays or objects. The cost is ~3μs per call, which is negligible at typical UI event rates (100 events/s = 300μs/s total). Only optimise this if profiling proves it to be a real bottleneck.
-
-## 2024-05-30 - SWR Chart Aggregation Optimization
-
-**Learning:** Using chained array methods (e.g., `[...arr.map()]`) to extract values for finding a max or min leads to excessive intermediate array allocations and slower performance, especially in `useMemo` hooks calculating values over arrays. Using a standard `for` loop to directly calculate these aggregates is up to ~10x faster and uses less memory.
-**Action:** Replaced `.map()` and spread syntax with standard `for` loops in `xBounds` and `yMax` calculations in `SWRChart.tsx`.
-
-## 2025-02-14 - O(1) Map Lookups for Static Presets
-
-**Learning:** In Three.js geometry generation, recalculating vertex angles (spherical coordinates from Cartesian) for `thetaDeg` and `phiDeg` on every frame or state change can be significantly expensive and redundant, especially when LOD details stay the same. Caching these arrays separately from visual attributes drastically improves performance.
-**Action:** When mapping scalar data to 3D meshes (like antenna radiation patterns), cache structural calculations (like vertex spherical angles) separately from dynamic visual state (like colors or scale) using separate `useMemo` hooks.
-
-## 2025-02-18 - Pre-allocate Arrays in Polar Plot Generation
-
-**Performance Issue:** Dynamic array resizing via `out.push(...)` in `cutAzimuth` and `cutElevation` inside `src/components/Charts/PolarPlots.tsx` caused significant memory overhead and slowdowns when called frequently during polar chart rendering.
-**Optimization:** Replaced `[]` and `push` with `new Array(size)` and populated elements using a standard `for` loop and index assignments. This eliminates reallocation and pushes array creation performance from ~361ms down to ~138ms in synthetic benchmarking.
-**Action:** Always pre-allocate arrays when the exact final size is known upfront, especially in chart generation or rendering loops.
-
-## 2024-05-18 - Optimized Zenith Gain Fetch
-
-**Learning:** In spherical coordinates used by the NEC-2 engine (theta=0 at zenith), the direction vector is straight up regardless of the azimuth (phi) step.
-**Action:** Replace $O(N)$ averaging loops over `phi` at zenith with a direct $O(1)$ sample from `data[0]` to fetch the gain faster, avoiding redundant memory reads in the JS engine.
-
-## 2025-02-18 - [Batching WebAssembly Engine Execution]
-
 **Learning:** Instantiating the Emscripten WASM module and interacting with its virtual filesystem repeatedly inside a `for` loop (as seen in sequential sweeps) is a major performance bottleneck due to the engine's internal concurrency lock and initialization overhead.
 **Action:** Always batch related simulations at the lowest possible layer. For the NEC-2 engine, this means generating a single input deck using the `FR` card's linear sweep capability (`FR 0 nfreq ...`) and parsing the multiple concatenated outputs in a single execution context.
 
@@ -119,6 +58,12 @@
 
 **Learning:** Using chained array methods (e.g., `[...arr.map()]`) to extract values for finding a max or min leads to excessive intermediate array allocations and slower performance, especially in `useMemo` hooks calculating values over arrays. Using a standard `for` loop to directly calculate these aggregates is up to ~10x faster and uses less memory.
 **Action:** Replaced `.map()` and spread syntax with standard `for` loops in `xBounds` and `yMax` calculations in `SWRChart.tsx`.
+
+## 2025-02-14 - Cache structural geometry separately from visual state
+
+**Learning:** In Three.js geometry generation, recalculating vertex angles (spherical coordinates from Cartesian) for `thetaDeg` and `phiDeg` on every frame or state change can be significantly expensive and redundant, especially when LOD details stay the same. Caching these arrays separately from visual attributes drastically improves performance.
+**Action:** When mapping scalar data to 3D meshes (like antenna radiation patterns), cache structural calculations (like vertex spherical angles) separately from dynamic visual state (like colors or scale) using separate `useMemo` hooks.
+
 
 ## 2025-02-14 - O(1) Map Lookups for Static Presets
 
@@ -226,9 +171,6 @@
 ## 2024-05-18 - Replace Math.hypot with Math.sqrt
 **Learning:** Math.hypot is notoriously slow in V8 (often ~45x slower) due to necessary overhead for underflow/overflow protection and arbitrary arguments. For hot loops like SWR/impedance calculations where values are comfortably within safe float boundaries, using Math.sqrt(x*x + y*y) directly provides a significant performance boost.
 **Action:** Always favor Math.sqrt(x*x + y*y) over Math.hypot in performance-critical sections (e.g. loops processing physics arrays) when input domain boundaries are well known and safe from floating point extremes.
-## 2026-08-01 - Avoid Math.hypot in bounded rendering loops
-**Learning:** `Math.hypot` is significantly slower than doing a manual sum of squares and `Math.sqrt`, especially in V8 and other modern JS engines. The overhead of handling an arbitrary number of arguments and ensuring protection against overflow/underflow makes `Math.hypot` roughly 10-12x slower than standard `Math.sqrt(x*x + y*y + z*z)` when iterating over thousands of vertices.
-**Action:** Always prefer `Math.sqrt` with manual squaring for simple 2D or 3D distance calculations in tight rendering or geometry loops where numbers are bounded (e.g. unit sphere coordinates). Avoid this optimization for unbounded numeric domains like complex magnitude or impedance calculations, where `Math.hypot`'s overflow/underflow protections are necessary.
 ## 2026-08-01 - Optimize polar plot data generation caching
 **Learning:** Splitting computationally expensive array transformations from lightweight normalisation steps within React `useMemo` hooks prevents redundant recalculations when only cosmetic or scaling properties change.
 **Action:** Extracted the expensive `cutAzimuth` and `cutElevation` array generation functions in `PolarPlots.tsx` into independent `useMemo` hooks to decouple their execution from UI slider updates (like `dbRange`).

--- a/.jules/sweep.md
+++ b/.jules/sweep.md
@@ -18,17 +18,16 @@
 ## 2024-06-11 - Constant export cleanup
 **Learning:** Removing an unused export for a constant that is still used internally within the same file requires leaving the import intact.
 **Action:** When un-exporting variables, do a local grep to see if they are still used in the file; if so, do not remove the import.
-## 2025-02-13 - Un-exporting Internal Utilities and Constants
 ## 2026-06-17 - Un-exporting Internal Utilities and Constants
 **Learning:** `knip` correctly flagged `reflectionCoefficientMag`, `INITIAL_HEIGHT`, and `FEED_BRIDGE_LENGTH_M` (re-export) as unused outside their declaring files. When a function or constant is only used internally, it should not be exported, improving module encapsulation.
 **Action:** When cleaning up unused exports, simply remove the `export` keyword if the symbol is used locally. If it was re-exported in a centralized `export { ... }` block but unused outside, remove it from that block while keeping its import intact if it's used within the aggregator file. Always verify with `npm run build` and `npm run test` afterward.
-## 2024-05-18 - [False Positive on Unused Type Import]
+## 2024-05-18 - [False Positive on Unused Type Import: ComparisonSnapshot]
 **Learning:** A static analysis tool incorrectly flagged a valid type import (`ComparisonSnapshot` in `src/components/Scene/AntennaScene.tsx`) as unused, when it was actually being used as a type for a property in an interface definition (`interface AntennaSceneProps`).
 **Action:** When investigating reported unused type imports, carefully examine the file to ensure the type isn't used within type signatures or interfaces. If verified as a false positive, do not remove the import, and instead note the false positive in the journal and close the task without making codebase changes.
 ## 2024-06-25 - False Positive on AntennaType Import
 **Learning:** The static analysis scanner incorrectly flagged `type AntennaType` in `src/components/Panel/GeometryControl.tsx` as an unused import. However, manual inspection verified it was used as a type parameter in definitions like `Record<AntennaType, string>`. Removing valid, in-use imports causes build failures and is an anti-pattern.
 **Action:** Closed the task without making changes to the codebase, strictly adhering to the Code Health Refactoring Pattern which dictates preserving valid code when confronted with false positives.
-## 2024-05-19 - [False Positive on Unused Type Import]
+## 2024-05-19 - [False Positive on Unused Type Import: SwrBand]
 **Learning:** A static analysis tool incorrectly flagged a valid type import (`SwrBand` in `src/physics/nec2Engine.ts`) as unused, when it was actually being used as a type annotation for function parameters (`bands: readonly SwrBand[]` and `b: SwrBand`). Removing it causes `tsc` build errors.
 **Action:** When investigating reported unused type imports, carefully examine the file to ensure the type isn't used within type signatures or interfaces. If verified as a false positive, do not remove the import, and instead note the false positive in the journal and close the task without making codebase changes.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,3 +20,25 @@ When making modifications to the project or the `nec2c` prediction engine (locat
 4. **Source Code Availability:** Ensure that the repository structure continues to support the free distribution of the source code for both the frontend application and the engine.
 
 Failure to adhere to these rules violates the GPL v3 license.
+
+## Agent Journals (`.jules/*.md`)
+
+Each agent keeps a journal of lessons learned. Entries are `## YYYY-MM-DD - Title`
+followed by `**Learning:**` and `**Action:**` lines. Before appending one:
+
+1. **Use the real current date.** Check it (`date -u +%F`) rather than recalling
+   one. Journals have accumulated entries dated one to two years before the work
+   actually happened, which makes the chronology useless for judging whether a
+   lesson still applies.
+2. **Search the file for the lesson first.** If an entry already covers it, amend
+   that entry instead of appending a second one. Journals have carried up to three
+   verbatim copies of the same lesson.
+3. **Title the entry after what the body says.** A title describing a different
+   optimisation than the body makes the lesson unfindable.
+4. **Check the interpolation actually happened.** Entries have been committed
+   reading `Inverted theta and phi loops in , and deferred  string resolution`,
+   where a template variable resolved to nothing.
+
+A journal entry is not a substitute for a code change. If the finding turns out to
+be already fixed, or a false positive, say so on the issue — do not open a pull
+request whose diff is empty.


### PR DESCRIPTION
The follow-up I flagged while triaging #590, #606, #607 and #611. Doing it now that the PR queue is empty — rewriting these files collides with anything in flight that appends to them, which is exactly what happened merging #606.

## Duplicates

`.jules/bolt.md` had reached 56 entries with 12 duplicated titles, including **three verbatim copies** of the `Math.hypot` lesson.

- **bolt.md: 56 → 44.** Eleven exact duplicates, plus one pair differing only by a typo (`due the` / `due to the`) — kept the correct one.
- **One entry was mistitled.** `O(1) Map Lookups for Static Presets` appeared twice with completely different bodies: one about `Map` lookups for `GROUND_PRESETS`/`FEEDLINE_PRESETS`, the other about caching Three.js vertex angles across LOD changes. The second is a real lesson wearing the wrong title, so it's retitled rather than dropped.
- **sweep.md: 35 → 34.** Dropped a heading with an empty body. Its two `[False Positive on Unused Type Import]` entries are genuinely different instances (`ComparisonSnapshot` in `AntennaScene.tsx`, `SwrBand` in `nec2Engine.ts`), so both are kept, with the symbol named in each title.

No unique lesson is lost — I checked rather than assuming, comparing the set of distinct entry bodies before and after:

```
.jules/bolt.md:  unique lessons before=43 after=43  LOST=0
.jules/sweep.md: unique lessons before=32 after=32  LOST=0
```

## Root cause

Deduping alone won't hold — four PRs this week alone appended a duplicate or a wrong date. So `AGENTS.md` gains a short section covering what actually goes wrong:

- **Dates.** 106 of 176 entries across all seven journals are dated 2024 or 2025, in a repo at 2026-08. #590 wrote `2024-05-14`, #606 `2025-02-15`, #607 `2024-10-27`, #611 `2025-02-14`. The guidance is to check the date rather than recall one.
- **Search before appending**, since the same lesson has landed up to three times.
- **Title the entry after its body**, per the mistitled entry above.
- **Check template interpolation happened** — #606 committed `Inverted theta and phi loops in , and deferred  string resolution`, with the identifiers resolved to nothing.
- **A journal entry is not a substitute for a code change** — five PRs in two days (#599, #601, #603, #610, #615) had empty diffs, with the finding only in the commit message. #615 was titled `[CRITICAL]`, so an already-mitigated issue read as an open critical vulnerability until the branch was diffed by hand.

## Left alone

**The wrong dates themselves.** They could be recovered from `git log`, but I'd be rewriting ~106 lines of other agents' memory on archaeology, and the diff would conflict with everything subsequently opened. Fixing the instruction is the cheaper half.

**Two conflicting `Math.hypot` measurements.** One entry says ~45× slower, another 10–12×. Both are presented as measured, and I have no basis for picking, so both stand — worth a benchmark by whoever next touches that path.

## Verification

`npm run typecheck`, `eslint .`, and the full suite pass — 75 files, 895 tests. No source files are touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MWa9hnvd1TmTAgVuzsM14j)_