### PR TITLE
🛡️ Sentinel: [security improvement] Prevent information leakage in worker console logs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -38,3 +38,7 @@
 **Vulnerability:** The Claude action was triggering on `issue_comment`, `pull_request_review_comment`, `pull_request_review`, and `issues` events by solely checking if the payload contained `@claude`. This allowed anyone to trigger the workflow and potentially execute arbitrary code or consume resources.
 **Learning:** GitHub Actions workflows triggered by comment and issue events without strict author validation can be exploited by unprivileged users. Always validate the `author_association` when responding to user-generated content in automated workflows.
 **Prevention:** Ensured the `if` condition in the workflow checks the `author_association` of the event's actor, restricting it to `OWNER`, `MEMBER`, or `COLLABORATOR` before execution.
+## 2025-02-14 - Information Leakage in Web Worker Error Handlers
+**Vulnerability:** Worker-side error and unhandledrejection handlers blindly invoked `console.error` in all environments, potentially leaking internal stack traces or configuration paths to the production browser console.
+**Learning:** Web workers typically run outside the main application bundle but are still client-facing. They must respect the same environmental error-masking rules (like `import.meta.env.DEV`) as the main UI to prevent inadvertent information disclosure.
+**Prevention:** Always wrap `console.error` and `console.warn` calls inside worker event listeners or hooks managing worker lifecycle with `if (import.meta.env.DEV)` to silence them in production.

--- a/src/hooks/usePhysicsEngine.ts
+++ b/src/hooks/usePhysicsEngine.ts
@@ -130,11 +130,15 @@ function useWorkerLifecycle(
     worker.addEventListener('message', handler);
 
     const errHandler = (ev: ErrorEvent) => {
-      console.error('[usePhysicsEngine] worker error', ev.message, ev.error);
+      if (import.meta.env.DEV) {
+        console.error('[usePhysicsEngine] worker error', ev.message, ev.error);
+      }
       useAntennaStore.getState()._setError(`Worker error: ${ev.message}`);
     };
     const rejectHandler = (ev: MessageEvent) => {
-      console.error('[usePhysicsEngine] worker messageerror', ev);
+      if (import.meta.env.DEV) {
+        console.error('[usePhysicsEngine] worker messageerror', ev);
+      }
     };
     worker.addEventListener('error', errHandler);
     worker.addEventListener('messageerror', rejectHandler);

--- a/src/workers/physicsWorker.ts
+++ b/src/workers/physicsWorker.ts
@@ -63,10 +63,14 @@ const ctx = self as unknown as DedicatedWorkerGlobalScope;
 
 // Surface worker-side errors explicitly so they don't vanish silently.
 self.addEventListener('error', (ev) => {
-  console.error('[worker error]', ev.message, ev.error);
+  if (import.meta.env.DEV) {
+    console.error('[worker error]', ev.message, ev.error);
+  }
 });
 self.addEventListener('unhandledrejection', (ev: PromiseRejectionEvent) => {
-  console.error('[worker unhandledrejection]', ev.reason);
+  if (import.meta.env.DEV) {
+    console.error('[worker unhandledrejection]', ev.reason);
+  }
 });
 
 
@@ -82,7 +86,7 @@ engine
     ctx.postMessage({ type: 'ready' } satisfies WorkerResponse);
   })
   .catch((err: unknown) => {
-    console.error('[worker] engine init failed', err);
+    if (import.meta.env.DEV) console.error('[worker] engine init failed', err);
     ctx.postMessage({
       id: -1,
       type: 'error',
@@ -93,7 +97,7 @@ engine
 ctx.addEventListener('message', (ev: MessageEvent<WorkerRequest>) => {
   // Security: drop cross-origin messages
   if (ev.origin && ev.origin !== '' && ev.origin !== self.location.origin) {
-    console.warn('[worker] dropping cross-origin message from', ev.origin);
+    if (import.meta.env.DEV) console.warn('[worker] dropping cross-origin message from', ev.origin);
     return;
   }
   const msg = ev.data;


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Raw worker errors and unhandled rejections were being logged directly to the browser console via `console.error` regardless of environment. This could inadvertently leak internal implementation details, WASM engine state, or file paths to end-users in production.
🎯 **Impact:** Information leakage that could aid an attacker in understanding the application's internal structure or dependencies.
🔧 **Fix:** Wrapped all `console.error` and `console.warn` calls within the worker event listeners (`physicsWorker.ts`) and the hook managing the worker lifecycle (`usePhysicsEngine.ts`) with `import.meta.env.DEV` conditionals. This ensures verbose error logging is restricted to local development environments.
✅ **Verification:** Verified via `pnpm lint` and `pnpm test -- --run` that all tests pass and no regressions were introduced. Vite correctly transforms `import.meta.env.DEV` at build time for both standard modules and IIFE workers.

---
*PR created automatically by Jules for task [2979124220921506644](https://jules.google.com/task/2979124220921506644) started by @2fst4u*