### PR TITLE
📚 Archivist: Fix Folded Dipole tag drift in antenna-spec.md

### DIFF
--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -146,3 +146,7 @@
 ## 2026-08-01 - Folded Dipole Feedline Support Documentation Drift
 **Learning:** The `docs/antenna-spec.md` falsely claimed that feedline support was "Not currently modelled" for the Folded Dipole. However, the codebase (`src/store/antennaStore.ts`) explicitly includes `folded-dipole` in `FEEDLINE_SUPPORTED_TYPES`, and the geometry engine fully generates the feedline shield layout for it just like standard dipoles. The documentation drifted from the implemented physics model.
 **Action:** The documentation in `docs/antenna-spec.md` was updated for the Folded Dipole to remove the false claim and explicitly clarify that feedline support is implemented using the standard radiating shield and NEC TL card at the centre bridge.
+
+## 2026-08-02 - Folded Dipole Tag Documentation Drift
+**Learning:** The documentation for the Folded Dipole claimed that the bottom (fed) conductor was split into two halves carrying `DIPOLE_LEFT_TAG` / `DIPOLE_RIGHT_TAG`. However, the codebase uses the standard split-fed convention tags `LEFT_LEG_TAG` / `RIGHT_LEG_TAG` for these halves, consistent with the standard dipole. The documentation drifted from the implemented physics constants.
+**Action:** Updated `docs/antenna-spec.md` to accurately reflect the use of `LEFT_LEG_TAG` and `RIGHT_LEG_TAG` for the fed conductor halves of the Folded Dipole.

--- a/docs/antenna-spec.md
+++ b/docs/antenna-spec.md
@@ -392,7 +392,7 @@ Every type below uses the coordinate conventions of Part I §1 and the glossary 
 - **`length` parameter:** Each conductor's length (metres). Reference length: ½λ (0.475λ with end-effect) — same as a standard dipole; the fold does not change the resonant length.
 - **`foldedDipoleAperture` parameter:** Vertical spacing between the two parallel conductors (metres). Default 0.3 m. Clamped to [0.02 m, `FOLDED_DIPOLE_MAX_APERTURE_M` = 0.5 m]. The upper cap keeps the antenna a genuine folded dipole and, crucially, within the spacing range where NEC's close-parallel-wire solution converges inside `MAX_SEGS_PER_LEG` (see §13.5).
 - **Orientation:** Azimuth the conductor axis runs. The aperture is in the vertical (Z) direction; changing the orientation rotates the axis in the horizontal plane but the top/bottom wire layout is preserved.
-- **Fed conductor:** Split at its centre by a `FEED_BRIDGE_LENGTH_M` feed bridge (the two halves carry `DIPOLE_LEFT_TAG` / `DIPOLE_RIGHT_TAG`, the same split-fed convention as the standard dipole).
+- **Fed conductor:** Split at its centre by a `FEED_BRIDGE_LENGTH_M` feed bridge (the two halves carry `LEFT_LEG_TAG` / `RIGHT_LEG_TAG`, the same split-fed convention as the standard dipole).
 - **Min Height:** Bottom conductor at `z = height`; fully supports `height = 0` (or `height <= 0`), which seamlessly switches the model to a free space environment without ground, preventing NEC-2 `GE 1` instability. The top conductor is automatically at `z = height + aperture`.
 
 ### 13.2 Feedpoint Definition


### PR DESCRIPTION
💡 Problem: The documentation in `docs/antenna-spec.md` incorrectly stated that the Folded Dipole used `DIPOLE_LEFT_TAG` and `DIPOLE_RIGHT_TAG` for its split-fed conductor. These constants do not exist in the codebase.
🎯 Fix: Updated the documentation to accurately reference `LEFT_LEG_TAG` and `RIGHT_LEG_TAG`, which are the actual constants defined in `src/physics/constants.ts` and used in `src/store/antennaGeometry.ts` for the Folded Dipole.
🧪 Verification: Confirmed via `grep` that `DIPOLE_LEFT_TAG` does not exist in the source code, while `LEFT_LEG_TAG` is actively used. Ran `npm run lint` and `npm run test` successfully.
🔎 Scope: This PR contains ONLY documentation changes to `docs/antenna-spec.md` and a new entry in `.jules/archivist.md`.

---
*PR created automatically by Jules for task [17471141575732854546](https://jules.google.com/task/17471141575732854546) started by @2fst4u*