### PR TITLE
🎨 Palette: Improve accessibility of external link context change

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -31,3 +31,6 @@
 ## 2026-08-02 - Fix ARIA Controls Missing Element
 **Learning:** When using `aria-controls` on a disclosure button, the controlled element MUST remain in the DOM even when collapsed. Conditionally rendering the target element (e.g., `{show && <div id="...">}`) causes the screen reader to lose track of the controlled element.
 **Action:** Use the `hidden` attribute (`<div id="..." hidden={!show}>`) instead of conditional mounting for elements controlled by `aria-controls`. When updating this logic, remember to update the corresponding tests (e.g., from `toBeNull()` to checking the `hidden` property on the wrapper element).
+## 2024-11-09 - Accessible External Links Context Change
+**Learning:** External links utilizing `target="_blank"` cause an unexpected context switch for screen reader users, disrupting navigation flow. Simply providing a visually-informative title is insufficient for accessibility.
+**Action:** When adding or modifying external links (`target="_blank"`), ensure an explicit `aria-label` is applied that appends "(opens in a new tab)" to the link text to provide fair warning of the behavior change.

--- a/src/components/Panel/ControlPanel.tsx
+++ b/src/components/Panel/ControlPanel.tsx
@@ -63,6 +63,7 @@ export function ControlPanel() {
           target="_blank"
           rel="noopener noreferrer"
           title="View source code on GitHub"
+          aria-label="Source code on GitHub (opens in a new tab)"
           style={{ color: 'inherit', textDecoration: 'none' }}
           onMouseOver={(e) => (e.currentTarget.style.textDecoration = 'underline')}
           onMouseOut={(e) => (e.currentTarget.style.textDecoration = 'none')}


### PR DESCRIPTION
💡 What: Added an explicit `aria-label` to the external GitHub source code link in `ControlPanel.tsx` that warns "(opens in a new tab)".
🎯 Why: Links that unexpectedly open new windows or tabs can disorient screen reader users. Warning them in advance via semantic markup improves the accessibility and predictability of the interface.
♿ Accessibility: Improves compliance with WCAG guidelines for predictable navigation and context changes without altering the visual design for sighted users.

---
*PR created automatically by Jules for task [1958631260446988285](https://jules.google.com/task/1958631260446988285) started by @2fst4u*