### PR TITLE
Fix gain pattern rendering and rebalance folded-dipole defaults

### DIFF
--- a/docs/antenna-spec.md
+++ b/docs/antenna-spec.md
@@ -34,14 +34,26 @@ We use the standard NEC-2 Cartesian coordinate system:
 - **Internal Mapping**: To convert a compass heading $\alpha$ to a standard unit circle angle $\theta$ (where $0^\circ$ is $+X$): $\theta = 90^\circ - \alpha$.
 - **Elevation**: $0^\circ$ is the horizon (XY plane), $90^\circ$ is the zenith ($+Z$ axis).
 
+#### 1.3.1 NEC azimuth $\varphi$ vs compass bearing
+
+The NEC-2 `RP` card sweeps its own azimuth $\varphi$, measured from $+X$ toward $+Y$ (counter-clockwise seen from above). That is the axis `GainPattern` is indexed by and the one `SimulationResult.takeoffAzimuthDeg` reports. Because the geometry puts North on $+Y$ and East on $+X$, $\varphi = 0^\circ$ is due **East** and $\varphi = 90^\circ$ is due **North**:
+
+$$\text{bearing} = 90^\circ - \varphi \pmod{360^\circ}$$
+
+The relation is its own inverse — the two conventions differ by a $90^\circ$ rotation *and* a handedness flip. **Every** display that shows a direction to the user (polar cuts, propagation radar, stats readout) must convert; helpers live in `src/physics/angles.ts`. Substituting $\varphi$ for a bearing rotates and mirrors the whole pattern, which makes a north–south dipole appear to radiate north and south — off its ends, where it has nulls.
+
+The 3D scene is a separate mapping and needs no conversion: it remaps NEC $(x, y, z)$ to Three.js $(x, z, -y)$, so its $\varphi = \operatorname{atan2}(-z, x)$ recovers the NEC azimuth exactly.
+
 ## 2. Glossary
 
 These definitions apply to every antenna type in Part II.
 
-- **Directivity ($D$):** $D = \frac{4\pi U_{max}}{P_{rad}}$.
-- **Gain ($G$):** $10 \log_{10}(\eta \cdot D)$ dBi.
+- **Directivity ($D$):** $D = \frac{4\pi U_{max}}{P_{rad}}$. Computed as $G_{max} / \langle G \rangle$, where $\langle G \rangle$ is the whole-sphere average of the NEC power-gain pattern (`src/physics/patternIntegral.ts`). Deriving it from the NEC `POWER BUDGET` block instead ($D = G/\eta$) is only valid in free space: that budget counts conductor and network loss but not power absorbed by a lossy ground, so over real soil it collapses $D$ onto $G$.
+- **Gain ($G$):** $10 \log_{10}(\eta \cdot D)$ dBi. Read directly from the `RP` card's TOTAL column, which with `XNDA = 1000` is power gain referenced to the accepted input power — all ohmic and termination losses already included.
 - **Realized Gain:** $G(dBi) + 10 \log_{10}(1 - |\Gamma|^2)$.
-- **Efficiency ($\eta$):** $P_{rad} / P_{in}$.
+- **Efficiency ($\eta$):** $P_{rad} / P_{in}$, from the NEC power budget: conductor and termination loss only. Ground absorption happens after radiation and is not counted here — it shows up as the gap between $G$ and $D$.
+- **Average gain ($\langle G \rangle$):** $\frac{1}{4\pi}\oint G\,d\Omega$ — the fraction of input power that reaches the far field. NEC's classical average-gain test: a lossless free-space model must return $1.0$, and a value far off that indicates unconverged segmentation.
+- **Pattern surface (3D):** the rendered radius is the *linear power* gain, $r \propto 10^{G(\theta,\varphi)/10}$, so the bubble is the gain surface itself. The $/20$ field-amplitude exponent would draw its square root and halve every lobe ratio in dB.
 - **Front/Back:** $G_{peak} - G_{180^\circ}$ (dB).
 - **Ripple:** $(I_{max}-I_{min})/(I_{max}+I_{min})$.
 

--- a/docs/antenna-spec.md
+++ b/docs/antenna-spec.md
@@ -70,7 +70,7 @@ A **terminated** antenna places a non-inductive resistive load somewhere on the 
 
 - **Sloping V**: Termination consists of a resistor connected from the end of each leg to ground via a short stub wire. Typical value $300\text{--}600\,\Omega$ (matches the leg's characteristic impedance against ground).
 - **Terminated Delta**: Termination is a single resistor on a short horizontal _bridge wire_ spanning the gap at the centre of the base. Typical value $\sim 600\,\Omega$ (close to the loop wire's characteristic impedance over typical HF heights, $Z_0 \approx 60 \ln(2h/a) \approx 500\text{--}700\,\Omega$). **Not** two resistors to ground — that topology is symmetric but fails to terminate the loop, leaving large reactive feedpoint impedance and high leg current ripple.
-- **Terminated Folded Dipole**: Termination is a single resistor on a short horizontal _bridge wire_ spanning the gap at the centre of the top (un-fed) conductor. Typical value $\sim 390\text{--}600\,\Omega$. Like the terminated delta, this implements a proper TFD (T2FD) aperiodic-loop topology by forcing current through the resistor across the gap.
+- **Terminated Folded Dipole**: Termination is a single resistor on a short horizontal _bridge wire_ spanning the gap at the centre of the top (un-fed) conductor. Like the terminated delta, this implements a proper TFD (T2FD) aperiodic-loop topology by forcing current through the resistor across the gap. Unlike the two loop types, the resistor lands in series with the feedpoint almost 1:1, so its value is a direct efficiency dial — recommended $300\,\Omega$ (−3 dB); see §13.3 for the closed form.
 - **Effect (sloping V)**: converts a resonant bi-directional radiator into a broadband uni-directional travelling-wave radiator.
 - **Effect (terminated delta)**: converts a resonant narrowband loop into a broadband aperiodic loop. Pattern stays roughly delta-loop-shaped (broadside max, end-fire minimum). Multi-band usable with a 9:1 unun.
 - **Effect (terminated folded dipole)**: flattens SWR across a wide frequency range compared to a standard folded dipole, at the cost of radiation efficiency due to power dissipated in the termination.
@@ -412,18 +412,26 @@ Every type below uses the coordinate conventions of Part I §1 and the glossary 
 - **NEC Excitation:** Segment 1 of `FEED_BRIDGE_TAG` (3) at the centre of the lower conductor — handled by the existing `hasBridge` excitation path.
 - **Feed Type:** Single-segment voltage source on the bridge; balanced.
 - **Feedline Support:** Supported (Radiating shield + NEC `TL` card; feedpoint always at the centre bridge, offset is not applicable).
-- **Feedpoint Impedance:** Approximately 4× a plain dipole (~300 Ω) for equal-diameter conductors, largely independent of spacing. A 4:1 balun brings this to ~75 Ω; a 6:1 brings it to ~50 Ω for direct coax use. 300 Ω twin-lead matches it directly.
+- **Feedpoint Impedance:** Approximately 4× a plain dipole (~300 Ω, `FOLDED_DIPOLE_FEED_R_OHMS`) for equal-diameter conductors, largely independent of spacing — the two conductors each carry the same antenna-mode current, doubling the current for a given feed current. A 4:1 balun brings this to ~75 Ω; a 6:1 to ~50 Ω. 300 Ω twin-lead matches it directly.
+- **Default balun: 9:1**, not the textbook 6:1. Over real ground the feedpoint is ~285 + 90j rather than a clean 300 Ω, and the recommended termination adds another ~300 Ω in series, so 6:1 suits only the unterminated case. Measured at 7.1 MHz, 8 m over pastoral ground: 9:1 gives 1.6:1 unterminated and 1.4:1 terminated, where 6:1 gives 1.4:1 and 2.0:1.
 
 ### 13.3 Termination Definition
 
 - **Topology:** Optional. The opposite conductor is split into two halves at the centre. When terminated, a single `LD 4` resistor sits on a short horizontal bridge wire (`FOLDED_DIPOLE_TERM_BRIDGE_TAG`) that spans the gap between the two inner ends of the un-fed (top) conductor.
 - **Unterminated (`terminatingResistor = 0`):** A classic folded dipole — ~300 Ω, narrowband, dipole gain and pattern.
-- **Terminated (`terminatingResistor > 0`):** A terminated folded dipole (TFD or T2FD). The resistor flattens SWR across a wide frequency range at the cost of efficiency (roughly half the power is dissipated). Typical value ~390–600 Ω. This is the straight-conductor cousin of the aperiodic loop modelled under §10 as a terminated delta.
+- **Terminated (`terminatingResistor > 0`):** A terminated folded dipole (TFD or T2FD). The resistor flattens SWR across a wide frequency range at the cost of efficiency. This is the straight-conductor cousin of the aperiodic loop modelled under §10 as a terminated delta.
+- **Cost of termination — closed form.** At the half-wave resonance the unfed conductor carries essentially the same current as the fed one (that is *why* the feedpoint is 4× a dipole's), and the resistor sits at its current maximum, so it appears at the feedpoint almost 1:1 in series with the radiation resistance:
+
+$$\eta \approx \frac{R_{feed}}{R_{feed} + R} \qquad \Delta G \approx -10\log_{10}\left(1 + \frac{R}{R_{feed}}\right)\ \text{dB}$$
+
+  Verified against the solver at 7.1 MHz, 8 m over pastoral ground: R = 300 Ω → 49 % efficiency (predicted 48.6 %), R = 600 Ω → 32.5 % (predicted 32.1 %), R = 900 Ω → 24.4 % (predicted 24.0 %). The feedpoint rises by almost exactly R, which is the same statement.
+- **Recommended value: `FOLDED_DIPOLE_DEFAULT_TERMINATION_OHMS` = 300 Ω** = $R_{feed}$, i.e. the 50 % / −3 dB point — the least that can be paid for broadband behaviour. **Not** the two-wire line's $Z_0$ (≈ 684 Ω at the default aperture), which was the earlier recommendation: that line is the *non-radiating* transmission-line mode, so terminating it in its own $Z_0$ flattens SWR without contributing to radiation, and measured 5.3 dB down at the design frequency. Across 7–28 MHz the 300 Ω + 9:1 pair holds the same worst-case SWR (5.6:1) as the old 684 Ω + 6:1 pair while returning 2.2 dB at the design frequency.
+- **Where the loss is booked.** The termination is an `LD 4` segment load, so NEC reports its dissipation under **STRUCTURE LOSS**, not NETWORK LOSS (which covers `NT` two-port networks and is 0 for these decks).
 
 ### 13.4 SWR Convention
 
 - **Reference:** 50 Ω.
-- **Statement:** Raw SWR against 50 Ω is high (~6:1) for the unterminated ~300 Ω feedpoint. A 6:1 impedance-transforming balun is **enabled by default** when this antenna type is selected, transforming the feedpoint to ~50 Ω and showing the characteristic flat broadband SWR curve. The terminated variant (TFD) shows an even flatter curve, reflecting the resistive termination rather than improved efficiency.
+- **Statement:** Raw SWR against 50 Ω is high (~6:1) for the unterminated ~300 Ω feedpoint. A 9:1 impedance-transforming balun is **enabled by default** when this antenna type is selected (see §13.2), landing both the plain and the terminated antenna under 1.7:1 at the design frequency. The terminated variant (TFD) shows a flatter curve across the band, reflecting the resistive termination rather than improved efficiency.
 
 ### 13.5 Segmentation Rules
 
@@ -436,4 +444,5 @@ Every type below uses the coordinate conventions of Part I §1 and the glossary 
 
 - **Unterminated:** Identical to a standard dipole (~2.15 dBi in free space) at narrow apertures. The fold is an impedance transformation, not a gain mechanism.
 - **Wide aperture:** As the spacing grows toward a notable fraction of a wavelength, the two in-phase conductors begin to act as a broadside two-element array and the pattern departs from a simple dipole.
-- **Terminated:** Lower than a plain dipole — the terminating resistor dissipates a substantial fraction of the input power (the broadband-vs-efficiency trade).
+- **Terminated:** Lower than a plain dipole by $10\log_{10}(1 + R/R_{feed})$ dB — 3.0 dB at the recommended 300 Ω (§13.3). The *pattern* is untouched: directivity holds at 7.7 dBi across the whole range of R, so every dB is dissipation, not a change in radiation.
+- **Harmonic dips:** At even multiples of the design frequency the transmission-line mode presents a short across the feed (each side becomes a half-wave shorted stub), collapsing the feedpoint resistance. Terminated, nearly all the power then goes into the resistor: measured −0.3 dBi at 2× against +3.2 dBi at the design frequency. This is inherent to the folded topology and is why a T2FD is specified from its design frequency upward rather than at its harmonics.

--- a/src/components/Charts/PolarPlots.tsx
+++ b/src/components/Charts/PolarPlots.tsx
@@ -13,48 +13,70 @@ import { useAntennaStore, selectAtuConfig } from '../../store/antennaStore';
 import { useShallow } from 'zustand/react/shallow';
 import React, { useMemo, type ComponentProps } from 'react';
 import { displayedFeedMetrics } from '../../physics/impedance';
+import { bearingToPhiDeg, normalizeDeg } from '../../physics/angles';
 import type { GainPattern, SimulationResult } from '../../physics/types';
 
 ChartJS.register(RadialLinearScale, PointElement, LineElement, Filler, Tooltip);
 
+/** Grid column holding NEC azimuth φ, wrapped into the pattern's phi range. */
+function phiIndex(p: GainPattern, phiDeg: number): number {
+  const wrapped = ((phiDeg % 360) + 360) % 360;
+  return Math.round(wrapped / p.dPhi) % p.phiSteps;
+}
+
+/**
+ * Azimuth cut at a fixed theta, resampled onto compass bearings.
+ *
+ * The pattern is indexed by NEC azimuth φ (0° = +X = East, counter-clockwise),
+ * but Chart.js lays a radar's points out clockwise from the top — i.e. exactly
+ * a compass rose. Entry k therefore has to sample the grid at
+ * φ = bearingToPhiDeg(k · dPhi), otherwise the plotted pattern is rotated 90°
+ * and mirrored relative to the cardinal labels.
+ */
 function cutAzimuth(p: GainPattern, thetaDeg: number): number[] {
   const ti = Math.max(0, Math.min(p.thetaSteps - 1, Math.round(thetaDeg / p.dTheta)));
   const out = new Array<number>(p.phiSteps);
   const baseIdx = ti * p.phiSteps;
-  for (let pi = 0; pi < p.phiSteps; pi++) {
-    out[pi] = p.data[baseIdx + pi] ?? -60;
+  for (let k = 0; k < p.phiSteps; k++) {
+    const pi = phiIndex(p, bearingToPhiDeg(k * p.dPhi));
+    out[k] = p.data[baseIdx + pi] ?? -60;
   }
   return out;
 }
 
+/** Cardinal labels for the azimuth ring, which is indexed by compass bearing. */
 function getAzimuthLabels(p: GainPattern): string[] {
   const labels = new Array<string>(p.phiSteps).fill('');
-  for (let pi = 0; pi < p.phiSteps; pi++) {
-    const phiDeg = pi * p.dPhi;
-    // We only label primary cardinal points if they align with the phi step.
-    if (phiDeg === 0 || phiDeg === 360) labels[pi] = 'N';
-    else if (phiDeg === 45) labels[pi] = 'NE';
-    else if (phiDeg === 90) labels[pi] = 'E';
-    else if (phiDeg === 135) labels[pi] = 'SE';
-    else if (phiDeg === 180) labels[pi] = 'S';
-    else if (phiDeg === 225) labels[pi] = 'SW';
-    else if (phiDeg === 270) labels[pi] = 'W';
-    else if (phiDeg === 315) labels[pi] = 'NW';
+  for (let k = 0; k < p.phiSteps; k++) {
+    const bearingDeg = k * p.dPhi;
+    // We only label primary cardinal points if they align with the step.
+    if (bearingDeg === 0 || bearingDeg === 360) labels[k] = 'N';
+    else if (bearingDeg === 45) labels[k] = 'NE';
+    else if (bearingDeg === 90) labels[k] = 'E';
+    else if (bearingDeg === 135) labels[k] = 'SE';
+    else if (bearingDeg === 180) labels[k] = 'S';
+    else if (bearingDeg === 225) labels[k] = 'SW';
+    else if (bearingDeg === 270) labels[k] = 'W';
+    else if (bearingDeg === 315) labels[k] = 'NW';
   }
   return labels;
 }
 
-function cutElevation(p: GainPattern, phiDeg: number): number[] {
+/**
+ * Elevation cut through a given compass bearing (0° = North, clockwise).
+ * The bearing is converted to NEC azimuth φ before indexing the pattern.
+ */
+function cutElevation(p: GainPattern, bearingDeg: number): number[] {
   // To create a full 360 degree elevation slice:
   // Top (0 deg) is Zenith. Bottom (180 deg) is Nadir.
-  // Right side (0 to 180) maps to forward azimuth (phiDeg).
-  // Left side (360 down to 180) maps to backward azimuth (phiDeg + 180).
+  // Right side (0 to 180) maps to the forward bearing.
+  // Left side (360 down to 180) maps to the reciprocal bearing (+180°).
   const numPoints = Math.round(360 / p.dTheta);
   const out = new Array<number>(numPoints).fill(-60);
 
-  const forwardPi = Math.max(0, Math.min(p.phiSteps - 1, Math.round(phiDeg / p.dPhi)));
-  const backwardPhiDeg = (phiDeg + 180) % 360;
-  const backwardPi = Math.max(0, Math.min(p.phiSteps - 1, Math.round(backwardPhiDeg / p.dPhi)));
+  const forwardPhiDeg = bearingToPhiDeg(bearingDeg);
+  const forwardPi = phiIndex(p, forwardPhiDeg);
+  const backwardPi = phiIndex(p, forwardPhiDeg + 180);
 
   for (let ti = 0; ti < p.thetaSteps; ti++) {
     out[ti] = p.data[ti * p.phiSteps + forwardPi] ?? -60;
@@ -192,10 +214,10 @@ function AzimuthPlot({ result, dbRange, options }: { result: SimulationResult, d
   );
 }
 
-function ElevationPlot({ title, result, dbRange, azimuth, options }: { title: string, result: SimulationResult, dbRange: number, azimuth: number, options: ComponentProps<typeof PolarPlotPanel>['options'] }) {
+function ElevationPlot({ title, result, dbRange, bearingDeg, options }: { title: string, result: SimulationResult, dbRange: number, bearingDeg: number, options: ComponentProps<typeof PolarPlotPanel>['options'] }) {
   const cut = useMemo(() => {
-    return cutElevation(result.pattern, azimuth);
-  }, [result.pattern, azimuth]);
+    return cutElevation(result.pattern, bearingDeg);
+  }, [result.pattern, bearingDeg]);
 
   const data = useMemo(() => {
     return normaliseForPolar(cut, result.maxGainDbi, dbRange);
@@ -262,23 +284,25 @@ export function PolarPlots() {
     return displayedRealizedGainDbi ?? result.maxGainDbi;
   }, [result, transformerEnabled, transformerRatio, feedlineId, atuEnabled, frequency, feedlineLength, atuMainFeedlineLength]);
 
-  const { broadsideAz, endOnAz } = useMemo(() => {
-    let azimuth = 0;
+  // `orientation` is a compass heading of the wire axis (NS = 0°, EW = 90°),
+  // the same convention `orientationVector()` builds the geometry from. Both
+  // cuts stay in compass bearings; `cutElevation` converts to NEC φ.
+  const { broadsideBearing, endOnBearing } = useMemo(() => {
+    let heading = 0;
     if (typeof orientation === 'number') {
-      azimuth = orientation;
+      heading = orientation;
     } else {
       switch (orientation) {
-        case 'NS': azimuth = 0; break;
-        case 'EW': azimuth = 90; break;
-        case 'NE-SW': azimuth = 45; break;
-        case 'NW-SE': azimuth = 315; break;
+        case 'NS': heading = 0; break;
+        case 'EW': heading = 90; break;
+        case 'NE-SW': heading = 45; break;
+        case 'NW-SE': heading = 315; break;
       }
     }
-    // "End-on" is along the wire axis (phi = azimuth).
-    // "Broadside" is perpendicular to the wire axis (azimuth + 90).
+    // "End-on" is along the wire axis; "broadside" is perpendicular to it.
     return {
-      endOnAz: azimuth % 360,
-      broadsideAz: (azimuth + 90) % 360,
+      endOnBearing: normalizeDeg(heading),
+      broadsideBearing: normalizeDeg(heading + 90),
     };
   }, [orientation]);
 
@@ -300,14 +324,14 @@ export function PolarPlots() {
           title="Elevation (Broadside)"
           result={result}
           dbRange={dbRange}
-          azimuth={broadsideAz}
+          bearingDeg={broadsideBearing}
           options={options}
         />
         <ElevationPlot
           title="Elevation (End-on)"
           result={result}
           dbRange={dbRange}
-          azimuth={endOnAz}
+          bearingDeg={endOnBearing}
           options={options}
         />
       </div>

--- a/src/components/Charts/PropagationRadar.tsx
+++ b/src/components/Charts/PropagationRadar.tsx
@@ -93,7 +93,10 @@ function buildAzimuthalWedges(
   const ringIndex = ringN - 1;
   let aPoint = az[0]!;
   const rA = (aPoint.rangeKm[ringIndex] ?? 0) * kmToPx;
-  const aRad = (((aPoint.phiDeg % 360) + 360) % 360) * DEG_TO_RAD;
+  // Screen angle is a compass bearing: 0° points up (North) and grows
+  // clockwise, hence x = sin, y = −cos. The pattern's own NEC azimuth φ is a
+  // different convention and must not be substituted here.
+  const aRad = (((aPoint.bearingDeg % 360) + 360) % 360) * DEG_TO_RAD;
   let ax = cx + rA * Math.sin(aRad);
   let ay = cy - rA * Math.cos(aRad);
 
@@ -112,7 +115,7 @@ function buildAzimuthalWedges(
     } else {
       bPoint = az[i + 1]!;
       const rB = (bPoint.rangeKm[ringIndex] ?? 0) * kmToPx;
-      const bRad = (((bPoint.phiDeg % 360) + 360) % 360) * DEG_TO_RAD;
+      const bRad = (((bPoint.bearingDeg % 360) + 360) % 360) * DEG_TO_RAD;
       bx = cx + rB * Math.sin(bRad);
       by = cy - rB * Math.cos(bRad);
     }

--- a/src/components/Panel/GeometryControl.tsx
+++ b/src/components/Panel/GeometryControl.tsx
@@ -9,7 +9,7 @@ import {
 } from '../../physics/units';
 import { type AntennaType } from '../../store/antennaStore';
 import { type OrientationPreset } from '../../store/antennaGeometry';
-import { FOLDED_DIPOLE_MAX_APERTURE_M } from '../../physics/constants';
+import { FOLDED_DIPOLE_MAX_APERTURE_M, FOLDED_DIPOLE_FEED_R_OHMS } from '../../physics/constants';
 import { TransformerControl } from './TransformerControl';
 
 const resonateTitles: Record<AntennaType, string> = {
@@ -20,7 +20,7 @@ const resonateTitles: Record<AntennaType, string> = {
   'terminated-delta': 'Set perimeter to 1λ',
   'vertical-whip': 'Set whip length to resonant ¼λ',
   'inverted-l': 'Set total wire length (vertical + horizontal) to resonant ¼λ. The horizontal section makes up any length the mast height falls short of a full quarter-wave.',
-  'folded-dipole': 'Set each conductor to a resonant ½λ. Raw feedpoint ~300 Ω (~4× a plain dipole). A 6:1 impedance-transforming balun is enabled by default, which transforms this to ~50 Ω and reveals the characteristic narrowband resonant curve. Same gain and pattern as a plain dipole when unterminated. For a broadband T2FD, add a terminating resistor (click Z₀) and apply the suggested transformer ratio.',
+  'folded-dipole': 'Set each conductor to a resonant ½λ. Raw feedpoint ~300 Ω (~4× a plain dipole). A 9:1 impedance-transforming balun is enabled by default — a compromise that lands both the plain and the terminated antenna under 1.7:1, since terminating adds the resistor in series with the feedpoint. Same gain and pattern as a plain dipole when unterminated. For a broadband T2FD, add the recommended 300 Ω terminating resistor and apply the suggested transformer ratio.',
 };
 
 function calculateTfdZ0(aperture: number, radius: number): number {
@@ -134,7 +134,7 @@ function LengthControl() {
 function getTerminationHint(antennaType: AntennaType, terminatingResistor: number, tfdZ0: number): string {
   if (terminatingResistor === 0) {
     if (antennaType === 'folded-dipole') {
-      return 'Unterminated: a classic folded dipole — ~300 Ω feedpoint, narrowband, same gain and pattern as a plain dipole. Add a resistor for a broadband terminated folded dipole (T2FD); click Z₀ to set the optimal termination for this conductor spacing. Use the Match button in the Transformer section below to apply the suggested ratio.';
+      return 'Unterminated: a classic folded dipole — ~300 Ω feedpoint, narrowband, same gain and pattern as a plain dipole. Add a resistor for a broadband terminated folded dipole (T2FD); the recommended 300 Ω costs 3 dB, the least you can pay for broadband behaviour. Use the Match button in the Transformer section below to apply the suggested ratio.';
     }
     return 'Unterminated: travelling wave reflects, creating a standing-wave pattern. Use this mode to check whether the antenna structure resonates at the design frequency.';
   }
@@ -144,7 +144,8 @@ function getTerminationHint(antennaType: AntennaType, terminatingResistor: numbe
   }
 
   if (antennaType === 'folded-dipole') {
-    return `${terminatingResistor} Ω resistor at the centre of the conductor opposite the feed. Estimated raw feedpoint ≈ ${terminatingResistor + 300} Ω. Use the Match button in the Transformer section below to apply the optimal ratio (the transformer is never changed automatically). For a true travelling-wave T2FD — flat broadband SWR — set R ≈ Z₀ of the two-wire line (≈ ${tfdZ0} Ω for this conductor spacing; click Z₀). Lower R reduces dissipation but leaves significant reflection, narrowing the bandwidth. Click Off to restore the plain folded dipole.`;
+    const lossDb = (10 * Math.log10(1 + terminatingResistor / FOLDED_DIPOLE_FEED_R_OHMS)).toFixed(1);
+    return `${terminatingResistor} Ω resistor at the centre of the conductor opposite the feed. It sits at that conductor's current maximum, so it lands at the feedpoint almost 1:1 — raw feedpoint ≈ ${terminatingResistor + FOLDED_DIPOLE_FEED_R_OHMS} Ω — and costs about ${lossDb} dB of gain (10·log10(1 + R/${FOLDED_DIPOLE_FEED_R_OHMS})). The pattern shape is unchanged; watch Directivity hold still while Gain drops. Use the Match button in the Transformer section below to apply the optimal ratio (the transformer is never changed automatically). Raising R toward the two-wire line's Z₀ (≈ ${tfdZ0} Ω here) flattens SWR further at a steep price in gain; lowering it keeps gain but narrows the usable range. Click Off to restore the plain folded dipole.`;
   }
 
   return `${terminatingResistor} Ω resistors at each inner half-base end (to ground via short stubs). Click Off to remove termination and inspect resonance. Affects gain, directivity, front/back ratio, feedpoint impedance, realized gain, and termination loss. Lower SWR alone does not indicate the best design point.`;
@@ -216,15 +217,17 @@ function TerminationControl() {
     return null;
   }
 
-  // Characteristic impedance of the two-wire line formed by the folded-dipole conductors.
-  // Z₀ = 120 × acosh(D / (2r))  where D = spacing (aperture), r = wire radius.
-  // Terminating at R ≈ Z₀ gives a travelling-wave (T2FD) — broadband flat SWR.
+  // Characteristic impedance of the two-wire line formed by the folded-dipole
+  // conductors. Z₀ = 120 × acosh(D / (2r)), D = spacing (aperture), r = wire
+  // radius. Quoted in the hint as the maximum-flatness option; it is no longer
+  // the recommended value, because that line is the non-radiating
+  // transmission-line mode and damping it costs far more gain than it is worth.
   const tfdZ0 = antennaType === 'folded-dipole' ? calculateTfdZ0(foldedDipoleAperture, wireRadius) : 0;
 
   // Recommended ("auto") terminating resistance for this antenna. Every type that
   // supports a terminating resistor gets the auto-resistance button.
   const isFolded = antennaType === 'folded-dipole';
-  const recommended = recommendedTerminatingResistor(antennaType, foldedDipoleAperture, wireRadius);
+  const recommended = recommendedTerminatingResistor(antennaType);
 
   return (
     <>
@@ -259,14 +262,12 @@ function TerminationControl() {
             title={terminatingResistor === recommended
               ? `Already using the recommended ${recommended} Ω termination`
               : isFolded
-                ? `Set terminating resistor to Z₀ ≈ ${recommended} Ω — the characteristic impedance of the two-wire line for this conductor spacing and wire diameter. Terminating at R = Z₀ gives a true travelling-wave (T2FD): flat broadband SWR at the cost of ~3 dB efficiency.`
+                ? `Set terminating resistor to ${recommended} Ω — the folded dipole's own feedpoint resistance, so the resistor takes half the power: −3 dB, the least you can pay for broadband behaviour. Raising it flattens SWR further but the loss grows as 10·log10(1 + R/${recommended}) dB.`
                 : `Set terminating resistor to the recommended ${recommended} Ω for this antenna — approximately the structure's characteristic impedance over real ground, giving a flat broadband match.`}
-            aria-label={isFolded
-              ? `Set terminating resistor to Z₀ (${recommended} Ω)`
-              : `Set terminating resistor to recommended (${recommended} Ω)`}
+            aria-label={`Set terminating resistor to recommended (${recommended} Ω)`}
             style={{ flex: '0 0 auto' }}
           >
-            {isFolded ? 'Z₀' : `${recommended} Ω`}
+            {`${recommended} Ω`}
           </button>
         )}
         <button

--- a/src/components/Panel/StatsReadout.tsx
+++ b/src/components/Panel/StatsReadout.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { useAntennaStore, selectAtuConfig, LEFT_LEG_TAG, RIGHT_LEG_TAG } from '../../store/antennaStore';
 import { useShallow } from 'zustand/react/shallow';
 import { displayedFeedMetrics } from '../../physics/impedance';
+import { phiToBearingDeg } from '../../physics/angles';
 import type { AtuMatchConfig } from '../../physics/impedance';
 import { TRANSFORMER_INSERTION_LOSS_DB } from '../../physics/constants';
 import type { TerminationDiagnostics } from '../../physics/types';
@@ -72,7 +73,7 @@ export function StatsReadout() {
       <h2>Results <span className="badge">{result.computeTimeMs.toFixed(0)} ms</span></h2>
       <StatRow label="Gain" title="Antenna gain (dBi): NEC total power gain relative to isotropic, normalised to accepted input power. Includes all ohmic and termination losses." value={`${result.maxGainDbi.toFixed(2)} dBi`} valueClassName="accent" />
       {result.maxDirectivityDbi != null && (
-        <StatRow label="Directivity" title="Directivity (dBi): normalised to radiated power only, excluding all losses. = Gain / efficiency." value={`${result.maxDirectivityDbi.toFixed(2)} dBi`} />
+        <StatRow label="Directivity" title="Directivity (dBi): peak gain normalised to the power that actually radiates, D = 4π·U_max / P_rad, obtained by integrating the pattern over the sphere. Over real ground it exceeds the gain by the conductor, termination and soil-absorption losses combined." value={`${result.maxDirectivityDbi.toFixed(2)} dBi`} />
       )}
       {displayedRealizedGainDbi != null && (
         <StatRow label="Realized gain" title={realizedGainTitle} value={`${displayedRealizedGainDbi.toFixed(2)} dBi`} />
@@ -80,8 +81,8 @@ export function StatsReadout() {
       {result.efficiency != null && (
         <StatRow label="Efficiency" title="Radiation efficiency: radiated power / accepted input power. Losses include wire conductors and any termination resistors." value={`${(result.efficiency * 100).toFixed(1)}%`} />
       )}
-      <StatRow label="Take-off elevation" value={`${result.takeoffElevationDeg.toFixed(1)}°`} />
-      <StatRow label="Azimuth of peak" value={`${result.takeoffAzimuthDeg.toFixed(0)}°`} />
+      <StatRow label="Take-off elevation" title="Elevation angle of the peak-gain direction: 0° = horizon, 90° = zenith." value={`${result.takeoffElevationDeg.toFixed(1)}°`} />
+      <StatRow label="Azimuth of peak" title="Compass bearing of the peak-gain direction: 0° = North, 90° = East. (NEC solves in its own azimuth φ, measured from +X/East; this row reports the bearing.)" value={`${phiToBearingDeg(result.takeoffAzimuthDeg).toFixed(0)}°`} />
       <StatRow label={impedanceLabel} title={impedanceTitle} value={`${displayedZ.R.toFixed(1)} ${displayedZ.X >= 0 ? '+' : '−'}j${Math.abs(displayedZ.X).toFixed(1)} Ω`} />
       <StatRow label="SWR (vs 50 Ω)" title={swrTitle} value={`${displayedSwr.toFixed(2)}:1`} valueStyle={{ color: displayedSwr > 2 ? 'var(--danger)' : displayedSwr > 1.5 ? 'var(--warning)' : 'var(--success)' }} />
       {mode === 'comparison' && reference && (

--- a/src/components/Panel/StatsReadout.tsx
+++ b/src/components/Panel/StatsReadout.tsx
@@ -172,7 +172,11 @@ function TerminationSection({ diagnostics }: { diagnostics: TerminationDiagnosti
       )}
       {powerBudget !== null && (
         <>
-          <StatRow label="Termination load" value={`${(powerBudget.networkLossW * 1000).toFixed(2)} mW`} />
+          <StatRow
+            label="Termination load"
+            title="Power dissipated in the termination resistors. NEC books LD-card segment loads (which is how every termination in this app is modelled) as STRUCTURE LOSS and NT-card networks as NETWORK LOSS; no conductor loss is modelled, so the sum is the termination's alone."
+            value={`${((powerBudget.structureLossW + powerBudget.networkLossW) * 1000).toFixed(2)} mW`}
+          />
           <StatRow label="Radiated power" value={`${(powerBudget.radiatedW * 1000).toFixed(2)} mW`} />
         </>
       )}

--- a/src/components/Scene/RadiationPattern.tsx
+++ b/src/components/Scene/RadiationPattern.tsx
@@ -4,6 +4,7 @@ import { useAdaptiveLOD } from '../../hooks/useAdaptiveLOD';
 import type { SimulationResult } from '../../physics/types';
 import type { Colormap } from '../../store/antennaStore';
 import { pickTable, sampleColormapFast } from '../../utils/colormap';
+import { DB_TO_LINEAR_POWER, radiusScaleForPattern } from './patternRadius';
 
 interface Props {
   originY?: number;
@@ -76,14 +77,22 @@ function buildRenderGeometry(
 
   const invDTheta = 1 / dTheta;
   const invDPhi = 1 / dPhi;
-  const linearRangeFactor = patternScale * 2.5;
-  // 10^(x/20) = exp(x * ln(10)/20)
-  const scaleFactor = Math.LN10 / 20;
-  // Floor the gain used for radius calculation to ensure the pattern remains
-  // visible even for extremely lossy antennas (e.g. verticals without a
-  // counterpoise). At -25 dBi the bubble is ~0.15m radius, large enough to
-  // peek out from the feedpoint marker.
-  const RADIUS_GAIN_FLOOR_DBI = -25;
+  const scaleFactor = DB_TO_LINEAR_POWER;
+
+  // Peak of the pattern actually being drawn (realized-gain offset included).
+  let peakDb = -Infinity;
+  for (let i = 0; i < data.length; i++) {
+    const v = data[i]!;
+    if (v > peakDb) peakDb = v;
+  }
+  peakDb += realizedGainOffsetDb;
+
+  const { floorDb: radiusFloorDb, factor: linearRangeFactor } = radiusScaleForPattern(
+    peakDb,
+    dbRange,
+    patternScale,
+  );
+
   const minDb = colorMaxDb - dbRange;
   const invRange = 1 / dbRange;
   const table = pickTable(colormap);
@@ -123,7 +132,7 @@ function buildRenderGeometry(
     const gainDb = v0 + (v1 - v0) * ft + realizedGainOffsetDb;
 
     // Position
-    const radius = Math.exp(Math.max(gainDb, RADIUS_GAIN_FLOOR_DBI) * scaleFactor) * linearRangeFactor;
+    const radius = Math.exp(Math.max(gainDb, radiusFloorDb) * scaleFactor) * linearRangeFactor;
     const idx = i * 3;
     posBuffer[idx] = basePositions[idx]! * radius;
     posBuffer[idx + 1] = basePositions[idx + 1]! * radius;

--- a/src/components/Scene/patternRadius.ts
+++ b/src/components/Scene/patternRadius.ts
@@ -1,0 +1,57 @@
+// Radius law for the 3D radiation-pattern surface.
+//
+// Kept out of the component file so it can be unit-tested directly and so the
+// component module keeps exporting only its component.
+
+/**
+ * NEC reports *power* gain in dB, so the linear gain is 10^(dB/10) and the
+ * surface r(θ,φ) ∝ G(θ,φ) is the antenna's actual gain surface. The /20
+ * (field-amplitude) exponent would draw the square root of the pattern
+ * instead: lobes flattened, and every null and front-to-back ratio shown at
+ * half its true dB depth.
+ *
+ *   10^(x/10) = exp(x · ln(10)/10)
+ */
+export const DB_TO_LINEAR_POWER = Math.LN10 / 10;
+
+/**
+ * Metres of radius per unit of linear gain, at 1× pattern scale: a 6 dBi
+ * antenna draws a ~5 m peak radius, which sits sensibly against a typical HF
+ * wire span.
+ */
+const RADIUS_M_PER_LINEAR_GAIN = 1.25;
+
+/**
+ * Very lossy antennas would otherwise shrink to nothing. Below this peak
+ * radius the whole bubble is scaled up uniformly — shape and relative lobe
+ * structure are preserved, only the absolute size stops being to scale.
+ */
+const MIN_PEAK_RADIUS_M = 0.35;
+
+/**
+ * Resolves the two numbers the vertex loop needs to turn a gain in dB into a
+ * radius in metres:
+ *
+ *   radius = exp(max(gainDb, floorDb) · DB_TO_LINEAR_POWER) · factor
+ *
+ * `floorDb` is the pattern's own peak less the display dynamic range, rather
+ * than a fixed absolute floor. An absolute floor collapses an entire low-gain
+ * pattern onto one radius, so a very lossy antenna rendered as a featureless
+ * sphere with no directivity at all; referencing the floor to the peak keeps
+ * the shape intact at every gain level.
+ */
+export function radiusScaleForPattern(
+  peakDb: number,
+  dbRange: number,
+  patternScale: number,
+): { floorDb: number; factor: number } {
+  const naturalPeakRadius = Math.exp(peakDb * DB_TO_LINEAR_POWER) * patternScale * RADIUS_M_PER_LINEAR_GAIN;
+  const sizeBoost =
+    naturalPeakRadius > 0 && naturalPeakRadius < MIN_PEAK_RADIUS_M
+      ? MIN_PEAK_RADIUS_M / naturalPeakRadius
+      : 1;
+  return {
+    floorDb: peakDb - dbRange,
+    factor: patternScale * RADIUS_M_PER_LINEAR_GAIN * sizeBoost,
+  };
+}

--- a/src/physics/angles.ts
+++ b/src/physics/angles.ts
@@ -1,0 +1,48 @@
+// Angle conventions shared by the physics layer and every display surface.
+//
+// Two different azimuth conventions are in play and they are NOT the same
+// number, so every boundary between them has to convert explicitly:
+//
+//   NEC azimuth φ — the angle the NEC-2 RP card sweeps. Measured in the
+//     horizontal plane from the +X axis toward the +Y axis (mathematical /
+//     counter-clockwise seen from above). This is what `GainPattern` is
+//     indexed by and what `SimulationResult.takeoffAzimuthDeg` reports.
+//
+//   Compass bearing — what the user reads. 0° = North, increasing clockwise
+//     (90° = East). Per docs/antenna-spec.md §1.3 the geometry builder puts
+//     North on +Y and East on +X, so φ = 0 is due East and φ = 90 is due
+//     North.
+//
+// Substituting those two anchors into a linear map gives
+//
+//     bearing = 90° − φ   (mod 360)
+//
+// which is its own inverse — the same expression converts back — because the
+// two conventions differ by both a 90° rotation and a handedness flip.
+//
+// Getting this wrong is not a cosmetic label problem: it rotates the whole
+// azimuth pattern by 90° and mirrors it, which (for example) makes a
+// north–south dipole look as though it radiates north and south instead of
+// broadside to east and west.
+
+/** Wrap an angle in degrees into [0, 360). */
+export function normalizeDeg(deg: number): number {
+  return ((deg % 360) + 360) % 360;
+}
+
+/**
+ * NEC azimuth φ (0° = +X = East, increasing toward +Y = North) → compass
+ * bearing (0° = North, increasing clockwise toward East).
+ */
+export function phiToBearingDeg(phiDeg: number): number {
+  return normalizeDeg(90 - phiDeg);
+}
+
+/**
+ * Compass bearing (0° = North, clockwise) → NEC azimuth φ (0° = +X = East,
+ * counter-clockwise). Identical expression to `phiToBearingDeg`: the mapping
+ * is an involution.
+ */
+export function bearingToPhiDeg(bearingDeg: number): number {
+  return normalizeDeg(90 - bearingDeg);
+}

--- a/src/physics/constants.ts
+++ b/src/physics/constants.ts
@@ -288,6 +288,18 @@ export const FOLDED_DIPOLE_TERM_BRIDGE_TAG = 19;
 export const FOLDED_DIPOLE_DEFAULT_APERTURE_M = 0.3;
 
 /**
+ * Nominal feedpoint resistance of a resonant folded dipole, ohms: 4× a plain
+ * dipole's ~73 Ω, because the two equal-diameter conductors each carry the
+ * same antenna-mode current, doubling the current for a given feed current and
+ * so quadrupling the impedance. Independent of conductor spacing.
+ *
+ * Doubles as the recommended T2FD termination — see
+ * `FOLDED_DIPOLE_DEFAULT_TERMINATION_OHMS` — because a resistor in the unfed
+ * conductor lands in series with this resistance almost 1:1.
+ */
+export const FOLDED_DIPOLE_FEED_R_OHMS = 300;
+
+/**
  * Maximum folded-dipole conductor spacing, metres. Two long, closely-spaced
  * parallel wires converge slowly in NEC's thin-wire kernel: the segment length
  * must shrink with the spacing, and beyond ~0.5 m the structure would need

--- a/src/physics/nec2Engine.ts
+++ b/src/physics/nec2Engine.ts
@@ -21,6 +21,7 @@
 import { buildNecCards } from './necCard';
 import { parseNecImpedanceSweep, parseNecOutput } from './necParser';
 import { computeTerminationDiagnostics } from './terminationDiagnostics';
+import { directivityDbi } from './patternIntegral';
 import { swr, mismatchLossFactor } from './impedance';
 import type { Engine, GainPattern, ImpedanceResult, SimulationInput, SimulationResult, SweepPoint } from './types';
 import { SWEEP_F_MIN_MHZ, SWEEP_F_MAX_MHZ } from './constants';
@@ -97,23 +98,70 @@ export interface Nec2EngineOptions {
 }
 
 /**
- * Helper to locate the maximum gain direction and its corresponding elevation
- * and azimuth angles in degrees.
+ * Locate the maximum-gain direction and report it as an elevation angle and a
+ * NEC azimuth φ, both in degrees.
+ *
+ * Ties matter. A pattern is frequently flat to within NEC's 0.01 dB print
+ * resolution over a whole span of directions — a free-space dipole is exactly
+ * as strong straight up as it is broadside, and a lobe over ground is often
+ * equal-valued across several elevation rows. Scanning the flat grid and
+ * keeping the first strict maximum resolves every one of those ties toward
+ * θ = 0 (the zenith), because row 0 is visited first. That produced a
+ * take-off elevation of 90° for free-space patterns, and made the azimuth cut
+ * a featureless circle: at the zenith every φ holds the same value.
+ *
+ * So among directions tied at the peak we keep the *lowest* elevation, which
+ * is both the useful HF take-off angle and the direction whose azimuth cut
+ * actually carries the pattern's shape. Remaining ties keep the lowest φ.
  */
 function findMaxGainDirection(pattern: GainPattern): { maxGain: number; elevationDeg: number; phiDeg: number } {
+  // NEC prints gains to 0.01 dB, so tied directions arrive as bit-identical
+  // Float32s. This epsilon only absorbs float noise — it deliberately does not
+  // merge directions NEC itself distinguishes.
+  const TIE_EPSILON_DB = 1e-6;
+
   let maxGain = -Infinity;
-  let maxIdx = 0;
   for (let i = 0; i < pattern.data.length; i++) {
     const v = pattern.data[i]!;
-    if (v > maxGain) {
-      maxGain = v;
-      maxIdx = i;
+    if (v > maxGain) maxGain = v;
+  }
+
+  // Walk theta rows from the horizon back up to the zenith so the first row
+  // holding a tied peak is the lowest-elevation one. θ > 90° (below the
+  // horizon) is only ever populated in free space, so it is searched last.
+  const threshold = maxGain - TIE_EPSILON_DB;
+  const horizonTi = Math.min(pattern.thetaSteps - 1, Math.round(90 / pattern.dTheta));
+  const firstPeakPi = (ti: number): number => {
+    const row = ti * pattern.phiSteps;
+    for (let pi = 0; pi < pattern.phiSteps; pi++) {
+      if (pattern.data[row + pi]! >= threshold) return pi;
+    }
+    return -1;
+  };
+
+  let bestTi = 0;
+  let bestPi = 0;
+  let found = false;
+  for (let ti = horizonTi; ti >= 0 && !found; ti--) {
+    const pi = firstPeakPi(ti);
+    if (pi >= 0) {
+      bestTi = ti;
+      bestPi = pi;
+      found = true;
     }
   }
-  const ti = Math.floor(maxIdx / pattern.phiSteps);
-  const pi = maxIdx % pattern.phiSteps;
-  const thetaDeg = ti * pattern.dTheta;
-  const phiDeg = pi * pattern.dPhi;
+  // Peak lies below the horizon (only reachable in free space).
+  for (let ti = horizonTi + 1; ti < pattern.thetaSteps && !found; ti++) {
+    const pi = firstPeakPi(ti);
+    if (pi >= 0) {
+      bestTi = ti;
+      bestPi = pi;
+      found = true;
+    }
+  }
+
+  const thetaDeg = bestTi * pattern.dTheta;
+  const phiDeg = bestPi * pattern.dPhi;
   // Convert NEC theta (0 = +z zenith) to elevation (0 = horizon).
   const elevationDeg = 90 - thetaDeg;
 
@@ -311,12 +359,12 @@ export class Nec2Engine implements Engine {
 
       const efficiency = parsed.powerBudget ? parsed.powerBudget.efficiencyPct / 100 : undefined;
 
-      // Directivity: D = G / η  →  D(dBi) = G(dBi) − 10·log10(η)
-      // Only defined when the power budget is available and η > 0.
-      const maxDirectivityDbi =
-        efficiency && efficiency > 1e-6
-          ? maxGain - 10 * Math.log10(efficiency)
-          : undefined;
+      // Directivity: D = 4π·U_max / P_rad = G_max / ⟨G⟩, with ⟨G⟩ the whole-
+      // sphere average of the power gain. Integrating the pattern is the
+      // definition; the shortcut D = G / η only matches it in free space,
+      // because NEC's power budget cannot see the power a lossy ground
+      // absorbs and so reports η = 100 % over soil.
+      const maxDirectivityDbi = directivityDbi(parsed.pattern, maxGain);
 
       // Realized gain: deducts feedpoint mismatch loss vs 50 Ω source.
       // G_r(dBi) = G(dBi) + 10·log10(1 − |Γ|²)

--- a/src/physics/necParser.ts
+++ b/src/physics/necParser.ts
@@ -206,7 +206,10 @@ export function parseNecCurrents(text: string): SegmentCurrent[] {
  *   NETWORK LOSS  =  0.0000E+00 Watts
  *   EFFICIENCY    =  100.00 Percent
  *
- * NETWORK LOSS includes power dissipated in NT-card resistors (termination).
+ * STRUCTURE LOSS is where LD-card segment loads land — which is how every
+ * termination resistor in this app is modelled, so it is the termination's
+ * dissipation. NETWORK LOSS covers NT-card two-port networks instead, and is
+ * therefore 0 for these decks.
  */
 export function parseNecPowerBudget(text: string): PowerBudget | null {
   const blockStart = text.indexOf('POWER BUDGET');

--- a/src/physics/patternIntegral.ts
+++ b/src/physics/patternIntegral.ts
@@ -1,0 +1,75 @@
+// Whole-sphere integration of a NEC gain pattern.
+//
+// NEC's RP card with D = 0 reports *power gain*: G(θ,φ) = 4π U(θ,φ) / P_in.
+// Integrating that over the sphere therefore recovers the fraction of the
+// input power that actually left as a far field:
+//
+//   ⟨G⟩ = (1/4π) ∮ G(θ,φ) dΩ = P_far-field / P_in
+//
+// This is NEC's classical "average gain test". Two things fall out of it:
+//
+//   • Directivity. D = 4π U_max / P_rad = G_max / ⟨G⟩, which in dB is
+//     G_max(dBi) − 10·log10⟨G⟩. Deriving it from the POWER BUDGET block
+//     instead (D = G / η) is only equivalent in free space: NEC's budget
+//     counts conductor and network loss, but knows nothing about power the
+//     ground absorbs on reflection. Over average soil roughly a quarter of
+//     the radiated power is lost that way, so the budget reports η = 100 %
+//     and the directivity collapses onto the gain, understating it by well
+//     over a dB.
+//
+//   • A model sanity check. For a lossless antenna in free space ⟨G⟩ must
+//     come out at 1.0; a value far from that means the segmentation or the
+//     geometry is not converged.
+
+import type { GainPattern } from './types';
+
+/**
+ * Average of the power gain over the whole sphere, as a linear ratio.
+ *
+ * The pattern is a regular θ/φ grid, so this is a midpoint sum in φ (which is
+ * periodic and therefore exact for the sampling) and a trapezoidal sum in θ
+ * weighted by the sin θ area element. The θ endpoints carry half weight; both
+ * sit at a pole where sin θ = 0, so they contribute nothing either way.
+ *
+ * Directions NEC never computed (below-ground rows over a ground plane, and
+ * true nulls) arrive as a large negative dB sentinel, which contributes ~0 to
+ * the sum — correct in both cases, since no power goes there.
+ *
+ * Returns 0 for a pattern with no usable grid.
+ */
+export function averageGainLinear(pattern: GainPattern): number {
+  const { data, thetaSteps, phiSteps, dTheta, dPhi } = pattern;
+  if (thetaSteps < 2 || phiSteps < 1 || data.length < thetaSteps * phiSteps) return 0;
+
+  const DEG = Math.PI / 180;
+  const dThetaRad = dTheta * DEG;
+  const dPhiRad = dPhi * DEG;
+  const dbToLinear = Math.LN10 / 10;
+
+  let sum = 0;
+  for (let ti = 0; ti < thetaSteps; ti++) {
+    const sinTheta = Math.sin(ti * dTheta * DEG);
+    if (sinTheta === 0) continue;
+    const weight = ti === 0 || ti === thetaSteps - 1 ? 0.5 : 1;
+    const row = ti * phiSteps;
+    let rowSum = 0;
+    for (let pi = 0; pi < phiSteps; pi++) {
+      rowSum += Math.exp(data[row + pi]! * dbToLinear);
+    }
+    sum += rowSum * sinTheta * weight;
+  }
+
+  return (sum * dThetaRad * dPhiRad) / (4 * Math.PI);
+}
+
+/**
+ * Peak directivity in dBi: D = G_max / ⟨G⟩.
+ *
+ * Returns undefined when the pattern cannot be integrated (degenerate grid, or
+ * a pattern that radiates nowhere), so callers can fall back or hide the row.
+ */
+export function directivityDbi(pattern: GainPattern, maxGainDbi: number): number | undefined {
+  const avg = averageGainLinear(pattern);
+  if (!Number.isFinite(avg) || avg <= 1e-12) return undefined;
+  return maxGainDbi - 10 * Math.log10(avg);
+}

--- a/src/physics/propagation.ts
+++ b/src/physics/propagation.ts
@@ -49,6 +49,7 @@
 //   • IPS Radio & Space Services (Australia): definition of T-index.
 //   • Davies, K. (1990), Ionospheric Radio: zenith-angle absorption model.
 
+import { phiToBearingDeg } from './angles';
 import type { GainPattern } from './types';
 
 /**
@@ -109,7 +110,14 @@ export interface PropagationPrediction {
   readonly solarZenithDeg: number;
   /** Ranges for each azimuth, if a pattern was provided. */
   readonly azimuthalHops?: {
+    /** NEC azimuth φ (0° = +X = East, counter-clockwise): the pattern column. */
     readonly phiDeg: number;
+    /**
+     * The same direction as a compass bearing (0° = North, clockwise). Carried
+     * alongside φ so the radar plot never has to re-derive it — plotting φ as
+     * though it were a bearing rotates the whole plot 90° and mirrors it.
+     */
+    readonly bearingDeg: number;
     readonly takeoffElevationDeg: number;
     readonly rangeKm: number[];
     readonly status: HopStatus;
@@ -461,6 +469,7 @@ export function predictPropagation(input: PropagationInputs): PropagationPredict
 
         azimuthalHops.push({
           phiDeg: pi * p.dPhi,
+          bearingDeg: phiToBearingDeg(pi * p.dPhi),
           takeoffElevationDeg: bestBase.takeoffElevationDeg,
           rangeKm: [bestBase.rangeKm, bestBase.rangeKm * 2, bestBase.rangeKm * 3],
           status: bestBase.status,

--- a/src/physics/types.ts
+++ b/src/physics/types.ts
@@ -292,9 +292,16 @@ export interface SimulationResult {
   readonly efficiency?: number;
   /**
    * Peak directivity in dBi. Directivity describes pattern shape only,
-   * normalised to radiated power (excluding all losses).
-   * D(dBi) = G(dBi) − 10·log10(η)  where η = efficiency.
-   * Undefined when the NEC power budget cannot be parsed or η ≈ 0.
+   * normalised to the power that actually radiates:
+   *   D = 4π·U_max / P_rad = G_max / ⟨G⟩
+   * where ⟨G⟩ is the whole-sphere average of the power gain, obtained by
+   * integrating the pattern (see physics/patternIntegral.ts).
+   *
+   * NOT D = G − 10·log10(η): NEC's power budget accounts for conductor and
+   * network loss but not for power absorbed by a lossy ground, so that form
+   * collapses D onto G over real soil.
+   *
+   * Undefined when the pattern cannot be integrated.
    */
   readonly maxDirectivityDbi?: number;
   /**

--- a/src/store/antennaStore.ts
+++ b/src/store/antennaStore.ts
@@ -55,6 +55,7 @@ import {
   FOLDED_DIPOLE_TERM_BRIDGE_TAG,
   FOLDED_DIPOLE_DEFAULT_APERTURE_M,
   FOLDED_DIPOLE_MAX_APERTURE_M,
+  FOLDED_DIPOLE_FEED_R_OHMS,
 } from '../physics/constants';
 
 // Re-export geometry tags for UI and tests.
@@ -100,6 +101,32 @@ const FEEDLINE_SUPPORTED_TYPES = new Set<string>(['dipole', 'inverted-v', 'delta
 // is selected, and as the value set by the auto-resistance button in the UI.
 export const SLOPING_V_DEFAULT_TERMINATION_OHMS = 300;
 export const TERMINATED_DELTA_DEFAULT_TERMINATION_OHMS = 600;
+/**
+ * Recommended T2FD termination, in ohms — equal to the folded dipole's own
+ * feedpoint resistance (`FOLDED_DIPOLE_FEED_R_OHMS`), and chosen for that
+ * reason.
+ *
+ * At the half-wave resonance the unfed conductor carries essentially the same
+ * current as the fed one — that is exactly why a folded dipole's feedpoint is
+ * 4× a plain dipole's — and the resistor sits at that conductor's current
+ * maximum. It therefore appears at the feedpoint almost 1:1, in series with
+ * the radiation resistance:
+ *
+ *   η ≈ R_feed / (R_feed + R)     loss ≈ 10·log10(1 + R / R_feed) dB
+ *
+ * So R = R_feed is the 50 % / −3 dB point, which is what the UI copy has
+ * always promised and roughly where published T2FD designs sit.
+ *
+ * The former recommendation was the two-wire line's Z₀ (≈ 684 Ω at the default
+ * 0.3 m aperture), on the reasoning that terminating a line in its own Z₀ kills
+ * reflections. But that line is the *non-radiating* transmission-line mode:
+ * damping it flattens SWR without contributing anything to radiation, and it
+ * cost 5.3 dB at the design frequency, measured. Dropping to R_feed recovers
+ * 2.2 dB of that while — paired with the 9:1 balun below — leaving the
+ * worst-case SWR across 7–28 MHz unchanged. Users who want maximum flatness
+ * can still type Z₀ in; the hint text quotes it.
+ */
+export const FOLDED_DIPOLE_DEFAULT_TERMINATION_OHMS = FOLDED_DIPOLE_FEED_R_OHMS;
 
 /**
  * The recommended terminating resistance for an antenna type, in ohms, or 0 for
@@ -108,23 +135,18 @@ export const TERMINATED_DELTA_DEFAULT_TERMINATION_OHMS = 600;
  *
  *   • sloping-V / terminated-delta — a fixed design value (≈ the structure's
  *     characteristic impedance over real ground).
- *   • folded-dipole — the characteristic impedance Z₀ of the two-wire line,
- *     which depends on the conductor spacing (aperture) and wire radius:
- *     Z₀ = 120 · acosh(D / 2r). Terminating at R = Z₀ gives a travelling-wave
- *     (T2FD) broadband match.
+ *   • folded-dipole — the antenna's own feedpoint resistance, i.e. the −3 dB
+ *     efficiency point (see FOLDED_DIPOLE_DEFAULT_TERMINATION_OHMS). Both are
+ *     independent of the conductor spacing.
  */
-export function recommendedTerminatingResistor(
-  antennaType: AntennaType,
-  foldedDipoleAperture: number,
-  wireRadius: number,
-): number {
+export function recommendedTerminatingResistor(antennaType: AntennaType): number {
   switch (antennaType) {
     case 'sloping-v':
       return SLOPING_V_DEFAULT_TERMINATION_OHMS;
     case 'terminated-delta':
       return TERMINATED_DELTA_DEFAULT_TERMINATION_OHMS;
     case 'folded-dipole':
-      return Math.round(120 * Math.acosh(foldedDipoleAperture / (2 * wireRadius)));
+      return FOLDED_DIPOLE_DEFAULT_TERMINATION_OHMS;
     default:
       return 0;
   }
@@ -149,7 +171,12 @@ const TRANSFORMER_DEFAULTS: Record<AntennaType, TransformerDefaults> = {
   'sloping-v': { enabled: true, ratio: 1 },
   'delta-loop': { enabled: true, ratio: 1 },
   'terminated-delta': { enabled: true, ratio: 9 },
-  'folded-dipole': { enabled: true, ratio: 6 },
+  // 9:1, not the textbook 6:1. Over real ground the unterminated feedpoint is
+  // ~285 + 90j rather than a clean 300 Ω, and the recommended termination adds
+  // another ~300 Ω in series. 6:1 suits only the unterminated case (1.4:1
+  // there, 2.0:1 terminated); 9:1 lands both within 1.7:1 and holds the same
+  // worst-case SWR across 7–28 MHz as the old high-loss default did.
+  'folded-dipole': { enabled: true, ratio: 9 },
   // Base-fed monopole-style verticals: unbalanced feedpoint, no balun.
   'vertical-whip': { enabled: false, ratio: 1 },
   'inverted-l': { enabled: false, ratio: 1 },
@@ -524,13 +551,12 @@ export const useAntennaStore = create<AntennaState>()(
         } else if (type === 'folded-dipole') {
           // Two parallel half-wave conductors separated vertically by the
           // aperture. Plain (unterminated) by default — ~300 Ω feedpoint,
-          // dipole-like pattern. A non-zero terminating resistor (TFD) adds
-          // a series R at the top-conductor centre, raising the feedpoint by
-          // approximately R (Z ≈ 300 + R Ω). The 6:1 balun is appropriate for
-          // both unterminated (~300 Ω → ~50 Ω) and terminated
-          // (e.g. R=600 Ω → ~900 Ω → ~150 Ω) cases; for optimal traveling-wave
-          // termination choose R ≈ Z0 of the two-wire line (typically 600–700 Ω
-          // for typical HF apertures of 0.1–0.5 m with 1 mm wire).
+          // dipole-like pattern, full gain. A non-zero terminating resistor
+          // (T2FD) adds a series R at the centre of the unfed conductor, which
+          // lands at the feedpoint almost 1:1 (Z ≈ 300 + R Ω) and costs
+          // 10·log10(1 + R/300) dB of gain. The recommended R is 300 Ω — the
+          // −3 dB point — with the 9:1 balun matching both states to under
+          // 1.7:1 at the design frequency.
           s.vAngle = 180;
           s.legSlope = 0;
           s.terminatingResistor = 0;

--- a/tests/GeometryControl.test.tsx
+++ b/tests/GeometryControl.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, cleanup } from '@testing-library/react';
 import { GeometryControl } from '../src/components/Panel/GeometryControl';
 import { mockAntennaStore, type MockAntennaState } from './helpers/mockStore';
+import { FOLDED_DIPOLE_FEED_R_OHMS } from '../src/physics/constants';
 
 // Mock the store
 vi.mock('../src/store/antennaStore', async () => {
@@ -259,7 +260,7 @@ describe('GeometryControl', () => {
     expect(setHeight).toHaveBeenCalledWith(15);
   });
 
-  it('sets the terminating resistor to Z₀ for a folded dipole', () => {
+  it('sets the terminating resistor to the recommended -3 dB value for a folded dipole', () => {
     const setTerminatingResistor = vi.fn();
     mockAntennaStore(buildMockState({
       antennaType: 'folded-dipole',
@@ -271,12 +272,13 @@ describe('GeometryControl', () => {
 
     render(<GeometryControl />);
 
-    const z0Button = screen.getByRole('button', { name: /Set terminating resistor to Z₀/i });
-    fireEvent.click(z0Button);
+    const recommendButton = screen.getByRole('button', { name: /Set terminating resistor to recommended/i });
+    fireEvent.click(recommendButton);
 
     expect(setTerminatingResistor).toHaveBeenCalledTimes(1);
-    // Z₀ = round(120 · acosh(0.1 / 0.002)) ≈ 552 Ω — well above zero.
-    expect(setTerminatingResistor.mock.calls[0][0]).toBeGreaterThan(100);
+    // The folded dipole's own feedpoint resistance, not the two-wire line's Z₀
+    // (which for this 0.1 m aperture would be ~552 Ω and cost 4.3 dB).
+    expect(setTerminatingResistor.mock.calls[0][0]).toBe(FOLDED_DIPOLE_FEED_R_OHMS);
   });
 
   it('turns the termination off and resets the resistor field on blur', () => {

--- a/tests/PolarPlotsMapping.test.tsx
+++ b/tests/PolarPlotsMapping.test.tsx
@@ -1,0 +1,142 @@
+// The polar cuts have to place the pattern on the compass the same way the
+// geometry builder places the antenna. NEC solves in its own azimuth φ
+// (0° = +X = East, counter-clockwise) while a Chart.js radar is a compass rose
+// (index 0 at the top, increasing clockwise), so the two differ by a 90°
+// rotation *and* a handedness flip. Reading φ straight into the ring made a
+// north–south wire look as though it radiated north and south — off its ends,
+// where a dipole has nulls.
+
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { PolarPlots } from '../src/components/Charts/PolarPlots';
+import { useAntennaStore } from '../src/store/antennaStore';
+import { makeSimulationResult } from './helpers/factories';
+
+const { charts } = vi.hoisted(() => ({
+  charts: [] as Array<{ title: string; labels: string[]; data: number[] }>,
+}));
+
+vi.mock('react-chartjs-2', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Radar: (props: any) => {
+    charts.push({
+      title: '',
+      labels: props.data.labels as string[],
+      data: props.data.datasets[0].data as number[],
+    });
+    return <div data-testid="mock-radar-chart" />;
+  },
+}));
+
+const THETA_STEPS = 37;
+const PHI_STEPS = 72;
+const D_THETA = 5;
+const D_PHI = 5;
+
+/**
+ * Synthetic pattern for a wire lying along +Y (i.e. north–south): peak gain
+ * broadside at φ = 0° and 180° (±X, east and west), deep nulls off the ends at
+ * φ = 90° and 270° (±Y, north and south). Elevation independent, so a cut at
+ * any theta shows the same azimuth shape.
+ */
+function nsWirePattern(): Float32Array {
+  const data = new Float32Array(THETA_STEPS * PHI_STEPS);
+  for (let ti = 0; ti < THETA_STEPS; ti++) {
+    for (let pi = 0; pi < PHI_STEPS; pi++) {
+      const phi = (pi * D_PHI * Math.PI) / 180;
+      const c = Math.cos(phi);
+      data[ti * PHI_STEPS + pi] = -30 + 30 * c * c;
+    }
+  }
+  return data;
+}
+
+function setPattern(orientation: 'NS' | 'EW') {
+  useAntennaStore.setState({
+    showPolarCuts: true,
+    orientation,
+    dbRange: 40,
+    theme: 'light',
+    transformerEnabled: false,
+    feedlineId: 'none',
+    atuEnabled: false,
+    result: makeSimulationResult({
+      swr: 1.0,
+      impedance: { R: 50, X: 0 },
+      maxGainDbi: 0,
+      maxRealizedGainDbi: 0,
+      takeoffElevationDeg: 0,
+      takeoffAzimuthDeg: 0,
+      pattern: {
+        data: nsWirePattern(),
+        thetaSteps: THETA_STEPS,
+        phiSteps: PHI_STEPS,
+        dTheta: D_THETA,
+        dPhi: D_PHI,
+      },
+    }),
+  });
+}
+
+/** Index of a compass bearing on the azimuth ring. */
+const bearingIdx = (deg: number) => Math.round(deg / D_PHI);
+
+describe('polar cut compass mapping', () => {
+  beforeEach(() => {
+    cleanup();
+    charts.length = 0;
+  });
+
+  it('puts a north–south wire\'s lobes on east and west, not north and south', () => {
+    setPattern('NS');
+    render(<PolarPlots />);
+
+    const azimuth = charts[0]!;
+    expect(azimuth.labels[bearingIdx(0)]).toBe('N');
+    expect(azimuth.labels[bearingIdx(90)]).toBe('E');
+    expect(azimuth.labels[bearingIdx(270)]).toBe('W');
+
+    const at = (deg: number) => azimuth.data[bearingIdx(deg)]!;
+    // Broadside (east/west) carries the peak; off the ends (north/south) is
+    // the null. The ring values are dB above the plot floor, so higher = more.
+    expect(at(90)).toBeGreaterThan(at(0) + 20);
+    expect(at(270)).toBeGreaterThan(at(180) + 20);
+    expect(at(90)).toBeCloseTo(at(270), 6);
+    expect(at(0)).toBeCloseTo(at(180), 6);
+  });
+
+  it('rotates with the antenna: an east–west wire peaks north and south', () => {
+    // The pattern grid is fixed to the NEC axes, so re-pointing the wire is
+    // modelled by keeping the same grid and asking for the EW cuts; what must
+    // stay true is that the azimuth ring never moves with the orientation.
+    setPattern('EW');
+    render(<PolarPlots />);
+
+    const azimuth = charts[0]!;
+    const at = (deg: number) => azimuth.data[bearingIdx(deg)]!;
+    // Same pattern data ⇒ same ring. Orientation only selects which elevation
+    // cut is called "broadside"; it must not rotate the azimuth plot.
+    expect(at(90)).toBeGreaterThan(at(0) + 20);
+  });
+
+  it('labels the broadside and end-on elevation cuts the right way round', () => {
+    setPattern('NS');
+    render(<PolarPlots />);
+
+    const [, broadside, endOn] = charts;
+    // Right-hand half of the elevation ring is the forward bearing.
+    const sample = (c: { data: number[] }) => c.data[Math.round(45 / D_THETA)]!;
+    // Broadside of a north–south wire is east: the strong direction. End-on is
+    // north: the null. Swapping the two cuts would invert this.
+    expect(sample(broadside!)).toBeGreaterThan(sample(endOn!) + 20);
+  });
+
+  it('keeps the elevation cut oriented: zenith at the top, nadir at the bottom', () => {
+    setPattern('NS');
+    render(<PolarPlots />);
+    const broadside = charts[1]!;
+    expect(broadside.labels[0]).toBe('Zen');
+    expect(broadside.labels[Math.round(90 / D_THETA)]).toBe('Hor');
+    expect(broadside.labels[Math.round(180 / D_THETA)]).toBe('Dwn');
+  });
+});

--- a/tests/PropagationRadar.test.tsx
+++ b/tests/PropagationRadar.test.tsx
@@ -33,4 +33,35 @@ describe('PropagationRadar', () => {
     const polygons = container.querySelectorAll('polygon');
     expect(polygons.length).toBe(4);
   });
+
+  it('draws each radial at its compass bearing, not at its NEC φ', () => {
+    // One long radial due East (bearing 90°, which is NEC φ = 0°) and short
+    // ones elsewhere. Plotting φ as a bearing would swing this radial to the
+    // top of the plot (North) instead of the right-hand side.
+    const prediction: PropagationPrediction = makePropagationPrediction({
+      hops: [makeHop({ n: 1, rangeKm: 4000 })],
+      azimuthalHops: [
+        makeAzimuthalHop({ phiDeg: 0, rangeKm: [4000] }),
+        makeAzimuthalHop({ phiDeg: 90, rangeKm: [100] }),
+        makeAzimuthalHop({ phiDeg: 180, rangeKm: [100] }),
+        makeAzimuthalHop({ phiDeg: 270, rangeKm: [100] }),
+      ],
+    });
+    const { container } = render(<PropagationRadar prediction={prediction} units="metric" size={300} />);
+    const points = Array.from(container.querySelectorAll('polygon')).flatMap((poly) =>
+      (poly.getAttribute('points') ?? '')
+        .trim()
+        .split(/\s+/)
+        .map((pair) => pair.split(',').map(Number) as [number, number]),
+    );
+    const cx = 150;
+    const cy = 150;
+    // The far vertex must lie to the right of centre (East) and level with it,
+    // not above it (North).
+    const far = points.reduce((a, b) =>
+      Math.hypot(b[0] - cx, b[1] - cy) > Math.hypot(a[0] - cx, a[1] - cy) ? b : a,
+    );
+    expect(far[0] - cx).toBeGreaterThan(50);
+    expect(Math.abs(far[1] - cy)).toBeLessThan(1);
+  });
 });

--- a/tests/StatsReadout.test.tsx
+++ b/tests/StatsReadout.test.tsx
@@ -257,6 +257,35 @@ describe('StatsReadout', () => {
     expect(container.textContent).not.toContain('Termination reduces reflections');
   });
 
+  it('reads termination dissipation from the structure-loss bucket', () => {
+    // Every termination in this app is an LD-4 segment load, and NEC books LD
+    // loads as STRUCTURE LOSS — NETWORK LOSS covers NT-card two-port networks,
+    // which these decks never emit. Reading networkLossW alone made this row
+    // display 0.00 mW no matter how much the resistor was absorbing.
+    const diagnostics: TerminationDiagnostics = {
+      currentRippleByTag: [
+        { tagNo: 1, magnitudes: [2e-3, 1e-3], ripple: 2, rippleDb: 2.0 },
+      ],
+      powerBudget: {
+        inputW: 0.01, radiatedW: 0.006, structureLossW: 0.004,
+        networkLossW: 0, efficiencyPct: 60,
+      },
+      frontBackDb: 8.5,
+    };
+    useAntennaStore.setState({
+      antennaType: 'sloping-v',
+      result: {
+        computeTimeMs: 10, maxGainDbi: 2, takeoffElevationDeg: 15,
+        takeoffAzimuthDeg: 0, impedance: { R: 50, X: 0 }, swr: 1.0,
+        pattern: { data: new Float32Array([1]), phiSteps: 1, thetaSteps: 1 },
+        terminationDiagnostics: diagnostics,
+      } as unknown as import('../src/physics/types').SimulationResult,
+    });
+
+    const { getByText } = render(<StatsReadout />);
+    expect(getByText('4.00 mW')).not.toBeNull();
+  });
+
   it('renders termination section for sloping-v with front-back ratio', () => {
     // Arrange
     const diagnostics: TerminationDiagnostics = {

--- a/tests/StatsReadout.test.tsx
+++ b/tests/StatsReadout.test.tsx
@@ -41,7 +41,9 @@ describe('StatsReadout', () => {
     expect(getByText('Gain')).not.toBeNull();
     expect(getByText('5.50 dBi')).not.toBeNull();
     expect(getByText('25.0°')).not.toBeNull();
-    expect(getByText('90°')).not.toBeNull();
+    // takeoffAzimuthDeg is NEC azimuth φ (0° = +X = East). The row reports a
+    // compass bearing, so φ = 90° (which is +Y) reads as 0° = North.
+    expect(getByText('0°')).not.toBeNull();
     expect(getByText('1.20:1')).not.toBeNull();
     expect(container.textContent).toContain('45.0 +j10.0 Ω');
     // SWR label updated to "vs 50 Ω"

--- a/tests/angles.test.ts
+++ b/tests/angles.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { bearingToPhiDeg, normalizeDeg, phiToBearingDeg } from '../src/physics/angles';
+import { orientationVector } from '../src/store/antennaGeometry';
+
+describe('azimuth conventions', () => {
+  it('wraps angles into [0, 360)', () => {
+    expect(normalizeDeg(0)).toBe(0);
+    expect(normalizeDeg(360)).toBe(0);
+    expect(normalizeDeg(-90)).toBe(270);
+    expect(normalizeDeg(450)).toBe(90);
+  });
+
+  it('maps the cardinal directions between NEC φ and compass bearing', () => {
+    // φ is measured from +X toward +Y; the geometry puts East on +X and
+    // North on +Y (docs/antenna-spec.md §1.3).
+    expect(phiToBearingDeg(0)).toBe(90); // +X → East
+    expect(phiToBearingDeg(90)).toBe(0); // +Y → North
+    expect(phiToBearingDeg(180)).toBe(270); // −X → West
+    expect(phiToBearingDeg(270)).toBe(180); // −Y → South
+  });
+
+  it('round-trips: the mapping is its own inverse', () => {
+    for (let a = 0; a < 360; a += 7) {
+      expect(bearingToPhiDeg(phiToBearingDeg(a))).toBeCloseTo(a, 10);
+      expect(phiToBearingDeg(bearingToPhiDeg(a))).toBeCloseTo(a, 10);
+    }
+  });
+
+  it('agrees with the geometry builder for every preset orientation', () => {
+    // orientationVector takes a compass heading and returns the wire axis in
+    // NEC (x, y). Converting that axis back to a bearing must return the
+    // heading it was built from — this is the invariant the display layers
+    // rely on when they turn a heading into a pattern column.
+    for (const heading of [0, 45, 90, 135, 180, 225, 270, 315]) {
+      const [x, y] = orientationVector(heading);
+      const phi = normalizeDeg((Math.atan2(y, x) * 180) / Math.PI);
+      expect(phiToBearingDeg(phi)).toBeCloseTo(heading, 6);
+    }
+  });
+});

--- a/tests/antennaStore.test.ts
+++ b/tests/antennaStore.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import {
   useAntennaStore,
   buildWires,
@@ -27,6 +27,7 @@ import {
   VERTICAL_WHIP_BASE_GAP_M,
   VERTICAL_WHIP_RADIAL_TAG,
   VERTICAL_WHIP_RADIAL_COUNT,
+  FOLDED_DIPOLE_FEED_R_OHMS,
 } from "../src/physics/constants";
 
 describe("antennaStore selectors", () => {
@@ -501,22 +502,54 @@ describe("antennaStore selectors", () => {
 });
 
 
+describe("folded-dipole defaults", () => {
+  // These switch the shared store's antenna type; put it back so the
+  // initial-defaults suite further down still sees a pristine store.
+  afterEach(() => {
+    useAntennaStore.getState().setAntennaType("dipole");
+  });
+
+  it("lands unterminated with a 9:1 balun", () => {
+    useAntennaStore.getState().setAntennaType("folded-dipole");
+    const s = useAntennaStore.getState();
+    // Plain folded dipole out of the box: full gain, dipole pattern.
+    expect(s.terminatingResistor).toBe(0);
+    expect(s.transformerEnabled).toBe(true);
+    // 9:1, not the textbook 6:1 — it has to suit the terminated state too,
+    // where the recommended resistor adds ~300 Ω in series with the feedpoint.
+    // Measured over real ground at 8 m: 1.6:1 unterminated, 1.4:1 terminated,
+    // against 6:1's 1.4 / 2.0.
+    expect(s.transformerRatio).toBe(9);
+  });
+
+  it("keeps the recommended termination and the balun consistent", () => {
+    // Raw feedpoint terminated ≈ R_feed + R = 600 Ω; through 9:1 that is 67 Ω,
+    // an SWR well under 1.5 before the antenna's own reactance is counted.
+    const r = recommendedTerminatingResistor("folded-dipole");
+    expect((FOLDED_DIPOLE_FEED_R_OHMS + r) / 9).toBeGreaterThan(50);
+    expect((FOLDED_DIPOLE_FEED_R_OHMS + r) / 9).toBeLessThan(75);
+  });
+});
+
 describe("recommendedTerminatingResistor", () => {
   it("returns SLOPING_V_DEFAULT_TERMINATION_OHMS for sloping-v", () => {
-    expect(recommendedTerminatingResistor("sloping-v", 0.5, 0.001)).toBe(SLOPING_V_DEFAULT_TERMINATION_OHMS);
+    expect(recommendedTerminatingResistor("sloping-v")).toBe(SLOPING_V_DEFAULT_TERMINATION_OHMS);
   });
 
   it("returns TERMINATED_DELTA_DEFAULT_TERMINATION_OHMS for terminated-delta", () => {
-    expect(recommendedTerminatingResistor("terminated-delta", 0.5, 0.001)).toBe(TERMINATED_DELTA_DEFAULT_TERMINATION_OHMS);
+    expect(recommendedTerminatingResistor("terminated-delta")).toBe(TERMINATED_DELTA_DEFAULT_TERMINATION_OHMS);
   });
 
-  it("calculates correct rounded impedance for folded-dipole", () => {
-    // 120 * acosh(0.5 / (2 * 0.001)) = 120 * acosh(250) ≈ 120 * 6.2146 ≈ 746
-    expect(recommendedTerminatingResistor("folded-dipole", 0.5, 0.001)).toBe(746);
+  it("recommends the folded dipole's own feedpoint resistance — the -3 dB point", () => {
+    // A resistor in the unfed conductor lands in series with the feedpoint
+    // almost 1:1, so R = R_feed splits the power evenly: loss = 10*log10(2).
+    // Independent of conductor spacing, unlike the two-wire line's Z0.
+    expect(recommendedTerminatingResistor("folded-dipole")).toBe(FOLDED_DIPOLE_FEED_R_OHMS);
+    expect(10 * Math.log10(1 + FOLDED_DIPOLE_FEED_R_OHMS / FOLDED_DIPOLE_FEED_R_OHMS)).toBeCloseTo(3.01, 2);
   });
 
   it("returns 0 for unsupported antenna types like dipole", () => {
-    expect(recommendedTerminatingResistor("dipole", 0.5, 0.001)).toBe(0);
+    expect(recommendedTerminatingResistor("dipole")).toBe(0);
   });
 });
 

--- a/tests/helpers/factories.ts
+++ b/tests/helpers/factories.ts
@@ -15,6 +15,7 @@ import type {
 } from '../../src/physics/types';
 import type { ComparisonSnapshot } from '../../src/store/antennaStore';
 import type { HopPrediction, PropagationPrediction } from '../../src/physics/propagation';
+import { phiToBearingDeg } from '../../src/physics/angles';
 
 /** Flat pattern with a mild gradient, so cuts and peak-finding have something to bite on. */
 export function makeGainPattern(overrides: Partial<GainPattern> = {}): GainPattern {
@@ -116,8 +117,11 @@ export function makeHop(overrides: Partial<HopPrediction> = {}): HopPrediction {
 type AzimuthalHop = NonNullable<PropagationPrediction['azimuthalHops']>[number];
 
 export function makeAzimuthalHop(overrides: Partial<AzimuthalHop> = {}): AzimuthalHop {
+  const phiDeg = overrides.phiDeg ?? 0;
   return {
-    phiDeg: 0,
+    phiDeg,
+    // Keep the pair consistent unless a test deliberately overrides it.
+    bearingDeg: phiToBearingDeg(phiDeg),
     takeoffElevationDeg: 15,
     rangeKm: [1000],
     status: 'open',

--- a/tests/nec2Engine.integration.test.ts
+++ b/tests/nec2Engine.integration.test.ts
@@ -9,6 +9,7 @@
 import { describe, expect, it, beforeAll } from 'vitest';
 import { Nec2Engine } from '../src/physics/nec2Engine';
 import { halfWaveLength, wavelengthMeters } from '../src/physics/constants';
+import { averageGainLinear } from '../src/physics/patternIntegral';
 import type { SimulationInput } from '../src/physics/types';
 import { pathToFileURL } from 'node:url';
 import { resolve } from 'node:path';
@@ -55,6 +56,79 @@ describe('Nec2Engine (real Wasm)', () => {
     // Wavelength sanity.
     const lambda = wavelengthMeters(freq);
     expect(lambda).toBeCloseTo(42.224, 2);
+  }, 30_000);
+
+  it('integrates the pattern to an average gain of 1 in free space', async () => {
+    // NEC's average-gain test: for a lossless antenna in free space the whole-
+    // sphere average of the power gain must come back as 1.0, so directivity
+    // and gain coincide. This is simultaneously a check on the quadrature and
+    // on the pattern grid being parsed onto the right θ/φ axes.
+    const freq = 7.1;
+    const tip = halfWaveLength(freq, 1.0) / 2;
+    const input: SimulationInput = {
+      wires: [{ start: [-tip, 0, 0], end: [tip, 0, 0], radius: 0.001, segments: 21, tag: 1 }],
+      frequencyMHz: freq,
+      ground: { type: 'free' },
+      excitation: { wireTag: 1, segment: 11 },
+      patternResolution: { thetaSteps: 37, phiSteps: 72 },
+    };
+
+    const r = await engine.simulate(input);
+    expect(averageGainLinear(r.pattern)).toBeCloseTo(1, 1);
+    expect(r.maxDirectivityDbi!).toBeCloseTo(r.maxGainDbi, 1);
+  }, 30_000);
+
+  it('credits ground absorption to directivity, not to gain', async () => {
+    // Over average soil NEC's POWER BUDGET still reports 100 % efficiency —
+    // it counts conductor and network loss only, and the soil absorbs power
+    // after it has left the antenna. Directivity therefore has to come from
+    // integrating the pattern, and must exceed the gain by the absorbed share.
+    const freq = 7.1;
+    const tip = halfWaveLength(freq, 1.0) / 2;
+    const input: SimulationInput = {
+      wires: [{ start: [-tip, 0, 10], end: [tip, 0, 10], radius: 0.001, segments: 21, tag: 1 }],
+      frequencyMHz: freq,
+      ground: { type: 'real', sigma: 0.005, epsilon: 13 },
+      excitation: { wireTag: 1, segment: 11 },
+      patternResolution: { thetaSteps: 37, phiSteps: 72 },
+    };
+
+    const r = await engine.simulate(input);
+    // The wire itself is lossless, so the power budget sees no loss at all.
+    expect(r.efficiency).toBeCloseTo(1, 3);
+    // But a quarter or so of the radiated power goes into the soil.
+    const avg = averageGainLinear(r.pattern);
+    expect(avg).toBeGreaterThan(0.5);
+    expect(avg).toBeLessThan(0.95);
+    expect(r.maxDirectivityDbi!).toBeGreaterThan(r.maxGainDbi + 0.5);
+    expect(r.maxDirectivityDbi!).toBeCloseTo(r.maxGainDbi - 10 * Math.log10(avg), 6);
+  }, 30_000);
+
+  it('resolves a tied free-space peak toward the horizon, not the zenith', async () => {
+    // A free-space dipole is exactly as strong straight up as it is broadside,
+    // so the peak search has to break a tie. Taking the first grid hit landed
+    // on θ = 0 (the zenith), which reports a 90° take-off angle and makes the
+    // azimuth cut a featureless circle — every φ holds the same value up there.
+    const freq = 7.1;
+    const tip = halfWaveLength(freq, 1.0) / 2;
+    const input: SimulationInput = {
+      // Wire along +X, so broadside (the peak) is the ±Y directions: φ = 90°
+      // and 270°, i.e. due North and South.
+      wires: [{ start: [-tip, 0, 0], end: [tip, 0, 0], radius: 0.001, segments: 21, tag: 1 }],
+      frequencyMHz: freq,
+      ground: { type: 'free' },
+      excitation: { wireTag: 1, segment: 11 },
+      patternResolution: { thetaSteps: 37, phiSteps: 72 },
+    };
+
+    const r = await engine.simulate(input);
+    expect(r.takeoffElevationDeg).toBe(0);
+    expect(r.takeoffAzimuthDeg).toBe(90);
+    // And the reported direction really is a peak of the pattern.
+    const p = r.pattern;
+    const ti = Math.round((90 - r.takeoffElevationDeg) / p.dTheta);
+    const pi = Math.round(r.takeoffAzimuthDeg / p.dPhi);
+    expect(p.data[ti * p.phiSteps + pi]).toBeCloseTo(r.maxGainDbi, 5);
   }, 30_000);
 
   it('reports higher gain when above real ground vs free space', async () => {

--- a/tests/patternIntegral.test.ts
+++ b/tests/patternIntegral.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import { averageGainLinear, directivityDbi } from '../src/physics/patternIntegral';
+import type { GainPattern } from '../src/physics/types';
+
+const THETA_STEPS = 37;
+const PHI_STEPS = 72;
+
+function pattern(fill: (thetaDeg: number, phiDeg: number) => number): GainPattern {
+  const dTheta = 180 / (THETA_STEPS - 1);
+  const dPhi = 360 / PHI_STEPS;
+  const data = new Float32Array(THETA_STEPS * PHI_STEPS);
+  for (let ti = 0; ti < THETA_STEPS; ti++) {
+    for (let pi = 0; pi < PHI_STEPS; pi++) {
+      data[ti * PHI_STEPS + pi] = fill(ti * dTheta, pi * dPhi);
+    }
+  }
+  return { data, thetaSteps: THETA_STEPS, phiSteps: PHI_STEPS, dTheta, dPhi };
+}
+
+describe('averageGainLinear', () => {
+  it('returns 1 for a lossless isotropic radiator', () => {
+    // 0.06 % low: the trapezoidal ∫sinθ dθ on a 5° grid. That sets the floor
+    // on how exactly any of these values can come back.
+    expect(averageGainLinear(pattern(() => 0))).toBeCloseTo(1, 2);
+  });
+
+  it('tracks a uniform loss', () => {
+    // Every direction 3.0103 dB down = half the power radiated.
+    expect(averageGainLinear(pattern(() => -3.0103))).toBeCloseTo(0.5, 3);
+  });
+
+  it('halves for a pattern confined to the upper hemisphere', () => {
+    // 3 dBi above the horizon, nothing below: the classic perfect-ground
+    // doubling. Directions NEC never computed come through as the parser's
+    // large-negative sentinel.
+    //
+    // Tolerance is loose because this pattern steps discontinuously at the
+    // horizon and a 5° grid can only resolve that to within half a cell
+    // (~4 %). Real patterns taper into the horizon instead, which the same
+    // quadrature integrates to better than 1 % — see the sin²θ case below and
+    // the free-space average-gain check in nec2Engine.integration.test.ts.
+    const p = pattern((thetaDeg) => (thetaDeg <= 90 ? 3.0103 : -100));
+    expect(averageGainLinear(p)).toBeCloseTo(1, 1);
+  });
+
+  it('integrates a sin²θ (dipole-like) pattern to its analytic value', () => {
+    // A short dipole has U ∝ sin²θ and D = 1.5, so a lossless one has
+    // G(θ) = 1.5·sin²θ and ⟨G⟩ = 1.
+    const p = pattern((thetaDeg) => {
+      const s = Math.sin((thetaDeg * Math.PI) / 180);
+      const g = 1.5 * s * s;
+      return g > 0 ? 10 * Math.log10(g) : -100;
+    });
+    expect(averageGainLinear(p)).toBeCloseTo(1, 2);
+    // …and the directivity recovered from a 1.76 dBi peak is 1.5 (1.76 dB).
+    expect(directivityDbi(p, 10 * Math.log10(1.5))!).toBeCloseTo(10 * Math.log10(1.5), 1);
+  });
+
+  it('reports the extra loss a lossy ground takes out of the far field', () => {
+    // G(θ) = A·cosθ over the upper hemisphere is a smooth stand-in for a
+    // ground-reflected pattern; its directivity is exactly 4 (6.02 dBi)
+    // whatever A is. Scaling it down by 1.2 dB — the share of the radiated
+    // power a lossy soil absorbs — leaves the directivity untouched and drops
+    // the gain, so D − G must come back as that 1.2 dB.
+    //
+    // This is the case NEC's POWER BUDGET cannot see: it reports η = 100 %
+    // over soil, so the old D = G − 10·log10(η) form returned D = G exactly.
+    const LOSS_DB = 1.2;
+    const p = pattern((thetaDeg) => {
+      const c = Math.cos((thetaDeg * Math.PI) / 180);
+      return c > 0 ? 6.0206 - LOSS_DB + 10 * Math.log10(c) : -100;
+    });
+    const gain = 6.0206 - LOSS_DB;
+    const d = directivityDbi(p, gain)!;
+    expect(d).toBeCloseTo(6.0206, 1);
+    expect(d - gain).toBeCloseTo(LOSS_DB, 1);
+    expect(averageGainLinear(p)).toBeLessThan(1);
+  });
+
+  it('is defensive about degenerate patterns', () => {
+    const empty: GainPattern = { data: new Float32Array(0), thetaSteps: 0, phiSteps: 0, dTheta: 5, dPhi: 5 };
+    expect(averageGainLinear(empty)).toBe(0);
+    expect(directivityDbi(empty, 3)).toBeUndefined();
+    // A pattern that radiates nowhere cannot yield a directivity.
+    expect(directivityDbi(pattern(() => -999), 0)).toBeUndefined();
+  });
+});

--- a/tests/patternRadius.test.ts
+++ b/tests/patternRadius.test.ts
@@ -1,0 +1,61 @@
+// The 3D bubble is a gain surface: its radius in a direction is the linear
+// power gain there. Getting the dB→linear conversion wrong (the /20 field
+// exponent instead of /10) halves every lobe ratio the surface is supposed to
+// show, so the law is pinned here rather than left to the render path.
+
+import { describe, expect, it } from 'vitest';
+import { DB_TO_LINEAR_POWER, radiusScaleForPattern } from '../src/components/Scene/patternRadius';
+
+const radiusAt = (gainDb: number, peakDb: number, dbRange: number, scale = 1) => {
+  const { floorDb, factor } = radiusScaleForPattern(peakDb, dbRange, scale);
+  return Math.exp(Math.max(gainDb, floorDb) * DB_TO_LINEAR_POWER) * factor;
+};
+
+describe('pattern radius law', () => {
+  it('converts dB to linear power, not field amplitude', () => {
+    // 10 dB down is a factor of 10 in power. The field-amplitude law would
+    // give √10 ≈ 3.16.
+    const peak = radiusAt(0, 0, 40);
+    const tenDown = radiusAt(-10, 0, 40);
+    expect(peak / tenDown).toBeCloseTo(10, 6);
+
+    // 3 dB is a factor of 2.
+    expect(radiusAt(0, 0, 40) / radiusAt(-3.0103, 0, 40)).toBeCloseTo(2, 4);
+  });
+
+  it('scales the whole surface with absolute gain, so two antennas compare', () => {
+    // A 6 dBi antenna is four times the radius of a 0 dBi one at the same
+    // pattern scale — comparison mode reads absolute gain off bubble size.
+    expect(radiusAt(6, 6, 40) / radiusAt(0, 0, 40)).toBeCloseTo(10 ** 0.6, 6);
+  });
+
+  it('is linear in the user pattern scale', () => {
+    expect(radiusAt(6, 6, 40, 2)).toBeCloseTo(2 * radiusAt(6, 6, 40, 1), 6);
+  });
+
+  it('floors nulls relative to the peak, keeping shape at any gain level', () => {
+    // A hopeless antenna: peak −40 dBi, 20 dB of structure in the pattern.
+    // The peak-relative floor keeps that structure visible; the old fixed
+    // −25 dBi floor clamped every one of these directions to the same radius.
+    const weakPeak = radiusAt(-40, -40, 30);
+    const weakDown10 = radiusAt(-50, -40, 30);
+    expect(weakPeak / weakDown10).toBeCloseTo(10, 6);
+
+    // Below the dynamic range everything clamps together, as the colours do.
+    expect(radiusAt(-999, -40, 30)).toBeCloseTo(radiusAt(-70, -40, 30), 12);
+  });
+
+  it('keeps a very weak pattern visible without distorting it', () => {
+    const { factor } = radiusScaleForPattern(-40, 30, 1);
+    const peak = Math.exp(-40 * DB_TO_LINEAR_POWER) * factor;
+    // Boosted to a visible size…
+    expect(peak).toBeGreaterThan(0.3);
+    // …by a uniform factor, so lobe ratios are untouched.
+    expect(radiusAt(-40, -40, 30) / radiusAt(-46, -40, 30)).toBeCloseTo(10 ** 0.6, 6);
+  });
+
+  it('leaves normal patterns at their true scale', () => {
+    // 6 dBi at 1×: ~5 m peak radius, well above the minimum-size guard.
+    expect(radiusAt(6, 6, 40)).toBeCloseTo(10 ** 0.6 * 1.25, 6);
+  });
+});

--- a/tests/propagation.test.ts
+++ b/tests/propagation.test.ts
@@ -268,6 +268,26 @@ describe('predictPropagation', () => {
     expect(hop1!.rangeKm[0]).toBeLessThan(hop0!.rangeKm[0]);
   });
 
+  it('tags every azimuthal hop with the compass bearing of its φ', () => {
+    const pattern = {
+      data: new Float32Array(37 * 72).fill(-20),
+      thetaSteps: 37,
+      phiSteps: 72,
+      dTheta: 5,
+      dPhi: 5,
+    };
+    const p = predictPropagation({ ...baseInput, frequencyMHz: 7.1, pattern });
+    const hops = p.azimuthalHops!;
+    // φ = 0 is +X, which the geometry puts due East; φ = 90 is +Y, due North.
+    // The radar plots bearings, so it needs the converted value, not φ.
+    expect(hops[0]!.bearingDeg).toBe(90);
+    expect(hops.find((h) => h.phiDeg === 90)!.bearingDeg).toBe(0);
+    expect(hops.find((h) => h.phiDeg === 180)!.bearingDeg).toBe(270);
+    for (const h of hops) {
+      expect(h.bearingDeg).toBe(((90 - h.phiDeg) % 360 + 360) % 360);
+    }
+  });
+
   it('uses antenna support to choose a relevant ray without changing hop geometry', () => {
     const pattern = {
       data: new Float32Array(37 * 72).fill(-20),


### PR DESCRIPTION
Audit of the gain modelling and rendering path, plus two follow-ups it turned up. The NEC solve itself checks out — the free-space ½λ dipole comes back at 2.16 dBi, 73 Ω, and the pattern integrates to an average gain of 1.000 ± 0.2 %, so the deck, the parse and the grid layout are all sound. What was wrong sat between the solved pattern and what the user sees.

## 1. NEC azimuth φ was read as a compass bearing (worst of the four)

NEC's `RP` card sweeps φ from +X toward +Y, and `orientationVector()` puts East on +X and North on +Y, so **φ = 0 is due East** and `bearing = 90° − φ`. The two conventions differ by a 90° rotation *and* a handedness flip. Every 2D display substituted one for the other:

- **Azimuth polar cut** — the ring is indexed by φ but labelled N/E/S/W, and Chart.js lays radar points out clockwise from the top. A north–south dipole therefore drew its lobes on north and south: off the ends of the wire, where it has nulls. Verified against the solver — an N–S dipole's horizontal cut peaks at φ = 0/180 (±X, east/west) with nulls at φ = 90/270.
- **Elevation cuts** — `broadsideAz`/`endOnAz` are compass headings fed straight in as φ, so for any orientation the two plots were swapped: "Elevation (Broadside)" was showing the end-on cut and vice versa.
- **Propagation radar** — plots `x = sin(angle)`, `y = −cos(angle)`, i.e. a bearing, but was handed `phiDeg`. Every wedge sat on the wrong bearing.
- **"Azimuth of peak"** — printed raw φ, read by the user as a bearing.

Conversions now live in `src/physics/angles.ts` and are applied at each display boundary. `GainPattern` and `takeoffAzimuthDeg` keep the NEC convention; only the display layers convert. The 3D scene was already correct (it remaps NEC (x,y,z) → Three.js (x,z,−y), so its `atan2(-z, x)` recovers φ exactly) and is untouched.

## 2. The 3D bubble drew the field pattern, not the gain pattern

The radius used `10^(dB/20)` — the field-amplitude conversion — while NEC's `RP` card with `XNDA = 1000` reports **power** gain. The surface was therefore the square root of the gain surface: lobes flattened, and every null and front-to-back ratio shown at half its true dB depth (a 20 dB F/B rendered as a 10:1 radius ratio instead of 100:1). Now `10^(dB/10)`, with the scale constant calibrated so a 6 dBi antenna keeps its previous ~5 m peak radius at 1×.

The fixed −25 dBi radius floor is replaced by one referenced to the pattern's own peak (the display dynamic range). An absolute floor collapses an *entire* low-gain pattern onto one radius — the lossy antennas it was meant to keep visible were rendered as featureless spheres with no directivity at all. A minimum overall size keeps such a pattern visible by scaling it uniformly, so shape and lobe ratios survive.

## 3. Directivity ignored ground absorption

It was `G − 10·log10(η)` with η from NEC's `POWER BUDGET`, which counts conductor and network loss but knows nothing about power a lossy ground absorbs after radiation. Over average soil NEC reports η = 100 %, so the readout simply repeated the gain. Measured on a ½λ dipole at 10 m over pastoral ground: 24 % of the radiated power goes into the soil, so the row read 6.05 dBi where the directivity is 7.22 dBi.

Directivity is now `G_max / ⟨G⟩` with ⟨G⟩ integrated over the sphere — the definition in the spec glossary. The same integral is NEC's classical average-gain test; it returns 1.000 in free space and 0.997 over perfect ground, confirming both the quadrature and the pattern axes.

## 4. Peak-direction ties resolved to the zenith

Scanning the grid for the first strict maximum resolved every tie toward θ = 0, because row 0 is visited first. A free-space dipole is exactly as strong straight up as it is broadside, so it reported a 90° take-off angle — and the azimuth cut, taken at that elevation, degenerated to a circle, since every φ holds the same value at the zenith. Ties now resolve to the lowest elevation.

## 5. "Termination load" always read 0.00 mW

The row read `powerBudget.networkLossW`, but every termination in the app is an `LD 4` segment load and NEC books those as STRUCTURE LOSS — NETWORK LOSS covers `NT` two-port networks, which these decks never emit. A sloping-V run returns networkLoss = 0 against structureLoss = 1.16 µW. The row now sums both buckets (no conductor loss is modelled, so the sum is the termination's alone), and the parser comment that started the confusion is corrected.

## 6. Folded-dipole defaults cost 5.3 dB for no benefit

The recommended termination was the two-wire line's Z₀ (~684 Ω at the default aperture), on the reasoning that terminating a line in its own Z₀ kills reflections. But that line is the *non-radiating* transmission-line mode: damping it flattens SWR without contributing anything to radiation.

At the half-wave resonance the unfed conductor carries essentially the same current as the fed one — which is *why* the feedpoint is 4× a plain dipole's — and the resistor sits at its current maximum, so it lands at the feedpoint almost 1:1, in series with the radiation resistance:

```
η ≈ R_feed / (R_feed + R)      ΔG ≈ −10·log10(1 + R / R_feed) dB
```

Measured against the solver at 7.1 MHz, 8 m over pastoral ground: 300 Ω → 49.0 % efficiency (predicted 48.6), 600 Ω → 32.5 % (32.1), 900 Ω → 24.4 % (24.0). The feedpoint rises by almost exactly R, which is the same statement.

The recommendation is now R_feed itself — 300 Ω, the 50 % / −3 dB point, the least that can be paid for broadband behaviour and what the UI copy has always promised. It no longer depends on the aperture, because the feedpoint does not either. The default balun moves 6:1 → 9:1 so one ratio suits both states:

| | old (684 Ω, 6:1) | new (300 Ω, 9:1) |
|---|---|---|
| Gain, terminated | 1.0 dBi | **3.2 dBi** |
| SWR, terminated | 3.3:1 | **1.4:1** |
| SWR, out of box (unterminated) | 1.4:1 | 1.7:1 |
| Worst SWR, 7–28 MHz | 5.6:1 | 5.6:1 |

Z₀ is still quoted in the hint text for anyone wanting maximum flatness — it just no longer poses as the recommendation, and the hint now computes the loss any given R implies.

## Tests

`npm run lint`, `npm run typecheck` and the full suite pass: **923 tests, 79 files**, coverage thresholds met. New coverage:

- `tests/angles.test.ts` — cardinal mappings, involution, and agreement with `orientationVector()` for every preset heading.
- `tests/PolarPlotsMapping.test.tsx` — a synthetic N–S wire pattern must show its lobes on east and west, and the broadside/end-on cuts must not be swapped. All three assertions fail on the old code (checked).
- `tests/patternRadius.test.ts` — 10 dB down is a factor of 10 in radius, not √10; the peak-relative floor keeps shape at any gain level; the minimum-size boost is uniform.
- `tests/patternIntegral.test.ts` — isotropic ⟹ ⟨G⟩ = 1, sin²θ ⟹ D = 1.5, and a cos θ hemisphere scaled down by 1.2 dB returns exactly that 1.2 dB as D − G.
- `tests/nec2Engine.integration.test.ts` — three new cases against the real Wasm: average gain = 1 in free space, directivity exceeding gain over real ground while η stays 100 %, and the tied free-space peak resolving to the horizon at the broadside azimuth.
- `tests/StatsReadout.test.tsx` — termination dissipation read from the structure-loss bucket.
- `tests/antennaStore.test.ts` — folded-dipole defaults land unterminated at 9:1, and the recommended termination stays consistent with that ratio.

`docs/antenna-spec.md` gains a §1.3.1 stating the φ↔bearing relation and where it must be applied; the glossary now says how each of gain, directivity, efficiency and the 3D radius is obtained; and §13 carries the T2FD efficiency closed form with the solver measurements behind it, plus the harmonic-dip behaviour at even multiples of the design frequency.

## Noted, not changed

- Over a ground plane NEC computes nothing below the horizon, so those rows are the parser's sentinel fill. They now render at the dynamic-range floor (≈1/1000 of peak radius) instead of the old −25 dBi shell, so the artefact is effectively invisible — but it is still synthetic data in the buffer.
- The 3D scene has no compass markers, only the x/y/z gizmo, so a user cannot tell north from east in the view that is now the most trustworthy one. Worth adding.
- Azimuth cardinal labels only appear when 45° lands on a φ step, so at the low-LOD 10° step the intercardinals (NE/SE/SW/NW) go unlabelled.