### PR TITLE
🧪 Add tests for formatBandwidth edge cases

### DIFF
--- a/tests/swrChartUtils.test.ts
+++ b/tests/swrChartUtils.test.ts
@@ -136,6 +136,11 @@ describe('formatBandwidth', () => {
     expect(formatBandwidth(1.555)).toBe('1.55 MHz');
     expect(formatBandwidth(1.556)).toBe('1.56 MHz');
     expect(formatBandwidth(10)).toBe('10.00 MHz');
+    expect(formatBandwidth(2000)).toBe('2000.00 MHz');
+  });
+
+  it('formats exactly 0 correctly', () => {
+    expect(formatBandwidth(0)).toBe('0 kHz');
   });
 });
 


### PR DESCRIPTION
🎯 **What:** The `formatBandwidth` function lacked testing for some edge cases, specifically very large bandwidths (e.g., 2000) and zero boundaries.
📊 **Coverage:** Added explicit test cases for `2000` (large MHz) and `0` (boundary for the `< 1000 kHz` fallback) in `tests/swrChartUtils.test.ts`.
✨ **Result:** Improved test coverage for the `formatBandwidth` pure utility function, ensuring robust formatting for all expected magnitudes and extreme inputs.

---
*PR created automatically by Jules for task [2283296626564204007](https://jules.google.com/task/2283296626564204007) started by @2fst4u*