### PR TITLE
🧪 [testing improvement] Add coverage for HHmmToHour edge cases

### DIFF
--- a/tests/PropagationInputs.test.tsx
+++ b/tests/PropagationInputs.test.tsx
@@ -245,6 +245,12 @@ describe('PropagationInputs time parsers', () => {
       expect(HHmmToHour('12:30 PM')).toBe(12.5);
       expect(HHmmToHour('  09:45  ')).toBe(9.75);
       expect(HHmmToHour('a01b30c')).toBe(1.5);
+      expect(HHmmToHour('12x30')).toBe(12.5);
+    });
+
+    it('returns null for inputs longer than 20 characters', () => {
+      expect(HHmmToHour('12:30 with a very long string that exceeds 20 characters')).toBe(null);
+      expect(HHmmToHour('012345678901234567890')).toBe(null);
     });
 
     it('returns null for invalid lengths', () => {


### PR DESCRIPTION
🎯 **What:** The testing gap in the `HHmmToHour` parsing logic inside `src/components/Panel/Propagation/PropagationInputs.tsx` has been addressed. Specifically, the string-stripping functionality (e.g. converting `12x30` to `12.5`) and string length bounds checking (e.g. strings longer than 20 characters) lacked test coverage.
📊 **Coverage:** Added test cases covering:
- Strings with arbitrary characters within digits being stripped correctly (e.g., `12x30` -> 12.5).
- Strings exceeding the 20-character maximum bound returning `null` early.
✨ **Result:** Improved overall test coverage and reliability for string parsing edge cases. 100% test suite pass rate maintained.

---
*PR created automatically by Jules for task [7016439030890028232](https://jules.google.com/task/7016439030890028232) started by @2fst4u*