### PR TITLE
🧹 Sweep: Remove unused transformImpedance function

### DIFF
--- a/src/physics/impedance.ts
+++ b/src/physics/impedance.ts
@@ -216,17 +216,6 @@ export function displayedFeedMetrics(
 }
 
 /**
- * Apply an ideal impedance transformer: Z_transformed = Z_raw / ratio.
- * Divides both R and X by the impedance ratio (n²). Post-processing display
- * only — does not affect radiation pattern, currents, or NEC simulation.
- * Returns the original z unchanged for invalid ratios (≤ 0 or non-finite).
- */
-export function transformImpedance(z: ImpedanceResult, ratio: number): ImpedanceResult {
-  if (!Number.isFinite(ratio) || ratio <= 0) return z;
-  return { R: z.R / ratio, X: z.X / ratio };
-}
-
-/**
  * Forward propagation through a lossless transmission line: given the load
  * (far-end) impedance, returns the input (near-end) impedance seen looking
  * into a line of characteristic impedance `z0Line` and electrical length

--- a/tests/impedance.test.ts
+++ b/tests/impedance.test.ts
@@ -1,6 +1,6 @@
 import { vi } from "vitest";
 import { describe, expect, it } from 'vitest';
-import { swr, mismatchLossFactor, transformImpedance, deembedThroughLine, transformThroughLine, transformWithTransformerAtAntenna, realizedGainWithTransformer, suggestedTransformerRatio, matchRatioForFeedpoint, displayedFeedMetrics, atuLossDb, feedlineLossUnderSwrDb } from '../src/physics/impedance';
+import { swr, mismatchLossFactor, deembedThroughLine, transformThroughLine, transformWithTransformerAtAntenna, realizedGainWithTransformer, suggestedTransformerRatio, matchRatioForFeedpoint, displayedFeedMetrics, atuLossDb, feedlineLossUnderSwrDb } from '../src/physics/impedance';
 import { TRANSFORMER_INSERTION_LOSS_DB, ATU_COMPONENT_Q, feedlineLossDb, findFeedlinePreset } from '../src/physics/constants';
 import type { SimulationResult } from '../src/physics/types';
 
@@ -234,54 +234,6 @@ describe('mismatchLossFactor', () => {
     const mlf = mismatchLossFactor({ R: 50, X: 50 });
     expect(mlf).toBeGreaterThan(0);
     expect(mlf).toBeLessThan(1);
-  });
-});
-
-describe('transformImpedance', () => {
-  it('450+j0 with ratio 9 gives 50+j0 and SWR ~1:1', () => {
-    const z = transformImpedance({ R: 450, X: 0 }, 9);
-    expect(z.R).toBeCloseTo(50, 6);
-    expect(z.X).toBeCloseTo(0, 6);
-    expect(swr(z)).toBeCloseTo(1, 5);
-  });
-
-  it('ratio 1 leaves impedance unchanged', () => {
-    const z = transformImpedance({ R: 73, X: 42 }, 1);
-    expect(z.R).toBeCloseTo(73, 6);
-    expect(z.X).toBeCloseTo(42, 6);
-  });
-
-  it('transforms both R and X', () => {
-    const z = transformImpedance({ R: 400, X: 200 }, 4);
-    expect(z.R).toBeCloseTo(100, 6);
-    expect(z.X).toBeCloseTo(50, 6);
-  });
-
-  it('raw SWR is unaffected by calling transformImpedance', () => {
-    const original = { R: 450, X: 0 };
-    const rawSwr = swr(original);
-    transformImpedance(original, 9);
-    // Ensure the original object is not mutated
-    expect(swr(original)).toBe(rawSwr);
-    expect(original.R).toBe(450);
-  });
-
-  it('invalid ratio (0) returns original impedance unchanged', () => {
-    const original = { R: 100, X: 50 };
-    const result = transformImpedance(original, 0);
-    expect(result).toBe(original);
-  });
-
-  it('invalid ratio (negative) returns original impedance unchanged', () => {
-    const original = { R: 100, X: 50 };
-    const result = transformImpedance(original, -1);
-    expect(result).toBe(original);
-  });
-
-  it('invalid ratio (NaN) returns original impedance unchanged', () => {
-    const original = { R: 100, X: 50 };
-    const result = transformImpedance(original, NaN);
-    expect(result).toBe(original);
   });
 });
 


### PR DESCRIPTION
🎯 **What:** Removed the unused `transformImpedance` function from `src/physics/impedance.ts` and its associated tests/imports in `tests/impedance.test.ts`.
💡 **Why:** It was dead code not referenced anywhere in the `src/` codebase. Removing it improves codebase maintainability and reduces clutter.
✅ **Verification:** Verified by checking text references and running the full test suite via `npm run test -- --run --coverage` to ensure tests passed and coverage was maintained.
✨ **Result:** Cleaned up unused physics code without modifying any live behavior.

---
*PR created automatically by Jules for task [13358105636015864977](https://jules.google.com/task/13358105636015864977) started by @2fst4u*