### PR TITLE
🧹 Sweep: Remove unused gainToColorT function

### DIFF
--- a/.jules/sweep.md
+++ b/.jules/sweep.md
@@ -109,3 +109,6 @@
 ## 2024-05-30 - False Positives in Knip Analysis
 **Learning:** Knip static analysis might falsely flag exports that are actively used if it doesn't parse dynamically or if it's explicitly run with `--production`, which ignores usages inside test files. Wait to use `grep` everywhere to verify.
 **Action:** Always verify a Knip suggestion via a global text search (`grep -rn`) before including its deletion in the execution plan.
+## 2025-02-09 - Sweep: Remove unused gainToColorT function
+**Learning:** `gainToColorT` was unused dead code in `src/utils/colormap.ts` and successfully removed alongside its tests to improve maintainability.
+**Action:** Removed unused `gainToColorT` from `src/utils/colormap.ts` and `tests/colormap.test.ts`.

--- a/src/utils/colormap.ts
+++ b/src/utils/colormap.ts
@@ -76,17 +76,6 @@ export function sampleColormap(name: ColormapName, t: number): RGB {
 }
 
 /**
- * Map a dBi gain to a 0..1 colormap position using the chosen dynamic range.
- * Values above maxDb map to 1; values below maxDb - range map to 0.
- */
-export function gainToColorT(gainDb: number, maxDb: number, rangeDb: number): number {
-  const minDb = maxDb - rangeDb;
-  if (gainDb >= maxDb) return 1;
-  if (gainDb <= minDb) return 0;
-  return (gainDb - minDb) / rangeDb;
-}
-
-/**
  * Hot-path optimized version of sampleColormap that writes directly into an output array.
  * Uses bitwise operations and avoids creating intermediate array allocations.
  */

--- a/tests/colormap.test.ts
+++ b/tests/colormap.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { sampleColormap, gainToColorT, sampleColormapFast, getColormapCssGradient, pickTable } from '../src/utils/colormap';
+import { sampleColormap, sampleColormapFast, getColormapCssGradient, pickTable } from '../src/utils/colormap';
 
 describe('colormap utilities', () => {
   describe('sampleColormap', () => {
@@ -55,24 +55,6 @@ describe('colormap utilities', () => {
       // JET[0] = [0, 0, 0.5]
       const color = sampleColormap('jet', 0);
       expect(color).toEqual([0, 0, 0.5]);
-    });
-  });
-
-  describe('gainToColorT', () => {
-    it('returns 1 for gain at or above maxDb', () => {
-      expect(gainToColorT(10, 10, 20)).toBe(1);
-      expect(gainToColorT(15, 10, 20)).toBe(1);
-    });
-
-    it('returns 0 for gain at or below minDb', () => {
-      expect(gainToColorT(-10, 10, 20)).toBe(0);
-      expect(gainToColorT(-15, 10, 20)).toBe(0);
-    });
-
-    it('linearly maps intermediate values', () => {
-      expect(gainToColorT(0, 10, 20)).toBe(0.5);
-      expect(gainToColorT(-5, 10, 20)).toBe(0.25);
-      expect(gainToColorT(5, 10, 20)).toBe(0.75);
     });
   });
 


### PR DESCRIPTION
🎯 **What:** Removed the unused `gainToColorT` function from `src/utils/colormap.ts` and its corresponding tests in `tests/colormap.test.ts`.
💡 **Why:** Code search revealed this exported function was not imported or used anywhere in the codebase. Removing dead code improves maintainability and readability.
✅ **Verification:** Ran `npm run test -- --run --coverage` (all tests passed), `npm run lint` (passed), and `npm run build` (built successfully) to confirm the removal was safe and didn't break functionality.
✨ **Result:** A cleaner codebase with less dead code and slightly faster test execution.

---
*PR created automatically by Jules for task [881338050992179284](https://jules.google.com/task/881338050992179284) started by @2fst4u*