### PR TITLE
🧹 Sweep: remove unused realizedGainWithTransformer function

### DIFF
--- a/src/physics/impedance.ts
+++ b/src/physics/impedance.ts
@@ -298,25 +298,6 @@ export function transformWithTransformerAtAntenna(
 }
 
 /**
- * Realized gain after a transformer fitted at the antenna terminals: the
- * NEC-computed `gainDbi` (intrinsic radiation) minus the mismatch loss
- * computed against the radio-side impedance with the transformer in
- * place, minus a fixed insertion loss for the transformer hardware.
- */
-export function realizedGainWithTransformer(
-  gainDbi: number,
-  zSrcReportedByNec: ImpedanceResult,
-  ratio: number,
-  z0Line: number = Z0_SYSTEM,
-  lineLengthLambdas: number = 0,
-): number | undefined {
-  const zRadio = transformWithTransformerAtAntenna(zSrcReportedByNec, ratio, z0Line, lineLengthLambdas);
-  const mlf = mismatchLossFactor(zRadio);
-  if (mlf <= 0) return undefined;
-  return gainDbi + 10 * Math.log10(mlf) - TRANSFORMER_INSERTION_LOSS_DB;
-}
-
-/**
  * De-embeds an impedance reading taken at the source end of a lossless
  * transmission line: given Z measured at the source, returns the load-side
  * impedance at the far end of the line.

--- a/tests/impedance.test.ts
+++ b/tests/impedance.test.ts
@@ -1,6 +1,6 @@
 import { vi } from "vitest";
 import { describe, expect, it } from 'vitest';
-import { swr, mismatchLossFactor, transformImpedance, deembedThroughLine, transformThroughLine, transformWithTransformerAtAntenna, realizedGainWithTransformer, suggestedTransformerRatio, matchRatioForFeedpoint, displayedFeedMetrics, atuLossDb, feedlineLossUnderSwrDb } from '../src/physics/impedance';
+import { swr, mismatchLossFactor, transformImpedance, deembedThroughLine, transformThroughLine, transformWithTransformerAtAntenna, suggestedTransformerRatio, matchRatioForFeedpoint, displayedFeedMetrics, atuLossDb, feedlineLossUnderSwrDb } from '../src/physics/impedance';
 import { TRANSFORMER_INSERTION_LOSS_DB, ATU_COMPONENT_Q, feedlineLossDb, findFeedlinePreset } from '../src/physics/constants';
 import type { SimulationResult } from '../src/physics/types';
 
@@ -418,20 +418,6 @@ describe('transformWithTransformerAtAntenna', () => {
     const result = transformWithTransformerAtAntenna(zSrc, 4, 50, 0.25);
     expect(result.R).toBeCloseTo(100, 6);
     expect(result.X).toBeCloseTo(0, 6);
-  });
-});
-
-describe('realizedGainWithTransformer', () => {
-  it('computes expected realized gain', () => {
-    const zSrc = { R: 50, X: 0 };
-    const result = realizedGainWithTransformer(2.15, zSrc, 1, 50, 0);
-    expect(result).toBeDefined();
-    expect(typeof result).toBe('number');
-  });
-
-  it('returns undefined if mismatch loss factor is <= 0', () => {
-    const result = realizedGainWithTransformer(2.15, { R: 0, X: 0 }, 1, 50, 0);
-    expect(result).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
🎯 **What:** Removed the unused `realizedGainWithTransformer` function from `src/physics/impedance.ts` and its associated tests and imports in `tests/impedance.test.ts`.

💡 **Why:** This improves the maintainability and readability of the codebase by eliminating dead code, keeping the physics engine clean and focused on actively utilized logic.

✅ **Verification:** Verified by running `npm run test -- --run --coverage` ensuring all tests still pass and no regressions were introduced.

✨ **Result:** A cleaner codebase with less dead code and reduced complexity.

---
*PR created automatically by Jules for task [13539756747194663183](https://jules.google.com/task/13539756747194663183) started by @2fst4u*