### PR TITLE
🎨 Palette: Add ARIA live region to Comparison empty state

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -34,4 +34,6 @@
 ## 2024-11-09 - Accessible External Links Context Change
 **Learning:** External links utilizing `target="_blank"` cause an unexpected context switch for screen reader users, disrupting navigation flow. Simply providing a visually-informative title is insufficient for accessibility.
 **Action:** When adding or modifying external links (`target="_blank"`), ensure an explicit `aria-label` is applied that appends "(opens in a new tab)" to the link text to provide fair warning of the behavior change.
-## 2026-08-09 - Comparison Empty State Accessibility\n**Learning:** When a component conditionally renders an empty state message (e.g., after clearing a reference), screen readers do not automatically announce the transition back to the empty state unless the container has an explicit ARIA live region.\n**Action:** Add `role="status" aria-live="polite"` to conditionally rendered empty state containers to ensure screen readers announce the state change.
+## 2026-08-09 - Comparison Empty State Accessibility
+**Learning:** When a component conditionally renders an empty state message (e.g., after clearing a reference), screen readers do not automatically announce the transition back to the empty state unless the container has an explicit ARIA live region.
+**Action:** Add `role="status" aria-live="polite"` to conditionally rendered empty state containers to ensure screen readers announce the state change.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -34,3 +34,4 @@
 ## 2024-11-09 - Accessible External Links Context Change
 **Learning:** External links utilizing `target="_blank"` cause an unexpected context switch for screen reader users, disrupting navigation flow. Simply providing a visually-informative title is insufficient for accessibility.
 **Action:** When adding or modifying external links (`target="_blank"`), ensure an explicit `aria-label` is applied that appends "(opens in a new tab)" to the link text to provide fair warning of the behavior change.
+## 2026-08-09 - Comparison Empty State Accessibility\n**Learning:** When a component conditionally renders an empty state message (e.g., after clearing a reference), screen readers do not automatically announce the transition back to the empty state unless the container has an explicit ARIA live region.\n**Action:** Add `role="status" aria-live="polite"` to conditionally rendered empty state containers to ensure screen readers announce the state change.

--- a/src/components/Panel/ComparisonControl.tsx
+++ b/src/components/Panel/ComparisonControl.tsx
@@ -99,7 +99,7 @@ export function ComparisonControl() {
           </div>
         </div>
       ) : (
-        <div className="compare-empty">Capture a solved configuration to enable side-by-side comparison.</div>
+        <div className="compare-empty" role="status" aria-live="polite">Capture a solved configuration to enable side-by-side comparison.</div>
       )}
     </section>
   );


### PR DESCRIPTION
💡 **What:** Added `role="status" aria-live="polite"` to the conditionally rendered empty state in the Comparison control panel.
🎯 **Why:** When a visually impaired user clicks "Clear reference", the UI drops back to the empty state message. Without a live region, screen readers do not announce this update, leaving the user unaware that the action succeeded and the reference was cleared.
📸 **Before/After:** No visual changes.
♿ **Accessibility:** Screen readers will now announce "Capture a solved configuration to enable side-by-side comparison" when the reference is cleared, providing immediate semantic feedback.

---
*PR created automatically by Jules for task [1248325864381921237](https://jules.google.com/task/1248325864381921237) started by @2fst4u*