### PR TITLE
🧹 Sweep: Remove unused parseNtLine function from test helpers

### DIFF
--- a/.jules/sweep.md
+++ b/.jules/sweep.md
@@ -109,3 +109,6 @@
 ## 2024-05-30 - False Positives in Knip Analysis
 **Learning:** Knip static analysis might falsely flag exports that are actively used if it doesn't parse dynamically or if it's explicitly run with `--production`, which ignores usages inside test files. Wait to use `grep` everywhere to verify.
 **Action:** Always verify a Knip suggestion via a global text search (`grep -rn`) before including its deletion in the execution plan.
+## 2025-03-02 - Removed unused parseNtLine
+**Learning:** Functions that parse NEC output formats (like `parseNtLine`) might be written defensively or for future use, but if they are never actually invoked by the main codebase or tests (other than their own isolated unit test), they are dead code. Tools like `knip --production` might miss this if they ignore test directories, while standard `knip` correctly flags them.
+**Action:** Always cross-reference Knip's unused export findings with `grep` to ensure they are genuinely unused in all workflows before removing them entirely (including their tests).

--- a/tests/necInspect.test.ts
+++ b/tests/necInspect.test.ts
@@ -5,7 +5,6 @@ import {
   parseGwLine,
   parseLdLine,
   parseTlLine,
-  parseNtLine,
   expectNoGroundTouchingWires,
   expectExcitation
 } from './necInspect';
@@ -86,26 +85,6 @@ describe('necInspect helpers', () => {
   it('parseTlLine throws on non-TL line', () => {
     const line = 'GW 1 11 0.00000 -5.00000 10.00000 0.00000 5.00000 10.00000 0.00100';
     expect(() => parseTlLine(line)).toThrow(/Not a TL line/);
-  });
-
-  it('parseNtLine parses NT correctly', () => {
-    const line = 'NT 1 1 2 1 0.020000 0.000000 -0.020000 0.000000 0.020000 0.000000';
-    const nt = parseNtLine(line);
-    expect(nt.tag1).toBe(1);
-    expect(nt.seg1).toBe(1);
-    expect(nt.tag2).toBe(2);
-    expect(nt.seg2).toBe(1);
-    expect(nt.y11r).toBe(0.02);
-    expect(nt.y11i).toBe(0);
-    expect(nt.y12r).toBe(-0.02);
-    expect(nt.y12i).toBe(0);
-    expect(nt.y22r).toBe(0.02);
-    expect(nt.y22i).toBe(0);
-  });
-
-  it('parseNtLine throws on non-NT line', () => {
-    const line = 'GW 1 11 0.00000 -5.00000 10.00000 0.00000 5.00000 10.00000 0.00100';
-    expect(() => parseNtLine(line)).toThrow(/Not an NT line/);
   });
 
   it('expectNoGroundTouchingWires passes for high dipole', () => {

--- a/tests/necInspect.ts
+++ b/tests/necInspect.ts
@@ -95,25 +95,3 @@ export function expectExcitation(deck: string, tag: number, segment: number) {
   expect(found, `Excitation not found on tag ${tag} segment ${segment}`).toBe(true);
 }
 
-/**
- * Parses an NT (Network) card line.
- * Format: NT tag1 seg1 tag2 seg2 Y11r Y11i Y12r Y12i Y22r Y22i
- */
-export function parseNtLine(line: string) {
-  const parts = line.trim().split(/\s+/);
-  if (parts[0] !== 'NT') {
-    throw new Error(`Not an NT line: ${line}`);
-  }
-  return {
-    tag1: parseInt(parts[1], 10),
-    seg1: parseInt(parts[2], 10),
-    tag2: parseInt(parts[3], 10),
-    seg2: parseInt(parts[4], 10),
-    y11r: parseFloat(parts[5]),
-    y11i: parseFloat(parts[6]),
-    y12r: parseFloat(parts[7]),
-    y12i: parseFloat(parts[8]),
-    y22r: parseFloat(parts[9]),
-    y22i: parseFloat(parts[10]),
-  };
-}


### PR DESCRIPTION
🎯 What:
Removed the `parseNtLine` utility function from `tests/necInspect.ts` along with its associated unit tests and imports in `tests/necInspect.test.ts`.

💡 Why:
The `parseNtLine` function was completely unused by any actual test assertions or application logic. It was identified as an unused export by static analysis (`knip`) and confirmed via a global `grep` search. Removing it reduces test utility bloat and removes dead code.

✅ Verification:
- Ran `npx knip` to flag it initially.
- Ran `grep -rn "parseNtLine" .` confirming it was only used in its own unit tests.
- Executed `npm run test -- --run --coverage` to ensure tests passed and coverage thresholds were maintained after removal.
- Executed `npm run lint` for code quality checks.

---
*PR created automatically by Jules for task [8521250410376549537](https://jules.google.com/task/8521250410376549537) started by @2fst4u*