### PR TITLE
🧹 Sweep: Remove redundant folded dipole termination alias

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,9 +1,3 @@
-1. **Update `StatsReadout.tsx` to include a loading spinner.**
-   - In `src/components/Panel/StatsReadout.tsx`, the loading state currently just says "Computing...". It's missing the `.spinner` class that is used in other similar loading states (like in `Propagation/ConditionsReadout.tsx` and `Charts/SWRChart.tsx`). I'll add the spinner here to make the visual feedback consistent and add a bit more delight to the UI while waiting for the calculation.
-
-2. **Run tests and linting to verify the changes.**
-   - Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.
-
-3. **Submit the PR.**
-   - Title: `🎨 Palette: Add loading spinner to StatsReadout`
-   - Description: Added a spinner to the loading state in StatsReadout to match the loading pattern used elsewhere in the application.
+1. Remove `FOLDED_DIPOLE_DEFAULT_TERMINATION_OHMS` from `src/store/antennaStore.ts` as it is redundant and can be replaced with `FOLDED_DIPOLE_FEED_R_OHMS`. Done.
+2. Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.
+3. Submit the change using a git commit and push.

--- a/src/store/antennaStore.ts
+++ b/src/store/antennaStore.ts
@@ -126,7 +126,6 @@ export const TERMINATED_DELTA_DEFAULT_TERMINATION_OHMS = 600;
  * worst-case SWR across 7–28 MHz unchanged. Users who want maximum flatness
  * can still type Z₀ in; the hint text quotes it.
  */
-export const FOLDED_DIPOLE_DEFAULT_TERMINATION_OHMS = FOLDED_DIPOLE_FEED_R_OHMS;
 
 /**
  * The recommended terminating resistance for an antenna type, in ohms, or 0 for
@@ -136,7 +135,7 @@ export const FOLDED_DIPOLE_DEFAULT_TERMINATION_OHMS = FOLDED_DIPOLE_FEED_R_OHMS;
  *   • sloping-V / terminated-delta — a fixed design value (≈ the structure's
  *     characteristic impedance over real ground).
  *   • folded-dipole — the antenna's own feedpoint resistance, i.e. the −3 dB
- *     efficiency point (see FOLDED_DIPOLE_DEFAULT_TERMINATION_OHMS). Both are
+ *     efficiency point (see FOLDED_DIPOLE_FEED_R_OHMS). Both are
  *     independent of the conductor spacing.
  */
 export function recommendedTerminatingResistor(antennaType: AntennaType): number {
@@ -146,7 +145,7 @@ export function recommendedTerminatingResistor(antennaType: AntennaType): number
     case 'terminated-delta':
       return TERMINATED_DELTA_DEFAULT_TERMINATION_OHMS;
     case 'folded-dipole':
-      return FOLDED_DIPOLE_DEFAULT_TERMINATION_OHMS;
+      return FOLDED_DIPOLE_FEED_R_OHMS;
     default:
       return 0;
   }


### PR DESCRIPTION
🎯 What: Removed the `FOLDED_DIPOLE_DEFAULT_TERMINATION_OHMS` constant and replaced its single internal use with `FOLDED_DIPOLE_FEED_R_OHMS`.

💡 Why: `FOLDED_DIPOLE_DEFAULT_TERMINATION_OHMS` was simply an alias for `FOLDED_DIPOLE_FEED_R_OHMS`. Consolidating them removes unnecessary indirection without changing behavior.

✅ Verification: Used `grep -rn "FOLDED_DIPOLE_DEFAULT_TERMINATION_OHMS" .` and identified all usages. The replacement logic was confirmed in the `switch` statement for `folded-dipole`. Tests (`npm run test -- --run`) and static analysis (`npm run lint` and `npx knip`) verify no breakages.

✨ Result: A cleaner, slightly leaner module.

---
*PR created automatically by Jules for task [11320998557968302235](https://jules.google.com/task/11320998557968302235) started by @2fst4u*