### PR TITLE
📚 Archivist: Clarify FEED_BRIDGE_LENGTH_M with explicit value in antenna-spec.md

### DIFF
--- a/docs/antenna-spec.md
+++ b/docs/antenna-spec.md
@@ -290,7 +290,7 @@ Every type below uses the coordinate conventions of Part I §1 and the glossary 
 - **Leg Count & Length:** 3 wires forming a triangle, total perimeter $L$. The bottom wire is split at the centre, so the structure is emitted as two top legs + two half-base wires + one bridge wire across the gap (when terminated).
 - **Reference Length:** $1.0\lambda$ canonical, but resonance is not the design goal: a properly bridged termination flattens impedance across an octave or more, so the antenna is used multi-band rather than at a single design frequency.
 - **Angle/Slope:** Equilateral triangle in the vertical plane (flattens to isosceles when the mast height is below the equilateral height; perimeter preserved).
-- **Tips:** Bottom corners. The bottom wire is split at the centre with a gap (`FEED_BRIDGE_LENGTH_M`).
+- **Tips:** Bottom corners. The bottom wire is split at the centre with a gap (`FEED_BRIDGE_LENGTH_M` = 0.1 m).
 - **Min Height:** Bottom wire must be $\ge 0.5$ m above ground.
 
 ### 10.2 Feedpoint Definition
@@ -404,7 +404,7 @@ Every type below uses the coordinate conventions of Part I §1 and the glossary 
 - **`length` parameter:** Each conductor's length (metres). Reference length: ½λ (0.475λ with end-effect) — same as a standard dipole; the fold does not change the resonant length.
 - **`foldedDipoleAperture` parameter:** Vertical spacing between the two parallel conductors (metres). Default 0.3 m. Clamped to [0.02 m, `FOLDED_DIPOLE_MAX_APERTURE_M` = 0.5 m]. The upper cap keeps the antenna a genuine folded dipole and, crucially, within the spacing range where NEC's close-parallel-wire solution converges inside `MAX_SEGS_PER_LEG` (see §13.5).
 - **Orientation:** Azimuth the conductor axis runs. The aperture is in the vertical (Z) direction; changing the orientation rotates the axis in the horizontal plane but the top/bottom wire layout is preserved.
-- **Fed conductor:** Split at its centre by a `FEED_BRIDGE_LENGTH_M` feed bridge (the two halves carry `LEFT_LEG_TAG` / `RIGHT_LEG_TAG`, the same split-fed convention as the standard dipole).
+- **Fed conductor:** Split at its centre by a `FEED_BRIDGE_LENGTH_M` (0.1 m) feed bridge (the two halves carry `LEFT_LEG_TAG` / `RIGHT_LEG_TAG`, the same split-fed convention as the standard dipole).
 - **Min Height:** Bottom conductor at `z = height`; fully supports `height = 0` (or `height <= 0`), which seamlessly switches the model to a free space environment without ground, preventing NEC-2 `GE 1` instability. The top conductor is automatically at `z = height + aperture`.
 
 ### 13.2 Feedpoint Definition


### PR DESCRIPTION
💡 Problem: The `docs/antenna-spec.md` file referenced `FEED_BRIDGE_LENGTH_M` without explicitly stating its value, unlike other constants on the page (e.g., `FOLDED_DIPOLE_MAX_APERTURE_M = 0.5 m`). This created ambiguity for users trying to understand the exact geometry of the terminated delta loop.

🎯 Fix: Added the explicit value `(0.1 m)` alongside the two instances of `FEED_BRIDGE_LENGTH_M` in `docs/antenna-spec.md` to replace the ambiguity with absolute, testable facts that match the codebase (`src/physics/constants.ts`).

🧪 Verification: Checked `src/physics/constants.ts` to confirm the value is exactly `0.1`. Read the updated markdown file to verify formatting matches other constant definitions. Ran the full `vitest` suite to ensure no code regressions.

🔎 Scope: This PR contains ONLY documentation changes to `docs/antenna-spec.md`.

---
*PR created automatically by Jules for task [11412914375932241693](https://jules.google.com/task/11412914375932241693) started by @2fst4u*