### PR TITLE
🎨 Palette: Add inline validation feedback for UTC Hour

### DIFF
--- a/src/components/Panel/Propagation/PropagationInputs.tsx
+++ b/src/components/Panel/Propagation/PropagationInputs.tsx
@@ -241,6 +241,8 @@ function UtcHourInput() {
     }
   }
 
+  const isInvalid = HHmmToHour(localUtcHour) === null;
+
   return (
     <>
       <label htmlFor="utc-hour-input" style={{ marginTop: 10 }}>
@@ -255,7 +257,8 @@ function UtcHourInput() {
           value={localUtcHour}
           onFocus={() => setIsUtcHourFocused(true)}
           aria-label="UTC hour override"
-          aria-invalid={HHmmToHour(localUtcHour) === null}
+          aria-invalid={isInvalid}
+          aria-describedby={isInvalid ? "utc-error" : undefined}
           onChange={(e) => {
             const s = e.target.value;
             setLocalUtcHour(s);
@@ -279,6 +282,11 @@ function UtcHourInput() {
           Auto
         </button>
       </div>
+      {isInvalid && (
+        <div id="utc-error" role="alert" style={{ color: 'var(--danger)', fontSize: 11, marginTop: 4 }}>
+          Invalid time format. Use HH:mm (e.g., 14:30).
+        </div>
+      )}
     </>
   );
 }


### PR DESCRIPTION
💡 What: Added inline validation feedback for the UTC Hour input in the Propagation panel.
🎯 Why: Previously, entering an invalid format (like "12345") would set `aria-invalid="true"` but provide no visual feedback or error text. It would simply silently reset to the previous valid time on blur, leaving users confused about why their input was rejected. This change displays a clear, inline error message and links it for screen readers.
📸 Before/After: Visual changes verified via Playwright screenshot.
♿ Accessibility: Uses `aria-invalid` and `aria-describedby` pointing to an error `div` with `role="alert"` so screen readers immediately announce the invalid format.

---
*PR created automatically by Jules for task [17174161845908846972](https://jules.google.com/task/17174161845908846972) started by @2fst4u*