### PR TITLE
🧹 Fix duplicate import in GeometryControl

### DIFF
--- a/src/components/Panel/GeometryControl.tsx
+++ b/src/components/Panel/GeometryControl.tsx
@@ -1,13 +1,12 @@
 import { GeometryStatus } from './GeometryStatus';
 import { useState } from 'react';
-import { useAntennaStore, legMultipleFromLength, recommendedTerminatingResistor } from '../../store/antennaStore';
+import { useAntennaStore, legMultipleFromLength, recommendedTerminatingResistor, type AntennaType } from '../../store/antennaStore';
 import { useShallow } from 'zustand/react/shallow';
 import {
   toDisplayLength,
   fromDisplayLength,
   displayLengthUnit,
 } from '../../physics/units';
-import { type AntennaType } from '../../store/antennaStore';
 import { type OrientationPreset } from '../../store/antennaGeometry';
 import { FOLDED_DIPOLE_MAX_APERTURE_M, FOLDED_DIPOLE_FEED_R_OHMS } from '../../physics/constants';
 import { TransformerControl } from './TransformerControl';


### PR DESCRIPTION
🎯 **What:** Consolidated the import of `AntennaType` into the main `useAntennaStore` import block and removed the standalone import in `src/components/Panel/GeometryControl.tsx`.
💡 **Why:** This fixes a minor code health issue (duplicate imports from the same file), cleaning up the file header and improving readability.
✅ **Verification:** Verified the code using ESLint and ran the full unit test suite, ensuring no functionality was broken.
✨ **Result:** The code has cleaner and consolidated imports without altering the logic.

---
*PR created automatically by Jules for task [7266391007849953703](https://jules.google.com/task/7266391007849953703) started by @2fst4u*