### PR TITLE
🧹 Sweep: Remove duplicate sweep range constants in antennaStore

### DIFF
--- a/src/store/antennaStore.ts
+++ b/src/store/antennaStore.ts
@@ -22,6 +22,8 @@ import type {
   AntennaType,
 } from '../physics/types';
 import {
+  SWEEP_F_MIN_MHZ,
+  SWEEP_F_MAX_MHZ,
   TRANSFORMER_CHOKE_OHMS,
   ATU_COMPONENT_Q,
   DEFAULT_FEEDLINE_ID,
@@ -406,8 +408,6 @@ const INITIAL_LENGTH = referenceLength(INITIAL_TYPE, INITIAL_FREQ); // resonant 
 
 // SWR sweep view-window bounds (MHz). The window is always clamped inside this
 // range, which matches the engine's sweep limits (Nec2Engine.F_MIN/F_MAX_MHZ).
-export const SWR_VIEW_F_MIN_MHZ = 1.0;
-export const SWR_VIEW_F_MAX_MHZ = 30;
 // Tightest span the user can zoom to (kHz-scale detail) and the default span as
 // a fraction of the operating frequency (the "logical default zoom").
 const SWR_VIEW_MIN_SPAN_MHZ = 0.05;
@@ -415,10 +415,10 @@ const DEFAULT_SWR_VIEW_SPAN_FRACTION = 0.2;
 
 /** Clamp a (centre, span) pair so the whole window stays within the HF limits. */
 function clampSwrView(centerMHz: number, spanMHz: number): { center: number; span: number } {
-  const fullSpan = SWR_VIEW_F_MAX_MHZ - SWR_VIEW_F_MIN_MHZ;
+  const fullSpan = SWEEP_F_MAX_MHZ - SWEEP_F_MIN_MHZ;
   const span = Math.min(fullSpan, Math.max(SWR_VIEW_MIN_SPAN_MHZ, spanMHz));
   const half = span / 2;
-  const center = Math.min(SWR_VIEW_F_MAX_MHZ - half, Math.max(SWR_VIEW_F_MIN_MHZ + half, centerMHz));
+  const center = Math.min(SWEEP_F_MAX_MHZ - half, Math.max(SWEEP_F_MIN_MHZ + half, centerMHz));
   return { center, span };
 }
 

--- a/tests/antennaStore.test.ts
+++ b/tests/antennaStore.test.ts
@@ -10,8 +10,6 @@ import {
   recommendedTerminatingResistor,
   SLOPING_V_DEFAULT_TERMINATION_OHMS,
   TERMINATED_DELTA_DEFAULT_TERMINATION_OHMS,
-  SWR_VIEW_F_MIN_MHZ,
-  SWR_VIEW_F_MAX_MHZ,
   LEFT_LEG_TAG,
   RIGHT_LEG_TAG,
   DELTA_BASE_TAG,
@@ -20,6 +18,8 @@ import {
   type AntennaState,
 } from "../src/store/antennaStore";
 import {
+  SWEEP_F_MIN_MHZ,
+  SWEEP_F_MAX_MHZ,
   ATU_COMPONENT_Q,
   findFeedlinePreset,
   DEFAULT_WHIP_LENGTH_M,
@@ -1603,12 +1603,12 @@ describe("antennaStore actions", () => {
       // Pan hard against the low edge.
       store.panSwrView(-100);
       const win = selectSwrWindow(useAntennaStore.getState());
-      expect(win.startMHz).toBeGreaterThanOrEqual(SWR_VIEW_F_MIN_MHZ - 1e-9);
+      expect(win.startMHz).toBeGreaterThanOrEqual(SWEEP_F_MIN_MHZ - 1e-9);
       // Zoom way out — the span saturates at the full HF range.
       store.zoomSwrView(1000);
       const full = selectSwrWindow(useAntennaStore.getState());
-      expect(full.startMHz).toBeCloseTo(SWR_VIEW_F_MIN_MHZ, 6);
-      expect(full.endMHz).toBeCloseTo(SWR_VIEW_F_MAX_MHZ, 6);
+      expect(full.startMHz).toBeCloseTo(SWEEP_F_MIN_MHZ, 6);
+      expect(full.endMHz).toBeCloseTo(SWEEP_F_MAX_MHZ, 6);
     });
 
     it("re-centres on the operating frequency when the band changes", () => {


### PR DESCRIPTION
🎯 What: Removed the `SWR_VIEW_F_MIN_MHZ` and `SWR_VIEW_F_MAX_MHZ` constants from `src/store/antennaStore.ts` and replaced them with `SWEEP_F_MIN_MHZ` and `SWEEP_F_MAX_MHZ` imported from `src/physics/constants.ts`. Updated the corresponding references in `tests/antennaStore.test.ts`.

💡 Why: `SWR_VIEW_F_MIN_MHZ` (1.0) and `SWR_VIEW_F_MAX_MHZ` (30) were completely duplicate constants mapping directly to the central constants `SWEEP_F_MIN_MHZ` and `SWEEP_F_MAX_MHZ` in the physics layer. Removing these duplicate sources of truth improves maintainability and ensures any future changes to the simulation frequency bounds remain consistently applied across both the core model and the SWR graph views.

✅ Verification: 
- `npx eslint src/store/antennaStore.ts` passed.
- `npx tsc --noEmit` passed.
- `npm run test -- --run --coverage` completed with 108 tests passing out of 108, and all 915 overall suite tests passing.

✨ Result: A single unified source of truth for the SWR sweep bounds, reducing code duplication and exported constants.

---
*PR created automatically by Jules for task [12418543356764782260](https://jules.google.com/task/12418543356764782260) started by @2fst4u*