### PR TITLE
🔒 Prevent RCE via untrusted URL dynamic imports

### DIFF
--- a/src/physics/nec2Engine.ts
+++ b/src/physics/nec2Engine.ts
@@ -61,6 +61,26 @@ interface EmscriptenFactory {
  *
  * Keep this helper separate so tests can stub it out with a file:// URL.
  */
+
+function validateUrlOrigin(parsedUrl: URL): void {
+  if (!['http:', 'https:', 'file:'].includes(parsedUrl.protocol)) {
+    throw new Error(`Untrusted protocol: ${parsedUrl.protocol}`);
+  }
+
+  if (parsedUrl.protocol === 'file:') return;
+
+  const currentOrigin =
+    typeof self !== 'undefined' && typeof self.location !== 'undefined' && self.location.origin !== 'null'
+      ? self.location.origin
+      : 'http://localhost';
+
+  const expectedOrigin = new URL(currentOrigin === 'http://localhost' ? 'http://localhost/' : currentOrigin).origin;
+
+  if (parsedUrl.origin !== expectedOrigin && parsedUrl.hostname !== 'localhost' && parsedUrl.hostname !== '127.0.0.1') {
+    throw new Error(`Untrusted origin: ${parsedUrl.origin}`);
+  }
+}
+
 async function loadNec2Factory(baseUrl: string): Promise<EmscriptenFactory> {
   let url: string;
   if (/^https?:|^file:/.test(baseUrl)) {
@@ -76,9 +96,7 @@ async function loadNec2Factory(baseUrl: string): Promise<EmscriptenFactory> {
     url = new URL(`${baseUrl}nec2.js`, origin || 'http://localhost/').href;
   }
   const parsedUrl = new URL(url, 'http://localhost/');
-  if (!['http:', 'https:', 'file:'].includes(parsedUrl.protocol)) {
-    throw new Error(`Untrusted protocol: ${parsedUrl.protocol}`);
-  }
+  validateUrlOrigin(parsedUrl);
   const mod = (await import(/* @vite-ignore */ parsedUrl.href)) as { default: EmscriptenFactory };
   return mod.default;
 }
@@ -251,9 +269,7 @@ export class Nec2Engine implements Engine {
       url = new URL(`${this.baseUrl}${path}`, origin).href;
     }
     const parsedUrl = new URL(url, 'http://localhost/');
-    if (!['http:', 'https:', 'file:'].includes(parsedUrl.protocol)) {
-      throw new Error(`Untrusted protocol: ${parsedUrl.protocol}`);
-    }
+    validateUrlOrigin(parsedUrl);
     return parsedUrl.href;
   }
 

--- a/tests/nec2Engine.origin.test.ts
+++ b/tests/nec2Engine.origin.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { Nec2Engine } from '../src/physics/nec2Engine';
+
+describe('Nec2Engine untrusted origin', () => {
+  it('throws untrusted origin error on init', async () => {
+    const engine = new Nec2Engine({ baseUrl: 'http://attacker.com/' });
+    await expect(engine.init()).rejects.toThrow('Untrusted origin: http://attacker.com');
+  });
+
+  it('throws untrusted origin error on simulate', async () => {
+    const engine = new Nec2Engine({ baseUrl: 'https://attacker.com/' });
+    const dummyInput = {
+      wires: [{ start: [0, 0, 1] as [number, number, number], end: [0, 0, 2] as [number, number, number], radius: 0.001, segments: 11, tag: 1 }],
+      frequencyMHz: 14,
+      ground: { type: 'free' as const },
+      excitation: { wireTag: 1, segment: 6 },
+      patternResolution: { thetaSteps: 5, phiSteps: 8 },
+    };
+    await expect(engine.simulate(dummyInput)).rejects.toThrow('Untrusted origin: https://attacker.com');
+  });
+});


### PR DESCRIPTION
🎯 **What:** Adds rigorous origin validation for URLs loaded via Vite's dynamic import in the Nec2Engine.
⚠️ **Risk:** Previously, the engine checked the protocol (http/https/file) but did not restrict the origin. If `baseUrl` could be externally controlled, a malicious domain (e.g. `https://attacker.com/nec2.js`) could have been injected, resulting in Remote Code Execution within the application context.
🛡️ **Solution:** Implemented `validateUrlOrigin` to restrict non-file URLs strictly to `self.location.origin` (or localhost for dev/testing), preventing the engine from ever loading remote, unverified modules while preserving correct behavior in web workers and Node.js testing environments.

---
*PR created automatically by Jules for task [7478919673961287376](https://jules.google.com/task/7478919673961287376) started by @2fst4u*