### PR TITLE
🧹 Sweep: Remove unused sampleColormap function

### DIFF
--- a/.jules/sweep.md
+++ b/.jules/sweep.md
@@ -115,3 +115,4 @@
 ## 2026-08-09 - Sweep: Remove unused gainToColorT function
 **Learning:** `gainToColorT` was unused dead code in `src/utils/colormap.ts` and successfully removed alongside its tests to improve maintainability.
 **Action:** Removed unused `gainToColorT` from `src/utils/colormap.ts` and `tests/colormap.test.ts`.
+## 2026-08-19 - Sweep: Remove unused sampleColormap function\n**Learning:** `sampleColormap` was unused dead code in `src/utils/colormap.ts` (having been replaced by `sampleColormapFast`) and successfully removed alongside its tests to improve maintainability.\n**Action:** Removed unused `sampleColormap` from `src/utils/colormap.ts` and its associated tests in `tests/colormap.test.ts`.

--- a/src/utils/colormap.ts
+++ b/src/utils/colormap.ts
@@ -55,28 +55,7 @@ export function pickTable(name: ColormapName): readonly RGB[] {
 }
 
 /**
- * Look up an RGB triplet from a colormap at a 0..1 position.
- * Clamps the input and lerps between adjacent stops.
- */
-export function sampleColormap(name: ColormapName, t: number): RGB {
-  const table = pickTable(name);
-  if (!Number.isFinite(t)) return table[0]!;
-  const clamped = Math.min(1, Math.max(0, t));
-  const f = clamped * (table.length - 1);
-  const i = Math.floor(f);
-  const j = Math.min(i + 1, table.length - 1);
-  const a = table[i]!;
-  const b = table[j]!;
-  const w = f - i;
-  return [
-    a[0] + (b[0] - a[0]) * w,
-    a[1] + (b[1] - a[1]) * w,
-    a[2] + (b[2] - a[2]) * w,
-  ];
-}
-
-/**
- * Hot-path optimized version of sampleColormap that writes directly into an output array.
+ * Hot-path optimized version of a colormap sampler that writes directly into an output array.
  * Uses bitwise operations and avoids creating intermediate array allocations.
  */
 export function sampleColormapFast(table: readonly RGB[], t: number, out: Float32Array, offset: number): void {

--- a/tests/colormap.test.ts
+++ b/tests/colormap.test.ts
@@ -1,63 +1,7 @@
 import { describe, expect, it } from 'vitest';
-import { sampleColormap, sampleColormapFast, getColormapCssGradient, pickTable } from '../src/utils/colormap';
+import { sampleColormapFast, getColormapCssGradient, pickTable } from '../src/utils/colormap';
 
 describe('colormap utilities', () => {
-  describe('sampleColormap', () => {
-    it('returns the first color at t=0', () => {
-      const color = sampleColormap('viridis', 0);
-      // VIRIDIS[0] = [0.267004, 0.004874, 0.329415]
-      expect(color[0]).toBeCloseTo(0.267004, 6);
-      expect(color[1]).toBeCloseTo(0.004874, 6);
-      expect(color[2]).toBeCloseTo(0.329415, 6);
-    });
-
-    it('returns the last color at t=1', () => {
-      const color = sampleColormap('viridis', 1);
-      // VIRIDIS[15] = [0.993248, 0.906157, 0.143936]
-      expect(color[0]).toBeCloseTo(0.993248, 6);
-      expect(color[1]).toBeCloseTo(0.906157, 6);
-      expect(color[2]).toBeCloseTo(0.143936, 6);
-    });
-
-    it('clamps t < 0 to the first color', () => {
-      const color = sampleColormap('viridis', -1);
-      expect(color[0]).toBeCloseTo(0.267004, 6);
-    });
-
-    it('clamps t > 1 to the last color', () => {
-      const color = sampleColormap('viridis', 2);
-      expect(color[0]).toBeCloseTo(0.993248, 6);
-    });
-
-    it('returns the first color for non-finite values', () => {
-      expect(sampleColormap('viridis', NaN)[0]).toBeCloseTo(0.267004, 6);
-      expect(sampleColormap('viridis', Infinity)[0]).toBeCloseTo(0.267004, 6);
-    });
-
-    it('linearly interpolates between stops', () => {
-      // VIRIDIS[0] = [0.267004, 0.004874, 0.329415]
-      // VIRIDIS[1] = [0.282656, 0.100196, 0.422160]
-      // t such that f = 0.5 => clamped * (16 - 1) = 0.5 => clamped = 0.5 / 15
-      const t = 0.5 / 15;
-      const color = sampleColormap('viridis', t);
-      expect(color[0]).toBeCloseTo((0.267004 + 0.282656) / 2, 6);
-      expect(color[1]).toBeCloseTo((0.004874 + 0.100196) / 2, 6);
-      expect(color[2]).toBeCloseTo((0.329415 + 0.422160) / 2, 6);
-    });
-
-    it('works with turbo colormap', () => {
-      // TURBO[0] = [0.18995, 0.07176, 0.23217]
-      const color = sampleColormap('turbo', 0);
-      expect(color[0]).toBeCloseTo(0.18995, 5);
-    });
-
-    it('works with jet colormap', () => {
-      // JET[0] = [0, 0, 0.5]
-      const color = sampleColormap('jet', 0);
-      expect(color).toEqual([0, 0, 0.5]);
-    });
-  });
-
   describe('sampleColormapFast', () => {
     it('writes the first color at t=0', () => {
       const table = pickTable('viridis');


### PR DESCRIPTION
🎯 **What:** Removed the `sampleColormap` function from `src/utils/colormap.ts` and its associated unit tests from `tests/colormap.test.ts`.

💡 **Why:** `sampleColormap` was an unused function and effectively dead code, having been superseded in active usage by its optimized counterpart, `sampleColormapFast`. Removing it reduces repository bloat.

✅ **Verification:** Ran `grep -rn 'sampleColormap[^F]' src/ tests/` to verify zero remaining references to the original function across the repository, ensuring `sampleColormapFast` remained intact. Passed both linting (`npm run lint`) and the full test suite (`npm run test -- --run --coverage`) without degrading coverage below project thresholds.

✨ **Result:** A cleaner codebase with reduced technical debt and dead code.

---
*PR created automatically by Jules for task [17124724307645078597](https://jules.google.com/task/17124724307645078597) started by @2fst4u*