### PR TITLE
🧹 Code Health: Extract duplicate ANTENNA INPUT PARAMETERS scanning logic into helper function

### DIFF
--- a/src/physics/necParser.ts
+++ b/src/physics/necParser.ts
@@ -33,19 +33,24 @@ const NO_HORIZ_SENTINEL = -999.99;
  */
 const impedanceRowRe = /^\s+\d+\s+\d+\s+(-?\d\.\d+E[+-]\d+)\s+(-?\d\.\d+E[+-]\d+)\s+(-?\d\.\d+E[+-]\d+)\s+(-?\d\.\d+E[+-]\d+)\s+(-?\d\.\d+E[+-]\d+)\s+(-?\d\.\d+E[+-]\d+)\s+(-?\d\.\d+E[+-]\d+)\s+(-?\d\.\d+E[+-]\d+)\s+(-?\d\.\d+E[+-]\d+)/gm;
 
+
+function findBlockEndIndex(text: string, startIdx: number, lines: number): number {
+  let blockEnd = startIdx;
+  for (let i = 0; i < lines; i++) {
+    const p = text.indexOf('\n', blockEnd);
+    if (p < 0) {
+      return text.length;
+    }
+    blockEnd = p + 1;
+  }
+  return blockEnd;
+}
+
 export function parseNecImpedance(text: string): { impedance: ImpedanceResult | null; power: number | null } {
   const blockStart = text.indexOf('ANTENNA INPUT PARAMETERS');
   if (blockStart < 0) return { impedance: null, power: null };
 
-  let blockEnd = blockStart;
-  for (let i = 0; i < 12; i++) {
-    const p = text.indexOf('\n', blockEnd);
-    if (p < 0) {
-      blockEnd = text.length;
-      break;
-    }
-    blockEnd = p + 1;
-  }
+  const blockEnd = findBlockEndIndex(text, blockStart, 12);
 
   const blockText = text.substring(blockStart, blockEnd);
   impedanceRowRe.lastIndex = 0;
@@ -74,15 +79,7 @@ export function parseNecImpedanceSweep(text: string): { impedance: ImpedanceResu
     const blockStart = text.indexOf('ANTENNA INPUT PARAMETERS', pos);
     if (blockStart < 0) break;
 
-    let blockEnd = blockStart;
-    for (let i = 0; i < 12; i++) {
-      const p = text.indexOf('\n', blockEnd);
-      if (p < 0) {
-        blockEnd = text.length;
-        break;
-      }
-      blockEnd = p + 1;
-    }
+    const blockEnd = findBlockEndIndex(text, blockStart, 12);
 
     if (blockEnd === blockStart) break;
 


### PR DESCRIPTION
🎯 **What:** The 12-line scanning logic used to find the end of the "ANTENNA INPUT PARAMETERS" block was duplicated in `parseNecImpedance` and `parseNecImpedanceSweep`. This logic has been extracted into a new shared helper function called `findBlockEndIndex`.

💡 **Why:** Extracting this logic into a self-contained helper function reduces code duplication, improving both the readability and maintainability of the `necParser.ts` file without altering the parser's overall behavior.

✅ **Verification:** Verified the code changes were applied correctly by checking the file modifications. Ran the full test suite (`npm run test -- --run --coverage`) which passed completely with 80 tests passing. Code coverage remained robust and did not regress.

✨ **Result:** A cleaner, less repetitive NEC output parser.

---
*PR created automatically by Jules for task [12396599206681539498](https://jules.google.com/task/12396599206681539498) started by @2fst4u*