### PR TITLE
🎨 Palette: Add accessible label to UTC hour Auto button

### DIFF
--- a/src/components/Panel/Propagation/PropagationInputs.tsx
+++ b/src/components/Panel/Propagation/PropagationInputs.tsx
@@ -278,6 +278,7 @@ function UtcHourInput() {
           aria-disabled={utcHourOverride === null}
           style={{ flex: '0 0 auto' }}
           title={utcHourOverride === null ? 'Already using current UTC time' : 'Reset to current UTC time'}
+          aria-label="Reset to Auto (current UTC time)"
         >
           Auto
         </button>

--- a/tests/PropagationControl.test.tsx
+++ b/tests/PropagationControl.test.tsx
@@ -123,7 +123,7 @@ describe('PropagationControl - time override visibility', () => {
     setupMockStore({ utcHourOverride: 10 });
     render(<PropagationControl />);
 
-    const autoButton = screen.getByRole('button', { name: 'Auto' });
+    const autoButton = screen.getByRole('button', { name: 'Reset to Auto (current UTC time)' });
     fireEvent.click(autoButton);
 
     expect(mockSetUtcHourOverride).toHaveBeenCalledWith(null);
@@ -133,7 +133,7 @@ describe('PropagationControl - time override visibility', () => {
     setupMockStore({ utcHourOverride: null });
     render(<PropagationControl />);
 
-    const autoButton = screen.getByRole('button', { name: 'Auto' }) as HTMLButtonElement;
+    const autoButton = screen.getByRole('button', { name: 'Reset to Auto (current UTC time)' }) as HTMLButtonElement;
     expect(autoButton.getAttribute('aria-disabled')).toBe('true');
   });
 });

--- a/tests/PropagationInputs.test.tsx
+++ b/tests/PropagationInputs.test.tsx
@@ -136,7 +136,7 @@ describe('PropagationInputs UI component', () => {
     useAntennaStore.setState({ utcHourOverride: 12.5 });
     render(<PropagationInputs />);
 
-    const button = screen.getByRole('button', { name: 'Auto' }) as HTMLButtonElement;
+    const button = screen.getByRole('button', { name: 'Reset to Auto (current UTC time)' }) as HTMLButtonElement;
     expect(button.getAttribute('aria-disabled')).toBe('false');
 
     fireEvent.click(button);


### PR DESCRIPTION
💡 What: Added an explicit `aria-label="Reset to Auto (current UTC time)"` to the "Auto" button in the UTC Hour propagation inputs.
🎯 Why: Previously, screen readers would only announce this button as "Auto, button", leaving visually impaired users with no context about its actual function. The new label clearly explains that it resets the manual override back to the current UTC time.
📸 Before/After: Visual appearance is completely unchanged. Assistive technology now receives full context.
♿ Accessibility: Improved screen reader clarity for the propagation settings panel. All relevant tests have been updated to query the button using its new accessible name.

---
*PR created automatically by Jules for task [1621642272180488898](https://jules.google.com/task/1621642272180488898) started by @2fst4u*