### PR TITLE
🧹 Sweep: Remove unused transformWithTransformerAtAntenna function

### DIFF
--- a/src/physics/impedance.ts
+++ b/src/physics/impedance.ts
@@ -251,37 +251,6 @@ export function transformThroughLine(
 }
 
 /**
- * Computes the impedance the radio sees when an ideal `n²`-ratio transformer
- * is fitted at the antenna terminals (between antenna and feedline).
- *
- * If `lineLengthLambdas` is 0 or undefined (no feedline), this is just the
- * antenna impedance divided by the ratio. With a feedline present, the
- * antenna feedpoint is de-embedded from the NEC-reported source-side Z,
- * divided by the ratio (the transformer's effect on the load presented to
- * the cable), then re-embedded through the cable to get what the radio
- * sees.
- *
- * De-embedding accuracy depends on the absence of significant common-mode
- * current on the cable shield — which is guaranteed in the simulation
- * because enabling a transformer also engages a choke on the shield.
- */
-export function transformWithTransformerAtAntenna(
-  zSrcReportedByNec: ImpedanceResult,
-  ratio: number,
-  z0Line: number = Z0_SYSTEM,
-  lineLengthLambdas: number = 0,
-): ImpedanceResult {
-  if (!Number.isFinite(ratio) || ratio <= 0) return zSrcReportedByNec;
-  if (lineLengthLambdas === 0 || !Number.isFinite(lineLengthLambdas)) {
-    // No feedline → NEC's reported Z is the antenna feedpoint directly.
-    return { R: zSrcReportedByNec.R / ratio, X: zSrcReportedByNec.X / ratio };
-  }
-  const zAntenna = deembedThroughLine(zSrcReportedByNec, z0Line, lineLengthLambdas);
-  const zXfmrPrimary = { R: zAntenna.R / ratio, X: zAntenna.X / ratio };
-  return transformThroughLine(zXfmrPrimary, z0Line, lineLengthLambdas);
-}
-
-/**
  * De-embeds an impedance reading taken at the source end of a lossless
  * transmission line: given Z measured at the source, returns the load-side
  * impedance at the far end of the line.

--- a/tests/impedance.test.ts
+++ b/tests/impedance.test.ts
@@ -1,6 +1,6 @@
 import { vi } from "vitest";
 import { describe, expect, it } from 'vitest';
-import { swr, mismatchLossFactor, deembedThroughLine, transformThroughLine, transformWithTransformerAtAntenna, suggestedTransformerRatio, matchRatioForFeedpoint, displayedFeedMetrics, atuLossDb, feedlineLossUnderSwrDb } from '../src/physics/impedance';
+import { swr, mismatchLossFactor, deembedThroughLine, transformThroughLine, suggestedTransformerRatio, matchRatioForFeedpoint, displayedFeedMetrics, atuLossDb, feedlineLossUnderSwrDb } from '../src/physics/impedance';
 import { TRANSFORMER_INSERTION_LOSS_DB, ATU_COMPONENT_Q, feedlineLossDb, findFeedlinePreset } from '../src/physics/constants';
 import type { SimulationResult } from '../src/physics/types';
 
@@ -342,33 +342,6 @@ describe('transformThroughLine', () => {
     const original = { R: 100, X: 50 };
     expect(transformThroughLine(original, 50, NaN)).toBe(original);
     expect(transformThroughLine(original, 50, Infinity)).toBe(original);
-  });
-});
-
-describe('transformWithTransformerAtAntenna', () => {
-  it('returns original if ratio is invalid', () => {
-    const original = { R: 100, X: 50 };
-    expect(transformWithTransformerAtAntenna(original, 0)).toBe(original);
-    expect(transformWithTransformerAtAntenna(original, -1)).toBe(original);
-    expect(transformWithTransformerAtAntenna(original, NaN)).toBe(original);
-  });
-
-  it('handles zero-length line (or undefined line length)', () => {
-    const zSrc = { R: 400, X: 200 };
-    const result1 = transformWithTransformerAtAntenna(zSrc, 4, 50, 0);
-    expect(result1.R).toBeCloseTo(100, 6);
-    expect(result1.X).toBeCloseTo(50, 6);
-
-    const result2 = transformWithTransformerAtAntenna(zSrc, 4, 50, NaN);
-    expect(result2.R).toBeCloseTo(100, 6);
-    expect(result2.X).toBeCloseTo(50, 6);
-  });
-
-  it('transforms properly with line length present', () => {
-    const zSrc = { R: 25, X: 0 };
-    const result = transformWithTransformerAtAntenna(zSrc, 4, 50, 0.25);
-    expect(result.R).toBeCloseTo(100, 6);
-    expect(result.X).toBeCloseTo(0, 6);
   });
 });
 


### PR DESCRIPTION
💡 What:
Removed the unused function `transformWithTransformerAtAntenna` from `src/physics/impedance.ts` and its associated unit tests from `tests/impedance.test.ts`.

🎯 Why:
The function `transformWithTransformerAtAntenna` was reported as unused by `ts-prune`. It is an unreferenced export that only added cognitive load to the codebase. Removing it cleans up dead code without affecting any application functionality.

🔬 Verification:
Ran `npx ts-prune -p tsconfig.app.json` which highlighted `transformWithTransformerAtAntenna` without the `(used in module)` flag.
Ran `grep -rn "transformWithTransformerAtAntenna" . --exclude-dir=node_modules` before deletion to verify it was only used in its export declaration and its corresponding unit tests.
Ran `npm run lint`, `npm run build`, and `npm run test` after deletion to confirm no regressions were introduced. All checks passed.

---
*PR created automatically by Jules for task [4856378483890557442](https://jules.google.com/task/4856378483890557442) started by @2fst4u*