### PR TITLE
🧹 Sweep: Remove unused transformThroughLine function

### DIFF
--- a/src/physics/impedance.ts
+++ b/src/physics/impedance.ts
@@ -211,46 +211,6 @@ export function displayedFeedMetrics(
 }
 
 /**
- * Forward propagation through a lossless transmission line: given the load
- * (far-end) impedance, returns the input (near-end) impedance seen looking
- * into a line of characteristic impedance `z0Line` and electrical length
- * `lengthLambdas` (cable length / cable wavelength).
- *
- *   Z_in = Z0 · (Z_load + j·Z0·tan(βd)) / (Z0 + j·Z_load·tan(βd))
- */
-export function transformThroughLine(
-  zLoad: ImpedanceResult,
-  z0Line: number,
-  lengthLambdas: number,
-): ImpedanceResult {
-  if (!Number.isFinite(lengthLambdas) || !Number.isFinite(z0Line) || z0Line <= 0) {
-    return zLoad;
-  }
-  const betaL = 2 * Math.PI * lengthLambdas;
-  const t = Math.tan(betaL);
-  if (!Number.isFinite(t)) {
-    const denMag2 = zLoad.R * zLoad.R + zLoad.X * zLoad.X;
-    if (denMag2 === 0) return zLoad;
-    return {
-      R: (z0Line * z0Line * zLoad.R) / denMag2,
-      X: -(z0Line * z0Line * zLoad.X) / denMag2,
-    };
-  }
-  // numerator = Z_load + j·Z0·t = zLoad.R + j·(zLoad.X + Z0·t)
-  const numR = zLoad.R;
-  const numI = zLoad.X + z0Line * t;
-  // denominator = Z0 + j·Z_load·t = (Z0 − zLoad.X·t) + j·(zLoad.R·t)
-  const denR = z0Line - zLoad.X * t;
-  const denI = zLoad.R * t;
-  const denMag2 = denR * denR + denI * denI;
-  if (denMag2 === 0) return zLoad;
-  return {
-    R: (z0Line * (numR * denR + numI * denI)) / denMag2,
-    X: (z0Line * (numI * denR - numR * denI)) / denMag2,
-  };
-}
-
-/**
  * De-embeds an impedance reading taken at the source end of a lossless
  * transmission line: given Z measured at the source, returns the load-side
  * impedance at the far end of the line.

--- a/tests/impedance.test.ts
+++ b/tests/impedance.test.ts
@@ -1,8 +1,40 @@
 import { vi } from "vitest";
 import { describe, expect, it } from 'vitest';
-import { swr, mismatchLossFactor, deembedThroughLine, transformThroughLine, suggestedTransformerRatio, matchRatioForFeedpoint, displayedFeedMetrics, atuLossDb, feedlineLossUnderSwrDb } from '../src/physics/impedance';
+import { swr, mismatchLossFactor, deembedThroughLine, suggestedTransformerRatio, matchRatioForFeedpoint, displayedFeedMetrics, atuLossDb, feedlineLossUnderSwrDb } from '../src/physics/impedance';
 import { TRANSFORMER_INSERTION_LOSS_DB, ATU_COMPONENT_Q, feedlineLossDb, findFeedlinePreset } from '../src/physics/constants';
-import type { SimulationResult } from '../src/physics/types';
+import type { SimulationResult, ImpedanceResult } from '../src/physics/types';
+
+/** Helper function moved from src/physics/impedance.ts for testing purposes */
+function transformThroughLine(
+  zLoad: ImpedanceResult,
+  z0Line: number,
+  lengthLambdas: number,
+): ImpedanceResult {
+  if (!Number.isFinite(lengthLambdas) || !Number.isFinite(z0Line) || z0Line <= 0) {
+    return zLoad;
+  }
+  const betaL = 2 * Math.PI * lengthLambdas;
+  const t = Math.tan(betaL);
+  if (!Number.isFinite(t)) {
+    const denMag2 = zLoad.R * zLoad.R + zLoad.X * zLoad.X;
+    if (denMag2 === 0) return zLoad;
+    return {
+      R: (z0Line * z0Line * zLoad.R) / denMag2,
+      X: -(z0Line * z0Line * zLoad.X) / denMag2,
+    };
+  }
+  const numR = zLoad.R;
+  const numI = zLoad.X + z0Line * t;
+  const denR = z0Line - zLoad.X * t;
+  const denI = zLoad.R * t;
+  const denMag2 = denR * denR + denI * denI;
+  if (denMag2 === 0) return zLoad;
+  return {
+    R: (z0Line * (numR * denR + numI * denI)) / denMag2,
+    X: (z0Line * (numI * denR - numR * denI)) / denMag2,
+  };
+}
+
 
 // Minimal result stub carrying only the fields displayedFeedMetrics reads.
 function stubResult(over: Partial<Pick<SimulationResult, 'impedance' | 'swr' | 'maxGainDbi' | 'maxRealizedGainDbi'>>) {


### PR DESCRIPTION
💡 What: Removed `transformThroughLine` from `src/physics/impedance.ts` and moved it directly into `tests/impedance.test.ts`.

🎯 Why: `transformThroughLine` was flagged as unused in production code by `ts-prune`. Moving it to the test file where it is exclusively used for generating fixtures and verifying `suggestedTransformerRatio` removes dead code from the production bundle without degrading test coverage.

🔬 Verification: Used `npx ts-prune` and `grep` to confirm it is not used in `src/`. Ran full test suite to ensure tests still pass using the inlined test helper.

---
*PR created automatically by Jules for task [3087001714455691130](https://jules.google.com/task/3087001714455691130) started by @2fst4u*