### PR TITLE
🧹 Sweep: Combine duplicate imports in ModeSelector.tsx

### DIFF
--- a/src/components/Panel/ModeSelector.tsx
+++ b/src/components/Panel/ModeSelector.tsx
@@ -1,6 +1,5 @@
 import { useShallow } from 'zustand/react/shallow';
-import { useAntennaStore } from '../../store/antennaStore';
-import type { Mode } from '../../store/antennaStore';
+import { useAntennaStore, type Mode } from '../../store/antennaStore';
 
 const MODES: Array<{ id: Mode; label: string; hint: string; shortcut?: string }> = [
   { id: 'normal', label: 'Normal', hint: 'Standard DX pattern view', shortcut: 'm' },


### PR DESCRIPTION
🎯 What: Combined separate value (`useAntennaStore`) and type (`type Mode`) imports from `../../store/antennaStore` into a single import statement in `ModeSelector.tsx`.
💡 Why: Removes duplicate import statements from the same module, reducing clutter and improving the readability and maintainability of the file.
✅ Verification: Ran `npm ci` followed by `npm run lint` and `npm run test -- --run --coverage`. The linter passes, the tests pass, and coverage remains consistent.
✨ Result: Cleaner, more concise import statements utilizing TypeScript's inline type import syntax, with no changes to runtime behavior.

---
*PR created automatically by Jules for task [4726023852353977149](https://jules.google.com/task/4726023852353977149) started by @2fst4u*