### PR TITLE
🧹 Sweep: Un-export internal types in swrChartUtils

### DIFF
--- a/.jules/sweep.md
+++ b/.jules/sweep.md
@@ -116,3 +116,6 @@
 **Learning:** `gainToColorT` was unused dead code in `src/utils/colormap.ts` and successfully removed alongside its tests to improve maintainability.
 **Action:** Removed unused `gainToColorT` from `src/utils/colormap.ts` and `tests/colormap.test.ts`.
 ## 2026-08-19 - Sweep: Remove unused sampleColormap function\n**Learning:** `sampleColormap` was unused dead code in `src/utils/colormap.ts` (having been replaced by `sampleColormapFast`) and successfully removed alongside its tests to improve maintainability.\n**Action:** Removed unused `sampleColormap` from `src/utils/colormap.ts` and its associated tests in `tests/colormap.test.ts`.
+## 2026-08-19 - Sweep: Un-exported strictly internal types
+**Learning:** `ts-prune` flags types and functions with `(used in module)` when they are exported but only used within their defining file. While some might be imported by tests (which app tsconfigs miss), those not imported by tests should be un-exported to reduce the public API surface area.
+**Action:** Un-exported `ComputeChartDataArgs`, `SWRStats`, `ComputeStatsArgs`, `ComputeYMaxArgs`, and `ComputeOptionsArgs` in `src/components/Charts/swrChartUtils.ts` since they were only used internally. Left `buildAnnotations` and `buildScales` exported because the test suite imports them explicitly.

--- a/src/components/Charts/swrChartUtils.ts
+++ b/src/components/Charts/swrChartUtils.ts
@@ -15,7 +15,7 @@ export function formatBandwidth(widthMHz: number): string {
   return `${widthMHz.toFixed(2)} MHz`;
 }
 
-export interface ComputeChartDataArgs {
+interface ComputeChartDataArgs {
   comparisonActive: boolean;
   reference: ComparisonSnapshot | null;
   referenceFill: string;
@@ -123,14 +123,14 @@ export function computeChartData({
   return { datasets };
 }
 
-export interface SWRStats {
+interface SWRStats {
   minSWR: number;
   minFreq: number;
   /** Every contiguous ≤2:1 band in the sweep, ascending by frequency. */
   bands: SwrBand[];
 }
 
-export interface ComputeStatsArgs {
+interface ComputeStatsArgs {
   sweep: readonly SweepPoint[];
   /** When true, evaluate min SWR and 2:1 bandwidth on the post-balun impedance. */
   transformerInDisplay?: boolean;
@@ -178,7 +178,7 @@ export function computeStats({
   };
 }
 
-export interface ComputeYMaxArgs {
+interface ComputeYMaxArgs {
   sweep: readonly SweepPoint[];
   comparisonActive: boolean;
   reference: ComparisonSnapshot | null;
@@ -239,7 +239,7 @@ export function computeYMax({
   return Math.min(scaled, SWR_CAP);
 }
 
-export interface ComputeOptionsArgs {
+interface ComputeOptionsArgs {
   frequency: number;
   accent: string;
   stats: SWRStats | null;


### PR DESCRIPTION
💡 What: Removed `export` from strictly internal types (`ComputeChartDataArgs`, `SWRStats`, `ComputeStatsArgs`, `ComputeYMaxArgs`, `ComputeOptionsArgs`) in `src/components/Charts/swrChartUtils.ts`.
🎯 Why: These types were flagged by `ts-prune` as only used within their defining module. Un-exporting them reduces the public API surface area and cleans up the codebase without impacting behavior or tests.
🔬 Verification: Ran `ts-prune` to identify module-only exports. Verified they are not imported anywhere else or in the test suite using `grep`. Ran the full test suite (`npm run test -- --run`) and ensured all passed, and verified static analysis with `npm run lint` and `npm run build`.

---
*PR created automatically by Jules for task [5422238034096149200](https://jules.google.com/task/5422238034096149200) started by @2fst4u*